### PR TITLE
fix: admin queue segfault on controllers with small CAP.MQES

### DIFF
--- a/include/libnvm/nvm_ctrl.h
+++ b/include/libnvm/nvm_ctrl.h
@@ -68,7 +68,8 @@ void nvm_ctrl_free(nvm_ctrl_t* ctrl);
  * Note: This function is implicitly called by the controller manager, so it
  *       should not be necessary to call it directly.
  */
-int nvm_raw_ctrl_reset(const nvm_ctrl_t* ctrl, uint64_t acq_ioaddr, uint64_t asq_ioaddr);
+int nvm_raw_ctrl_reset(const nvm_ctrl_t* ctrl, uint64_t acq_ioaddr, uint64_t asq_ioaddr,
+                       uint32_t acq_entries, uint32_t asq_entries);
 
 
 

--- a/src/libnvm/ctrl.cpp
+++ b/src/libnvm/ctrl.cpp
@@ -207,7 +207,8 @@ int _nvm_ctrl_init(nvm_ctrl_t** handle, struct device* dev, const struct device_
  * We deliberately use the pointers from the user-handle, in case the user
  * overrides them somehow.
  */
-int nvm_raw_ctrl_reset(const nvm_ctrl_t* ctrl, uint64_t acq_addr, uint64_t asq_addr)
+int nvm_raw_ctrl_reset(const nvm_ctrl_t* ctrl, uint64_t acq_addr, uint64_t asq_addr,
+                       uint32_t acq_entries, uint32_t asq_entries)
 {
     volatile uint32_t* cc = CC(ctrl->mm_ptr);
 
@@ -233,9 +234,7 @@ int nvm_raw_ctrl_reset(const nvm_ctrl_t* ctrl, uint64_t acq_addr, uint64_t asq_a
     // Set admin queue attributes
     volatile uint32_t* aqa = AQA(ctrl->mm_ptr);
 
-    uint32_t cq_max_entries = ctrl->page_size / sizeof(nvm_cpl_t) - 1;
-    uint32_t sq_max_entries = ctrl->page_size / sizeof(nvm_cmd_t) - 1;
-    *aqa = AQA$ACQS(cq_max_entries) | AQA$ASQS(sq_max_entries);
+    *aqa = AQA$ACQS(acq_entries - 1) | AQA$ASQS(asq_entries - 1);
     
     // Set admin completion queue
     volatile uint64_t* acq = ACQ(ctrl->mm_ptr);

--- a/src/libnvm/rpc.cpp
+++ b/src/libnvm/rpc.cpp
@@ -367,11 +367,33 @@ static int create_admin(struct local_admin** handle, const struct controller* ct
     admin->qmem = copy;
     memset((void*) admin->qmem->vaddr, 0, 2 * admin->qmem->page_size);
 
-    nvm_queue_clear(&admin->acq, &ctrl->handle, true, 0, ctrl->handle.page_size / sizeof(nvm_cpl_t), 
-            admin->qmem->local, admin->qmem->vaddr, admin->qmem->ioaddrs[0]);
+    uint32_t acq_qs = ctrl->handle.page_size / sizeof(nvm_cpl_t);
+    if (acq_qs > ctrl->handle.max_qs)
+        acq_qs = ctrl->handle.max_qs;
 
-    nvm_queue_clear(&admin->asq, &ctrl->handle, false, 0, ctrl->handle.page_size / sizeof(nvm_cmd_t), 
+    uint32_t asq_qs = ctrl->handle.page_size / sizeof(nvm_cmd_t);
+    if (asq_qs > ctrl->handle.max_qs)
+        asq_qs = ctrl->handle.max_qs;
+
+    status = nvm_queue_clear(&admin->acq, &ctrl->handle, true, 0, acq_qs,
+            admin->qmem->local, admin->qmem->vaddr, admin->qmem->ioaddrs[0]);
+    if (status != 0)
+    {
+        free(admin);
+        nvm_dma_unmap(copy);
+        dprintf("Failed to initialize admin CQ: %s\n", strerror(status));
+        return status;
+    }
+
+    status = nvm_queue_clear(&admin->asq, &ctrl->handle, false, 0, asq_qs,
             admin->qmem->local,  NVM_DMA_OFFSET(admin->qmem, 1), admin->qmem->ioaddrs[1]);
+    if (status != 0)
+    {
+        free(admin);
+        nvm_dma_unmap(copy);
+        dprintf("Failed to initialize admin SQ: %s\n", strerror(status));
+        return status;
+    }
 
     admin->timeout = ctrl->handle.timeout;
 
@@ -485,10 +507,14 @@ int nvm_aq_create(nvm_aq_ref* handle, const nvm_ctrl_t* ctrl, const nvm_dma_t* w
 
     // Reset controller
     const struct local_admin* admin = (const struct local_admin*) ref->data;
-    nvm_raw_ctrl_reset(ctrl, admin->qmem->ioaddrs[0], admin->qmem->ioaddrs[1]);
-    //printf("admin sq vaddr: %p\tsq ioaddr: %lx\n", admin->qmem->vaddr, admin->qmem->ioaddrs[0]);
-    //printf("admin cq vaddr: %p\tcq ioaddr: %lx\n", admin->qmem->vaddr+4096, admin->qmem->ioaddrs[1]);
-    
+    err = nvm_raw_ctrl_reset(ctrl, admin->qmem->ioaddrs[0], admin->qmem->ioaddrs[1],
+                             admin->acq.qs, admin->asq.qs);
+    if (err != 0)
+    {
+        _nvm_ref_put(ref);
+        return err;
+    }
+
     *handle = ref;
     return 0;
 }


### PR DESCRIPTION
## Problem

Ref #14

On NVMe controllers with small `CAP.MQES` (e.g. AWS Nitro instance storage, MQES=127), `create_admin()` computes the ACQ size as `page_size / sizeof(nvm_cpl_t) = 256`, exceeding the controller limit. `nvm_queue_clear()` returns `EINVAL` but the return value is not checked, leaving the queue with `vaddr = NULL` and causing a segfault on the first admin command submission.

Additionally, `nvm_raw_ctrl_reset()` programs the AQA register without capping to MQES, causing a mismatch between hardware and software queue sizes. `nvm_aq_create()` also does not check the return value of `nvm_raw_ctrl_reset()`, silently returning success on controller reset timeout.

## Fix

`rpc.cpp`: `create_admin()` caps ACQ/ASQ sizes at `ctrl->max_qs`, checks and propagates return values from `nvm_queue_clear()` and `nvm_raw_ctrl_reset()`

`ctrl.cpp`: `nvm_raw_ctrl_reset()` receives the capped queue sizes as parameters, ensuring the AQA register matches the software-side queue sizes

`nvm_ctrl.h`: updated `nvm_raw_ctrl_reset()` signature

## Test

All 20 functional tests pass locally (Samsung 990 PRO, MQES=16383). The bug only triggers on controllers with MQES < 256.