### PR TITLE
fix: reject misaligned on-the-fly buffers (silent DMA corruption)

### DIFF
--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -27,6 +27,12 @@
 #define UGDS_MAX_BATCH_IO_SIZE   128
 #define UGDS_PRP_POOL_PAGES      16
 
+// Granularity at which the kernel driver pins GPU memory (drv/map.c:
+// GPU_PAGE_SIZE = 1 << 16). The driver masks device addresses with
+// GPU_PAGE_MASK, so a base+offset that is not aligned to this is silently
+// rounded down — the DMA would then target the wrong GPU address.
+#define UGDS_GPU_PAGE_SIZE       (1UL << 16)
+
 struct IOQueuePair {
     nvm_queue_t    sq;
     nvm_queue_t    cq;

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -27,12 +27,6 @@
 #define UGDS_MAX_BATCH_IO_SIZE   128
 #define UGDS_PRP_POOL_PAGES      16
 
-// Granularity at which the kernel driver pins GPU memory (drv/map.c:
-// GPU_PAGE_SIZE = 1 << 16). The driver masks device addresses with
-// GPU_PAGE_MASK, so a base+offset that is not aligned to this is silently
-// rounded down — the DMA would then target the wrong GPU address.
-#define UGDS_GPU_PAGE_SIZE       (1UL << 16)
-
 struct IOQueuePair {
     nvm_queue_t    sq;
     nvm_queue_t    cq;

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -52,12 +52,8 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         }
     } else {
         void* map_ptr = static_cast<uint8_t*>(bufPtr_base) + bufPtr_offset;
-        // On-the-fly buffers are pinned by the kernel driver at GPU-page (64KB)
-        // granularity; it masks the device address with GPU_PAGE_MASK. A map_ptr
-        // that is not 64KB-aligned would be silently rounded down, so the DMA
-        // would land at the wrong GPU address (silent data corruption). The
-        // registered path above already enforces alignment; reject here too.
-        if ((reinterpret_cast<uintptr_t>(map_ptr) % UGDS_GPU_PAGE_SIZE) != 0) {
+        // Reject non-64KB-aligned on-the-fly buffers (kernel driver silently rounds down)
+        if ((reinterpret_cast<uintptr_t>(map_ptr) & ((1UL << 16) - 1)) != 0) {
             return -EINVAL;
         }
         int rc = nvm_dma_map_device(&buf_dma, hs->ctrl, map_ptr, size);

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -52,6 +52,14 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         }
     } else {
         void* map_ptr = static_cast<uint8_t*>(bufPtr_base) + bufPtr_offset;
+        // On-the-fly buffers are pinned by the kernel driver at GPU-page (64KB)
+        // granularity; it masks the device address with GPU_PAGE_MASK. A map_ptr
+        // that is not 64KB-aligned would be silently rounded down, so the DMA
+        // would land at the wrong GPU address (silent data corruption). The
+        // registered path above already enforces alignment; reject here too.
+        if ((reinterpret_cast<uintptr_t>(map_ptr) % UGDS_GPU_PAGE_SIZE) != 0) {
+            return -EINVAL;
+        }
         int rc = nvm_dma_map_device(&buf_dma, hs->ctrl, map_ptr, size);
         if (rc != 0 || buf_dma == nullptr) {
             return -EIO;

--- a/test/functional/test_alignment_errors.cu
+++ b/test/functional/test_alignment_errors.cu
@@ -46,11 +46,8 @@ int main(int argc, char** argv) {
     if (ret != -EINVAL)
         TEST_FAIL("negative offset: expected %d, got %zd", -EINVAL, ret);
 
-    // 6. Unregistered (on-the-fly) buffer must be 64KB GPU-page aligned.
-    //    The kernel driver pins at 64KB granularity and masks the device
-    //    address, so a non-aligned base+offset would be silently rounded down
-    //    and corrupt the transfer. uGDS must reject it before any DMA.
-    const uintptr_t kGpuPageSize = 65536;  // kernel pins GPU memory at 64KB
+    // 6. On-the-fly buffer must be 64KB-aligned (kernel rounds down otherwise)
+    const uintptr_t kGpuPageSize = 1UL << 16;
     void* d_unreg = nullptr;
     cudaMalloc(&d_unreg, 131072);
     if (!d_unreg) TEST_FAIL("cudaMalloc (unregistered) failed");

--- a/test/functional/test_alignment_errors.cu
+++ b/test/functional/test_alignment_errors.cu
@@ -46,6 +46,23 @@ int main(int argc, char** argv) {
     if (ret != -EINVAL)
         TEST_FAIL("negative offset: expected %d, got %zd", -EINVAL, ret);
 
+    // 6. Unregistered (on-the-fly) buffer must be 64KB GPU-page aligned.
+    //    The kernel driver pins at 64KB granularity and masks the device
+    //    address, so a non-aligned base+offset would be silently rounded down
+    //    and corrupt the transfer. uGDS must reject it before any DMA.
+    const uintptr_t kGpuPageSize = 65536;  // kernel pins GPU memory at 64KB
+    void* d_unreg = nullptr;
+    cudaMalloc(&d_unreg, 131072);
+    if (!d_unreg) TEST_FAIL("cudaMalloc (unregistered) failed");
+    // Pick a buf offset that guarantees base+offset is NOT 64KB-aligned,
+    // regardless of what alignment cudaMalloc happened to return.
+    uintptr_t base = (uintptr_t)d_unreg;
+    off_t mis_off = ((base & (kGpuPageSize - 1)) == 0) ? 4096 : 0;
+    ret = uGDSRead(fh, d_unreg, 4096, 0, mis_off);
+    if (ret != -EINVAL)
+        TEST_FAIL("unaligned on-the-fly buffer: expected %d, got %zd", -EINVAL, ret);
+    cudaFree(d_unreg);
+
     uGDSBufDeregister(d_buf);
     cudaFree(d_buf);
     close_handle(fh);


### PR DESCRIPTION
The on-the-fly (unregistered) buffer path in `do_io_internal` mapped `base + bufPtr_offset` directly without checking alignment. Because the kernel driver pins GPU memory at 64KB and masks the device address with `GPU_PAGE_MASK` (`drv/map.c:449`), a non-64KB-aligned pointer is silently rounded down — the DMA then lands at the wrong GPU address with no error returned.

This adds a 64KB-alignment guard that returns `-EINVAL` before mapping, matching the validation the registered path already does. Pure additive change — it cannot affect correctly-aligned callers.

Also adds a negative test case (case 6) in `test_alignment_errors.cu` covering an unregistered, misaligned buffer. The offset is chosen at runtime so the case triggers deterministically regardless of `cudaMalloc`'s alignment.

Note: built and verified the guard logic in isolation; full `nvcc` build + on-device run needs an NVMe+GPU rig, which I don't have — would appreciate a maintainer running the functional suite.