### PR TITLE
fix: improve benchmark robustness and correctness

### DIFF
--- a/test/perf/bench_utils.h
+++ b/test/perf/bench_utils.h
@@ -42,6 +42,7 @@ struct ThreadData {
     struct timespec end_time;
     long long total_io_time;
     unsigned long long io_operations;
+    size_t total_bytes;
     std::vector<uint64_t> latency_vec;
     int device_id;
 };

--- a/test/perf/bench_utils.h
+++ b/test/perf/bench_utils.h
@@ -50,15 +50,16 @@ static inline uint64_t ts_diff_ns(const struct timespec& a, const struct timespe
     return (b.tv_sec - a.tv_sec) * 1000000000ULL + (b.tv_nsec - a.tv_nsec);
 }
 
-static inline void get_percentile(std::vector<uint64_t>& vec, double p) {
+static inline void get_percentile(std::vector<uint64_t>& vec, double p,
+                                   bool per_batch = false) {
     if (vec.empty()) return;
-    size_t idx = (size_t)(p * vec.size());
-    if (idx >= vec.size()) idx = vec.size() - 1;
-    printf("  p%.1f: %.2f us\n", p * 100, vec[idx] / 1000.0);
+    size_t idx = (size_t)((vec.size() - 1) * p);
+    const char* suffix = per_batch ? " (per-batch)" : "";
+    printf("  p%.1f: %.2f us%s\n", p * 100, vec[idx] / 1000.0, suffix);
 }
 
 static inline void report_results(const char* label, std::vector<ThreadData>& threads,
-                                  size_t io_size,
+                                  size_t io_size, size_t actual_bytes,
                                   uint64_t prog_time_ns, bool json) {
     uint64_t total_ops = 0;
     long long total_io_time = 0;
@@ -72,8 +73,10 @@ static inline void report_results(const char* label, std::vector<ThreadData>& th
 
     std::sort(all_lat.begin(), all_lat.end());
 
-    double bw_mbps = (total_ops * io_size * 1.0 / MB) / (prog_time_ns / 1e9);
+    double bw_mbps = (actual_bytes * 1.0 / MB) / (prog_time_ns / 1e9);
     double avg_lat_us = total_ops > 0 ? (double)total_io_time / (total_ops * 1000.0) : 0;
+
+    bool is_batched = (!all_lat.empty() && all_lat.size() != total_ops);
 
     if (json) {
         printf("{\n");
@@ -84,17 +87,17 @@ static inline void report_results(const char* label, std::vector<ThreadData>& th
         printf("  \"bandwidth_mbps\": %.2f,\n", bw_mbps);
         printf("  \"avg_latency_us\": %.2f,\n", avg_lat_us);
         if (!all_lat.empty()) {
-            printf("  \"p50_us\": %.2f,\n", all_lat[(size_t)(0.5 * all_lat.size())] / 1000.0);
-            printf("  \"p95_us\": %.2f,\n", all_lat[(size_t)(0.95 * all_lat.size())] / 1000.0);
-            printf("  \"p99_us\": %.2f,\n", all_lat[(size_t)(0.99 * all_lat.size())] / 1000.0);
-            printf("  \"p999_us\": %.2f\n", all_lat[(size_t)(0.999 * all_lat.size())] / 1000.0);
+            size_t n = all_lat.size();
+            printf("  \"p50_us\": %.2f,\n", all_lat[(size_t)((n - 1) * 0.5)] / 1000.0);
+            printf("  \"p95_us\": %.2f,\n", all_lat[(size_t)((n - 1) * 0.95)] / 1000.0);
+            printf("  \"p99_us\": %.2f,\n", all_lat[(size_t)((n - 1) * 0.99)] / 1000.0);
+            printf("  \"p999_us\": %.2f\n", all_lat[(size_t)((n - 1) * 0.999)] / 1000.0);
         }
         printf("}\n");
     } else {
         printf("[%s]\n", label);
         printf("  Total IO operations: %llu\n", (unsigned long long)total_ops);
         printf("  Bandwidth: %.2f MB/s\n", bw_mbps);
-        bool is_batched = (!all_lat.empty() && all_lat.size() != total_ops);
         if (is_batched) {
             printf("  Avg latency: %.2f us (amortized per-IO)\n", avg_lat_us);
             size_t n_batches = all_lat.size();
@@ -107,10 +110,10 @@ static inline void report_results(const char* label, std::vector<ThreadData>& th
             printf("  Avg latency: %.2f us\n", avg_lat_us);
         }
         if (!all_lat.empty()) {
-            get_percentile(all_lat, 0.50);
-            get_percentile(all_lat, 0.95);
-            get_percentile(all_lat, 0.99);
-            get_percentile(all_lat, 0.999);
+            get_percentile(all_lat, 0.50, is_batched);
+            get_percentile(all_lat, 0.95, is_batched);
+            get_percentile(all_lat, 0.99, is_batched);
+            get_percentile(all_lat, 0.999, is_batched);
         }
         printf("\n");
     }
@@ -164,6 +167,22 @@ static inline bool parse_bench_opts(int argc, char** argv, BenchOpts& opts) {
     }
     if (!opts.file_path) {
         fprintf(stderr, "Error: -f <file_path> is required\n");
+        return false;
+    }
+    if (opts.io_size == 0) {
+        fprintf(stderr, "Error: io_size must be > 0\n");
+        return false;
+    }
+    if (opts.num_threads <= 0) {
+        fprintf(stderr, "Error: num_threads must be > 0\n");
+        return false;
+    }
+    if (opts.io_depth <= 0) {
+        fprintf(stderr, "Error: io_depth must be > 0\n");
+        return false;
+    }
+    if (opts.length == 0) {
+        fprintf(stderr, "Error: length must be > 0\n");
         return false;
     }
     return true;

--- a/test/perf/cufile_bench.cu
+++ b/test/perf/cufile_bench.cu
@@ -94,6 +94,7 @@ static void* sync_rw_thread(void* arg) {
         data->latency_vec.push_back(io_time);
         data->total_io_time += io_time;
         data->io_operations++;
+        data->total_bytes += result;
         done_bytes += result;
     }
 
@@ -179,10 +180,13 @@ static void* batch_rw_thread(void* arg) {
             fprintf(stderr, "thread %d: batch incomplete: submitted %u, completed %u\n",
                     data->thread_id, nr, nr_out);
         }
+        size_t completed_bytes = 0;
         for (unsigned i = 0; i < nr_out; i++) {
             if ((ssize_t)events[i].ret < 0) {
                 fprintf(stderr, "thread %d: batch event[%u] error: ret=%zd\n",
                         data->thread_id, i, (ssize_t)events[i].ret);
+            } else {
+                completed_bytes += events[i].ret;
             }
         }
 
@@ -192,6 +196,7 @@ static void* batch_rw_thread(void* arg) {
         data->latency_vec.push_back(batch_time);
         data->total_io_time += batch_time;
         data->io_operations += nr_out;
+        data->total_bytes += completed_bytes;
         done_bytes += batch_bytes;
     }
 
@@ -277,6 +282,7 @@ static void run_ugds_bench(BenchOpts& opts) {
         td->handler = &cf_handle;
         td->total_io_time = 0;
         td->io_operations = 0;
+        td->total_bytes = 0;
         td->device_id = opts.gpu_id;
 
         CHECK_CUDA(cudaMalloc(&td->gpu_buffer, chunk_size));
@@ -310,7 +316,7 @@ static void run_ugds_bench(BenchOpts& opts) {
 
     size_t actual_bytes = 0;
     for (auto& t : threads)
-        actual_bytes += t.io_operations * opts.io_size;
+        actual_bytes += t.total_bytes;
 
     report_results(label, threads, opts.io_size, actual_bytes, prog_time_ns, opts.json);
 

--- a/test/perf/cufile_bench.cu
+++ b/test/perf/cufile_bench.cu
@@ -60,29 +60,31 @@ static void* sync_rw_thread(void* arg) {
     ThreadData* data = (ThreadData*)arg;
     struct timespec io_start, io_end;
     uGDSHandle_t cf_handle = *(uGDSHandle_t*)data->handler;
-    ssize_t io_size = (ssize_t)data->io_size;
     size_t done_bytes = 0;
 
     clock_gettime(CLOCK_MONOTONIC, &data->start_time);
 
     while (done_bytes < data->size) {
+        size_t remaining = data->size - done_bytes;
+        size_t this_io = (remaining < data->io_size) ? remaining : data->io_size;
+
         clock_gettime(CLOCK_MONOTONIC, &io_start);
 
         ssize_t result;
         if (data->mode == 1) {
-            result = uGDSWrite(cf_handle, data->gpu_buffer, data->io_size,
+            result = uGDSWrite(cf_handle, data->gpu_buffer, this_io,
                                  data->offset + done_bytes, done_bytes);
         } else {
-            result = uGDSRead(cf_handle, data->gpu_buffer, data->io_size,
+            result = uGDSRead(cf_handle, data->gpu_buffer, this_io,
                                 data->offset + done_bytes, 0);
         }
 
         if (result == 0) {
             break;
         }
-        if (result != io_size) {
-            fprintf(stderr, "thread %d: IO error, result=%zd, expected=%zd\n",
-                    data->thread_id, result, io_size);
+        if (result != (ssize_t)this_io) {
+            fprintf(stderr, "thread %d: IO error, result=%zd, expected=%zu\n",
+                    data->thread_id, result, this_io);
             return NULL;
         }
 
@@ -129,24 +131,29 @@ static void* batch_rw_thread(void* arg) {
 
     while (done_bytes < data->size) {
         unsigned nr = 0;
-        for (size_t i = 0; i < batch_size && done_bytes + i * data->io_size < data->size; i++) {
+        size_t batch_bytes = 0;
+        for (size_t i = 0; i < batch_size && done_bytes + batch_bytes < data->size; i++) {
+            size_t remaining = data->size - done_bytes - batch_bytes;
+            size_t this_io = (remaining < data->io_size) ? remaining : data->io_size;
+
             memset(&params[i], 0, sizeof(params[0]));
 #ifdef USE_NVIDIA_GDS
             params[i].mode = CUFILE_BATCH;
             params[i].u.batch.devPtr_base = data->gpu_buffer;
-            params[i].u.batch.file_offset = data->offset + done_bytes + i * data->io_size;
-            params[i].u.batch.devPtr_offset = (done_bytes + i * data->io_size) % data->size;
-            params[i].u.batch.size = data->io_size;
+            params[i].u.batch.file_offset = data->offset + done_bytes + batch_bytes;
+            params[i].u.batch.devPtr_offset = (done_bytes + batch_bytes) % data->size;
+            params[i].u.batch.size = this_io;
             params[i].fh = cf_handle;
             params[i].opcode = data->mode ? CUFILE_WRITE : CUFILE_READ;
 #else
             params[i].devPtr_base = data->gpu_buffer;
-            params[i].file_offset = data->offset + done_bytes + i * data->io_size;
-            params[i].devPtr_offset = (done_bytes + i * data->io_size) % data->size;
-            params[i].size = data->io_size;
+            params[i].file_offset = data->offset + done_bytes + batch_bytes;
+            params[i].devPtr_offset = (done_bytes + batch_bytes) % data->size;
+            params[i].size = this_io;
             params[i].opcode = data->mode ? UGDS_WRITE : UGDS_READ;
 #endif
             nr++;
+            batch_bytes += this_io;
         }
         if (nr == 0) break;
 
@@ -162,11 +169,21 @@ static void* batch_rw_thread(void* arg) {
             break;
         }
 
-        unsigned nr_out = nr;
+        unsigned nr_out = 0;
         st = uGDSBatchIOGetStatus(batch, nr, &nr_out, events.data(), nullptr);
         if (st.err != UGDS_SUCCESS) {
             fprintf(stderr, "thread %d: BatchIOGetStatus failed\n", data->thread_id);
             break;
+        }
+        if (nr_out != nr) {
+            fprintf(stderr, "thread %d: batch incomplete: submitted %u, completed %u\n",
+                    data->thread_id, nr, nr_out);
+        }
+        for (unsigned i = 0; i < nr_out; i++) {
+            if ((ssize_t)events[i].ret < 0) {
+                fprintf(stderr, "thread %d: batch event[%u] error: ret=%zd\n",
+                        data->thread_id, i, (ssize_t)events[i].ret);
+            }
         }
 
         clock_gettime(CLOCK_MONOTONIC, &batch_end);
@@ -174,8 +191,8 @@ static void* batch_rw_thread(void* arg) {
         uint64_t batch_time = ts_diff_ns(batch_start, batch_end);
         data->latency_vec.push_back(batch_time);
         data->total_io_time += batch_time;
-        data->io_operations += nr;
-        done_bytes += nr * data->io_size;
+        data->io_operations += nr_out;
+        done_bytes += batch_bytes;
     }
 
     clock_gettime(CLOCK_MONOTONIC, &data->end_time);
@@ -203,7 +220,11 @@ static void run_ugds_bench(BenchOpts& opts) {
         label = opts.is_write ? "uGDS-write" : "uGDS-read";
 #endif
 
+#ifdef USE_NVIDIA_GDS
+    printf("=== GDS Benchmark ===\n");
+#else
     printf("=== uGDS Benchmark ===\n");
+#endif
     printf("  File:       %s\n", opts.file_path);
     printf("  Length:     %zu bytes (%.2f MB)\n", opts.length, opts.length / (double)MB);
     printf("  IO size:    %zu bytes\n", opts.io_size);
@@ -287,11 +308,15 @@ static void run_ugds_bench(BenchOpts& opts) {
 
     uint64_t prog_time_ns = ts_diff_ns(prog_start, prog_end);
 
-    report_results(label, threads, opts.io_size, prog_time_ns, opts.json);
+    size_t actual_bytes = 0;
+    for (auto& t : threads)
+        actual_bytes += t.io_operations * opts.io_size;
+
+    report_results(label, threads, opts.io_size, actual_bytes, prog_time_ns, opts.json);
 
     for (int i = 0; i < num_threads; i++) {
         uGDSBufDeregister(threads[i].gpu_buffer);
-        CHECK_CUDA(cudaFree(threads[i].gpu_buffer));
+        cudaFree(threads[i].gpu_buffer);
     }
 
     uGDSHandleDeregister(cf_handle);


### PR DESCRIPTION
## Summary

- Clamp last IO to remaining bytes when `chunk_size % io_size != 0`, preventing out-of-bound reads/writes
- Validate batch completion: check `nr_out` matches submitted count, check per-event `ret` for errors
- Use actual completed bytes for bandwidth calculation (instead of `total_ops * io_size`)
- Label percentile output as `(per-batch)` in batch mode to distinguish from per-IO latency
- Fix percentile off-by-one: use `floor((n-1)*p)` instead of `p*n` (p99.9 could access out of range)
- Use non-fatal `cudaFree` in cleanup path to avoid resource leaks on error
- Validate CLI parameters: reject zero/negative `io_size`, `num_threads`, `io_depth`, `length`
- Show `"GDS Benchmark"` header when built with `USE_NVIDIA_GDS` (was always showing `"uGDS Benchmark"`)

## Test plan

- [x] Build both `bench_ugds` and `bench_gds` targets
- [x] Run sync read/write benchmarks with various IO sizes
- [x] Run batch read/write benchmarks, verify per-batch labels in output
- [x] Test edge case: `length` not divisible by `io_size` (e.g., `-l 100K -s 64K`)
- [x] Test parameter validation: `-s 0`, `-t 0`, `-i 0` should report errors