### PR TITLE
refactor: extract CQ status into UGDS_CPL_STATUS macro

### DIFF
--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -35,7 +35,7 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
     if (!cpl) return false;
 
     uint16_t cid = *NVM_CPL_CID(cpl);
-    uint16_t status = (cpl->dword[3] >> 17) & 0x7FF;
+    uint16_t status = UGDS_CPL_STATUS(cpl);
 
     nvm_sq_update(&qp.sq);
     std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -35,7 +35,7 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
     if (!cpl) return false;
 
     uint16_t cid = *NVM_CPL_CID(cpl);
-    uint16_t status = UGDS_CPL_STATUS(cpl);
+    uint16_t status = UGDS_CPL_SCT_SC(cpl);
 
     nvm_sq_update(&qp.sq);
     std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -29,6 +29,10 @@
 #define UGDS_PRP_POOL_PAGES      64
 #define UGDS_HUGEPAGE_SIZE       (2UL * 1024 * 1024)
 
+/* Extract the combined SCT+SC (Status Code Type + Status Code) 11-bit field
+ * from an NVMe completion queue entry. A value of 0 indicates success. */
+#define UGDS_CPL_STATUS(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
+
 struct IOQueuePair {
     nvm_queue_t    sq{};
     nvm_queue_t    cq{};

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -29,9 +29,8 @@
 #define UGDS_PRP_POOL_PAGES      64
 #define UGDS_HUGEPAGE_SIZE       (2UL * 1024 * 1024)
 
-/* Extract the combined SCT+SC (Status Code Type + Status Code) 11-bit field
- * from an NVMe completion queue entry. A value of 0 indicates success. */
-#define UGDS_CPL_STATUS(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
+/* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec §4.6.1. */
+#define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 
 struct IOQueuePair {
     nvm_queue_t    sq{};

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -123,7 +123,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                     result = -EIO;
                     goto out;
                 }
-                uint16_t st = (drain->dword[3] >> 17) & 0x7FF;
+                uint16_t st = UGDS_CPL_STATUS(drain);
                 nvm_sq_update(&qp.sq);
                 std::atomic_thread_fence(std::memory_order_seq_cst);
                 nvm_cq_update(&qp.cq);
@@ -176,7 +176,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 goto out;
             }
 
-            uint16_t status = (cpl->dword[3] >> 17) & 0x7FF;
+            uint16_t status = UGDS_CPL_STATUS(cpl);
 
             nvm_sq_update(&qp.sq);
             std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -123,7 +123,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                     result = -EIO;
                     goto out;
                 }
-                uint16_t st = UGDS_CPL_STATUS(drain);
+                uint16_t st = UGDS_CPL_SCT_SC(drain);
                 nvm_sq_update(&qp.sq);
                 std::atomic_thread_fence(std::memory_order_seq_cst);
                 nvm_cq_update(&qp.cq);
@@ -176,7 +176,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 goto out;
             }
 
-            uint16_t status = UGDS_CPL_STATUS(cpl);
+            uint16_t status = UGDS_CPL_SCT_SC(cpl);
 
             nvm_sq_update(&qp.sq);
             std::atomic_thread_fence(std::memory_order_seq_cst);


### PR DESCRIPTION
Consolidates the duplicated NVMe completion-queue status extraction (cpl->dword[3] >> 17) & 0x7FF (appeared 3×: ugds_io.cpp ×2, ugds_batch.cpp ×1) into a single named macro UGDS_CPL_STATUS in ugds_internal.h. Behavior unchanged.