### PR TITLE
refactor: name the MDTS fallback constant (closes #9)

### DIFF
--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -75,7 +75,7 @@ static size_t compute_max_xfer(HandleState* hs)
     const size_t prp_capacity = page_size / sizeof(uint64_t);
 
     size_t max_xfer = hs->max_transfer_size;
-    if (max_xfer == 0) max_xfer = 128 * 1024;
+    if (max_xfer == 0) max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
     if (max_xfer < page_size) max_xfer = page_size;
 
     size_t prp_max = (prp_capacity + 1) * page_size;

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -29,6 +29,10 @@
 #define UGDS_PRP_POOL_PAGES      64
 #define UGDS_HUGEPAGE_SIZE       (2UL * 1024 * 1024)
 
+/* Fallback maximum data-transfer size (bytes) for a single I/O when the controller
+ * reports MDTS = 0 (no limit). Keeps one transfer within a single PRP list. */
+#define UGDS_DEFAULT_MAX_TRANSFER_SIZE (128UL * 1024)
+
 /* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec §4.6.1. */
 #define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -70,7 +70,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 
     size_t max_xfer = hs->max_transfer_size;
     if (max_xfer == 0) {
-        max_xfer = 128 * 1024;
+        max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
     }
     if (max_xfer < page_size) {
         max_xfer = page_size;


### PR DESCRIPTION
Replaces the hardcoded `128 * 1024` MDTS fallback (used when the controller reports `max_transfer_size == 0`) with a named, documented constant `UGDS_DEFAULT_MAX_TRANSFER_SIZE` in `src/ugds_internal.h`, used at both sites (`ugds_io.cpp`, `ugds_batch.cpp`).

No behavioral change — same 128 KiB value. Builds clean.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
