### PR TITLE
feat: add dma-buf export support for GPU memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(UGDS_CUDA_ARCHITECTURES "80;90")
 if(UGDS_BACKEND_CUDA)
     find_package(CUDAToolkit REQUIRED)
     set(UGDS_CUDA_INCLUDES ${CUDAToolkit_INCLUDE_DIRS})
-    list(APPEND UGDS_CUDA_LIBS CUDA::cudart)
+    list(APPEND UGDS_CUDA_LIBS CUDA::cudart CUDA::cuda_driver)
 endif()
 
 # - HIP backend setup (independent) ------------
@@ -87,6 +87,53 @@ if(NOT UGDS_BACKEND_CUDA AND NOT UGDS_BACKEND_HIP)
     message(WARNING "No GPU backend selected, building library only")
 endif()
 
+# - RDMA support (optional) --------------------
+option(UGDS_ENABLE_RDMA "Enable tracked RDMA convenience API (libibverbs)" OFF)
+
+include(CheckCXXSourceCompiles)
+
+if(UGDS_ENABLE_RDMA)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(IBVERBS REQUIRED IMPORTED_TARGET libibverbs)
+    # Verify ibv_reg_dmabuf_mr is available (rdma-core >= v37)
+    set(CMAKE_REQUIRED_LIBRARIES "PkgConfig::IBVERBS")
+    check_cxx_source_compiles("
+        #include <infiniband/verbs.h>
+        int main() {
+            ibv_reg_dmabuf_mr(0, 0, 0, 0, 0, 0);
+            return 0;
+        }" HAVE_IBV_REG_DMABUF_MR)
+    set(CMAKE_REQUIRED_LIBRARIES)
+    if(NOT HAVE_IBV_REG_DMABUF_MR)
+        message(FATAL_ERROR "ibv_reg_dmabuf_mr not found. "
+                            "Install rdma-core >= v37 or disable RDMA (-DUGDS_ENABLE_RDMA=OFF).")
+    endif()
+endif()
+
+# - CUDA dma-buf detection ----------------------
+if(UGDS_BACKEND_CUDA)
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES "${UGDS_CUDA_INCLUDES}")
+    set(CMAKE_REQUIRED_LIBRARIES "${UGDS_CUDA_LIBS}")
+    check_cxx_source_compiles("
+        #include <cuda.h>
+        int main() {
+            int fd; void* h = &fd;
+            cuMemGetHandleForAddressRange(h, (CUdeviceptr)0, 0,
+                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+            return 0;
+        }" HAVE_CUDA_DMABUF)
+    set(CMAKE_REQUIRED_INCLUDES)
+    set(CMAKE_REQUIRED_LIBRARIES)
+    if(HAVE_CUDA_DMABUF)
+        message(STATUS "CUDA dma-buf export supported (HAVE_CUDA_DMABUF)")
+        message(STATUS "  When building the kernel module, pass:")
+        message(STATUS "    make BUILD_CUDA=1 HAVE_CUDA_DMABUF=1")
+    else()
+        message(STATUS "CUDA dma-buf export NOT supported (need CUDA 11.7+)")
+    endif()
+endif()
 
 # Library sources
 set(UGDS_SOURCES
@@ -105,6 +152,7 @@ set(UGDS_SOURCES
     src/ugds_io.cpp
     src/ugds_batch.cpp
     src/ugds_async.cpp
+    src/ugds_rdma.cpp
     src/ugds_hugepage.cpp
 )
 
@@ -121,6 +169,9 @@ if(UGDS_BACKEND_CUDA)
     target_include_directories(ugds PRIVATE ${UGDS_CUDA_INCLUDES})
     target_compile_definitions(ugds PRIVATE _CUDA)
     target_link_libraries(ugds PRIVATE ${UGDS_CUDA_LIBS})
+    if(HAVE_CUDA_DMABUF)
+        target_compile_definitions(ugds PRIVATE HAVE_CUDA_DMABUF)
+    endif()
 endif()
 
 if(UGDS_BACKEND_HIP)
@@ -130,6 +181,18 @@ if(UGDS_BACKEND_HIP)
     if(HAVE_HSA_DMABUF_V2)
         target_compile_definitions(ugds PRIVATE HAVE_HSA_DMABUF_V2)
     endif()
+endif()
+
+# UGDS_HAVE_DMABUF: unified dmabuf guard (HIP or CUDA-dmabuf)
+# Use PUBLIC so test targets linking against ugds also see the definition.
+if(UGDS_BACKEND_HIP OR (UGDS_BACKEND_CUDA AND HAVE_CUDA_DMABUF))
+    target_compile_definitions(ugds PUBLIC UGDS_HAVE_DMABUF)
+endif()
+
+# RDMA support
+if(UGDS_ENABLE_RDMA)
+    target_link_libraries(ugds PRIVATE PkgConfig::IBVERBS)
+    target_compile_definitions(ugds PRIVATE _RDMA)
 endif()
 
 target_link_libraries(ugds PRIVATE Threads::Threads)
@@ -160,6 +223,13 @@ set(FUNCTIONAL_TESTS
     test_interrupt_ioctls
     test_cq_dw11
     test_interrupt_mode
+    test_dmabuf_export
+)
+
+# RDMA/dmabuf tests -- only built/run when RDMA is enabled
+set(RDMA_TESTS
+    test_rdma_export
+    test_rdma_tracked
 )
 
 # CUDA tests (compiled with nvcc)
@@ -190,6 +260,26 @@ if(UGDS_BACKEND_CUDA)
                 BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
             )
         endforeach()
+
+        # RDMA tests (only when UGDS_ENABLE_RDMA is ON)
+        if(UGDS_ENABLE_RDMA)
+            foreach(test_name ${RDMA_TESTS})
+                set(test_src ${CMAKE_CURRENT_SOURCE_DIR}/test/functional/${test_name}.cu)
+                add_executable(${test_name}${CUDA_SUFFIX} ${test_src})
+                target_include_directories(${test_name}${CUDA_SUFFIX} PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/test/functional
+                )
+                target_link_libraries(${test_name}${CUDA_SUFFIX} ugds CUDA::cudart PkgConfig::IBVERBS)
+                set_target_properties(${test_name}${CUDA_SUFFIX} PROPERTIES
+                    CUDA_ARCHITECTURES "${UGDS_CUDA_ARCHITECTURES}"
+                    BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
+                )
+                if(${test_name} STREQUAL "test_rdma_tracked")
+                    target_compile_definitions(${test_name}${CUDA_SUFFIX} PRIVATE _RDMA)
+                endif()
+            endforeach()
+        endif()
 
         # bench_ugds (CUDA)
         set(bench_src ${CMAKE_CURRENT_SOURCE_DIR}/test/perf/cufile_bench.cu)
@@ -237,21 +327,22 @@ if(UGDS_BACKEND_CUDA)
                 CUDA_ARCHITECTURES "${UGDS_CUDA_ARCHITECTURES}"
             )
 
-            # bench_overlap_gds: overlap benchmark linked against libcufile.so
-            add_executable(bench_overlap_gds test/perf/bench_overlap.cu)
-            target_include_directories(bench_overlap_gds PRIVATE
-                ${CMAKE_CURRENT_SOURCE_DIR}/test/perf
-            )
-            if(CUFILE_INCLUDE)
-                target_include_directories(bench_overlap_gds PRIVATE ${CUFILE_INCLUDE})
-            else()
-                target_include_directories(bench_overlap_gds PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+            if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test/perf/bench_overlap.cu)
+                add_executable(bench_overlap_gds test/perf/bench_overlap.cu)
+                target_include_directories(bench_overlap_gds PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/test/perf
+                )
+                if(CUFILE_INCLUDE)
+                    target_include_directories(bench_overlap_gds PRIVATE ${CUFILE_INCLUDE})
+                else()
+                    target_include_directories(bench_overlap_gds PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+                endif()
+                target_link_libraries(bench_overlap_gds ${CUFILE_LIB} CUDA::cudart)
+                target_compile_definitions(bench_overlap_gds PRIVATE USE_O_DIRECT USE_NVIDIA_GDS)
+                set_target_properties(bench_overlap_gds PROPERTIES
+                    CUDA_ARCHITECTURES "${UGDS_CUDA_ARCHITECTURES}"
+                )
             endif()
-            target_link_libraries(bench_overlap_gds ${CUFILE_LIB} CUDA::cudart)
-            target_compile_definitions(bench_overlap_gds PRIVATE USE_O_DIRECT USE_NVIDIA_GDS)
-            set_target_properties(bench_overlap_gds PROPERTIES
-                CUDA_ARCHITECTURES "${UGDS_CUDA_ARCHITECTURES}"
-            )
         endif()
     else()
         message(WARNING "CUDA compiler not found, CUDA tests will not be built")
@@ -297,6 +388,35 @@ if(UGDS_BACKEND_HIP)
             )
         endforeach()
 
+        # RDMA tests (only when UGDS_ENABLE_RDMA is ON)
+        if(UGDS_ENABLE_RDMA)
+            foreach(test_name ${RDMA_TESTS})
+                set(test_src ${CMAKE_CURRENT_SOURCE_DIR}/test/functional/${test_name}.cu)
+                if(UGDS_BACKEND_CUDA)
+                    set(hip_src ${CMAKE_CURRENT_BINARY_DIR}/${test_name}.hip.cu)
+                    configure_file(${test_src} ${hip_src} COPYONLY)
+                    set_source_files_properties(${hip_src} PROPERTIES LANGUAGE HIP)
+                    add_executable(${test_name}${HIP_SUFFIX} ${hip_src})
+                else()
+                    set_source_files_properties(${test_src} PROPERTIES LANGUAGE HIP)
+                    add_executable(${test_name}${HIP_SUFFIX} ${test_src})
+                endif()
+                target_include_directories(${test_name}${HIP_SUFFIX} PRIVATE
+                    ${CMAKE_CURRENT_SOURCE_DIR}/include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/test/functional
+                )
+                target_link_libraries(${test_name}${HIP_SUFFIX} ugds ${UGDS_HIP_LIBS} PkgConfig::IBVERBS)
+                target_compile_definitions(${test_name}${HIP_SUFFIX} PRIVATE __HIP_PLATFORM_AMD__)
+                set_target_properties(${test_name}${HIP_SUFFIX} PROPERTIES
+                    HIP_ARCHITECTURES "${UGDS_HIP_ARCHITECTURES}"
+                    BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
+                )
+                if(${test_name} STREQUAL "test_rdma_tracked")
+                    target_compile_definitions(${test_name}${HIP_SUFFIX} PRIVATE _RDMA)
+                endif()
+            endforeach()
+        endif()
+
         # bench_ugds (HIP)
         set(bench_src_orig ${CMAKE_CURRENT_SOURCE_DIR}/test/perf/cufile_bench.cu)
         if(UGDS_BACKEND_CUDA)
@@ -325,4 +445,25 @@ endif()
 
 if(NOT UGDS_BACKEND_CUDA AND NOT UGDS_BACKEND_HIP)
     message(WARNING "No GPU backend enabled, tests will not be built")
+endif()
+
+# - RDMA Example --------------------------------
+# Build only when CUDA compiler is available and RDMA is enabled
+if(UGDS_ENABLE_RDMA AND UGDS_BACKEND_CUDA)
+    include(CheckLanguage)
+    check_language(CUDA)
+    if(CMAKE_CUDA_COMPILER)
+        add_executable(rdma_example examples/rdma_example.cu)
+        target_include_directories(rdma_example PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+        target_link_libraries(rdma_example ugds ${UGDS_CUDA_LIBS} PkgConfig::IBVERBS)
+        target_compile_definitions(rdma_example PRIVATE UGDS_ENABLE_RDMA)
+        set_target_properties(rdma_example PROPERTIES
+            CUDA_ARCHITECTURES "${UGDS_CUDA_ARCHITECTURES}"
+            BUILD_RPATH "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+    else()
+        message(WARNING "CUDA compiler not found, rdma_example will not be built")
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ find_package(Threads REQUIRED)
 option(UGDS_BACKEND_CUDA "Use NVIDIA CUDA backend" ON)
 option(UGDS_BACKEND_HIP  "Use AMD HIP backend"     OFF)
 
-# Both backends can be enabled simultaneously for dual-GPU systems.
+# Both backends can be enabled simultaneously. The async API uses void*
+# for stream parameters to avoid cudaStream_t/hipStream_t type conflicts.
 
 # HIP language support requires CMake >= 3.21
 if(UGDS_BACKEND_HIP AND CMAKE_VERSION VERSION_LESS "3.21")
@@ -26,6 +27,7 @@ set(UGDS_CUDA_ARCHITECTURES "80;90")
 if(UGDS_BACKEND_CUDA)
     find_package(CUDAToolkit REQUIRED)
     set(UGDS_CUDA_INCLUDES ${CUDAToolkit_INCLUDE_DIRS})
+    list(APPEND UGDS_CUDA_LIBS CUDA::cudart)
 endif()
 
 # - HIP backend setup (independent) ------------
@@ -85,6 +87,7 @@ if(NOT UGDS_BACKEND_CUDA AND NOT UGDS_BACKEND_HIP)
     message(WARNING "No GPU backend selected, building library only")
 endif()
 
+
 # Library sources
 set(UGDS_SOURCES
     src/libnvm/admin.cpp
@@ -114,23 +117,22 @@ target_include_directories(ugds
 )
 
 # Backend includes and compile definitions (independent)
-target_link_libraries(ugds PRIVATE Threads::Threads)
-
 if(UGDS_BACKEND_CUDA)
     target_include_directories(ugds PRIVATE ${UGDS_CUDA_INCLUDES})
     target_compile_definitions(ugds PRIVATE _CUDA)
-    target_link_libraries(ugds PRIVATE CUDA::cudart)
+    target_link_libraries(ugds PRIVATE ${UGDS_CUDA_LIBS})
 endif()
 
 if(UGDS_BACKEND_HIP)
     target_include_directories(ugds PRIVATE ${UGDS_HIP_INCLUDES})
     target_link_libraries(ugds PRIVATE ${UGDS_HIP_LIBS})
-    target_compile_definitions(ugds PRIVATE _HIP)
+    target_compile_definitions(ugds PRIVATE _HIP __HIP_PLATFORM_AMD__)
     if(HAVE_HSA_DMABUF_V2)
         target_compile_definitions(ugds PRIVATE HAVE_HSA_DMABUF_V2)
     endif()
 endif()
 
+target_link_libraries(ugds PRIVATE Threads::Threads)
 target_compile_options(ugds PRIVATE -Wall -O2)
 
 # - Tests and benchmarks -----------------------

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **User-space IO stack** — bypasses the kernel NVMe driver and filesystem entirely; CPU builds NVMe commands and polls completions in user space
 - **cuFile API compatible** — existing GDS applications work with minimal changes (relink to `libugds.so`, change `cuFile` prefix to `uGDS`)
 - **Multi-vendor GPU support** — NVIDIA CUDA and AMD Infinity Storage (HIP/ROCm) backends; both can be enabled simultaneously for mixed-GPU systems
+- **DMA-buf export** -- export GPU memory as a Linux dma-buf file descriptor for RDMA, DPDK, and other dmabuf-aware subsystems
 - **Fully open-source** — BSD 3-Clause licensed; no proprietary runtime dependencies beyond the GPU driver (NVIDIA driver or AMD ROCm runtime)
 - **High performance** — busy-poll CQ completion with `_mm_pause()`, multi-queue round-robin IO, achieving up to 2.7x read and 28x write bandwidth over NVIDIA GDS
 - **Interrupt mode (opt-in)** — MSI-X + eventfd completion for near-zero CPU utilization at large IO sizes; disabled by default (`UGDS_INTERRUPT_MODE=1` to enable)
@@ -136,6 +137,8 @@ scripts/run_tests.sh all
 | `uGDSBatchIOSetUp / Submit / GetStatus / Destroy` | ✅ | Submit/poll separation, up to 128 IOs per batch |
 | `uGDSReadAsync / WriteAsync` | ✅ | CUDA stream integration, late-binding pointers |
 | `uGDSStreamRegister / Deregister` | ✅ | Optional (no-op, uGDS has no bounce buffer) |
+| `uGDSBufRegisterEx` | ✅ | Extended registration with backend selection and export flag |
+| `uGDSExportDmabuf` | ✅ | DMA-buf fd export for RDMA and dmabuf-aware consumers |
 
 ## Roadmap
 
@@ -146,6 +149,7 @@ scripts/run_tests.sh all
 | 2 | Batch IO API (multi-command doorbell) | ✅ |
 | 3 | Async Stream API (CUDA stream integration) | ✅ |
 | 4 | Hugepage support (larger QP depth) | ✅ |
+| 4.5 | Dual CUDA/HIP backend + DMA-buf export | ✅ |
 | 5 | SGL support (scatter-gather lists) | 🔜 |
 | 6 | Interrupt mode (MSI-X + eventfd) | ✅ |
 | 7 | Multi-SSD support (multi-handle aggregation) | 🔜 |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,10 +36,44 @@ The HIP backend implements AMD Infinity Storage (AIS) using the standard Linux D
 **Driver notes:**
 The kernel-side code uses standard upstream DMA-buf APIs (`dma_buf_dynamic_attach`, `dma_buf_pin`, `dma_buf_map_attachment`). The userspace side uses `hsa_amd_portable_export_dmabuf_v2()` from the ROCm runtime. No vendor-specific amdgpu extensions are required beyond upstream `CONFIG_HSA_AMD_P2P` support.
 
-**Synchronization contract:**
-Buffers registered with `uGDSBufRegister()` must not be modified by the GPU (HIP kernel writes) while NVMe I/O is in flight on the same buffer. Concurrent GPU access during DMA can cause data corruption. This mirrors the NVIDIA GDS requirement.
+**Synchronization contract (producer/consumer model):**
 
-**Important:** Each backend used at runtime must be enabled in both the kernel module and the userspace library. For example, a CUDA-only kernel module will reject HIP `uGDSBufRegister()` calls. In dual-backend builds, use `uGDSBufRegister(ptr, size, UGDS_REGISTER_DMABUF)` for AMD buffers and `uGDSBufRegister(ptr, size, 0)` for NVIDIA buffers (default).
+All GPU memory accessors are classified as **producers** (write to GPU VRAM) or **consumers** (read from GPU VRAM):
+
+| Accessor | Direction | Role |
+|----------|-----------|------|
+| NVMe **Read** | SSD -> GPU VRAM | **Producer** (writes VRAM) |
+| NVMe **Write** | GPU VRAM -> SSD | **Consumer** (reads VRAM) |
+| RDMA **Send/Write** | GPU VRAM -> Network | **Consumer** (reads VRAM) |
+| RDMA **Recv/Read** | Network -> GPU VRAM | **Producer** (writes VRAM) |
+| GPU **Kernel Write** | GPU ALU -> VRAM | **Producer** |
+| GPU **Kernel Read** | VRAM -> GPU ALU | **Consumer** |
+
+**Rules:**
+1. Any producer requires exclusive ownership of the region. Two producers must NOT overlap (e.g., NVMe Read + RDMA Recv on the same VRAM is a data race).
+2. Two consumers may safely overlap (e.g., NVMe Write + RDMA Send both reading GPU VRAM).
+3. Any transition involving a producer requires the previous operation's completion barrier:
+   - Consumer -> Producer: drain all consumer completions before starting the producer.
+   - Producer -> Consumer: wait for producer completion before starting the consumer.
+4. After a producer completes, an explicit barrier is required before any dependent operation:
+   - NVMe I/O: `uGDSRead()`/`uGDSWrite()` return value (synchronous) or batch completion poll
+   - RDMA: `ibv_poll_cq` for Work Completion
+   - GPU: `cudaStreamSynchronize()` / `hipStreamSynchronize()`
+5. A running GPU kernel must NOT overlap any third-party producer (NVMe/RDMA) on the same region.
+6. `CU_POINTER_ATTRIBUTE_SYNC_MEMOPS` is set automatically for RDMA-enabled CUDA buffers to ensure BAR consistency, but it does NOT replace explicit stream/CQ barriers.
+
+For **dmabuf-export** buffers (registered with `uGDSBufRegisterEx()` using `UGDS_BACKEND_CUDA` or `UGDS_BACKEND_HIP`), the dma-buf file descriptor is retained internally and can be exported via `uGDSExportDmabuf()`. The caller is responsible for closing the exported fd and ensuring all external users (e.g., RDMA MR registrations) are cleaned up before calling `uGDSBufDeregister()`.
+
+**Important:** Each backend used at runtime must be enabled in both the kernel module and the userspace library. For example, a CUDA-only kernel module will reject HIP `uGDSBufRegister()` calls. In dual-backend builds, use `uGDSBufRegisterEx()` with explicit `uGDSBackend_t`.
+
+**CUDA dma-buf:** The userspace CMake auto-detects CUDA dma-buf support (`HAVE_CUDA_DMABUF`). When enabled, the kernel module must also be built with the same flag:
+
+```bash
+cd drv
+make BUILD_CUDA=1 HAVE_CUDA_DMABUF=1
+```
+
+Without this flag, the kernel module will not include the `NVM_MAP_DMABUF_MEMORY` ioctl handler, and `uGDSBufRegisterEx()` with `UGDS_BACKEND_CUDA` for fd export will fail with `UGDS_IO_NOT_SUPPORTED`. Standard CUDA NVMe I/O (`uGDSRead`/`uGDSWrite`) does not require this flag.
 
 **Note:** In dual-backend builds, unregistered AMD buffers (on-the-fly I/O without prior `uGDSBufRegister`) are not supported. AMD buffers must be explicitly registered before I/O. NVIDIA buffers support both registered and unregistered paths.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,8 @@ Buffers registered with `uGDSBufRegister()` must not be modified by the GPU (HIP
 
 **Important:** Each backend used at runtime must be enabled in both the kernel module and the userspace library. For example, a CUDA-only kernel module will reject HIP `uGDSBufRegister()` calls. In dual-backend builds, use `uGDSBufRegister(ptr, size, UGDS_REGISTER_DMABUF)` for AMD buffers and `uGDSBufRegister(ptr, size, 0)` for NVIDIA buffers (default).
 
+**Note:** In dual-backend builds, unregistered AMD buffers (on-the-fly I/O without prior `uGDSBufRegister`) are not supported. AMD buffers must be explicitly registered before I/O. NVIDIA buffers support both registered and unregistered paths.
+
 ## Step 1: Build the Kernel Module
 
 The kernel module (`ugds_drv.ko`) provides PCI BAR mapping and GPU page pinning for user-space NVMe access.

--- a/drv/Makefile
+++ b/drv/Makefile
@@ -52,6 +52,22 @@ ifneq ($(KERNELRELEASE),)
  endif
  endif
 
+	# dmabuf backend available when HIP is enabled, or when CUDA
+	# explicitly requests it via HAVE_CUDA_DMABUF=1.
+UGDS_HAVE_DMABUF := 0
+ifeq ($(BUILD_HIP),1)
+  UGDS_HAVE_DMABUF := 1
+endif
+ifdef HAVE_CUDA_DMABUF
+  ifneq ($(HAVE_CUDA_DMABUF),0)
+    UGDS_HAVE_DMABUF := 1
+  endif
+endif
+
+ifeq ($(UGDS_HAVE_DMABUF),1)
+  ccflags-y += -DUGDS_HAVE_DMABUF
+endif
+
 else
 
 .PHONY: default reload unload load clean

--- a/drv/ctrl.c
+++ b/drv/ctrl.c
@@ -49,6 +49,7 @@ struct ctrl* ctrl_get(struct class* cls, struct pci_dev* pdev, int number)
     ctrl->cls = cls;
     ctrl->cdev = NULL;
     ctrl->chrdev = NULL;
+    ctrl->dmabuf_supported = 0;
 
     ctrl->irq = NULL;
 

--- a/drv/ctrl.h
+++ b/drv/ctrl.h
@@ -41,6 +41,7 @@ struct ctrl
     struct class*       cls;        /* Character device class */
     struct cdev*        cdev;       /* Character device (cdev_alloc'd) */
     struct device*      chrdev;     /* Character device handle */
+    bool                dmabuf_supported; /* 64-bit DMA mask established */
 
     struct ugds_irq_state* irq;     /* Opaque; managed by irq.c */
 };

--- a/drv/ioctl.h
+++ b/drv/ioctl.h
@@ -21,18 +21,19 @@ struct nvm_ioctl_map
     uint64_t*   ioaddrs;
 };
 
-#ifdef _HIP
+/* Always define the dmabuf struct so the ioctl enum can reference it
+ * unconditionally. The handler body is only compiled when
+ * UGDS_HAVE_DMABUF is set, but the type must exist for the enum. */
 struct nvm_ioctl_dmabuf
 {
     __u64  gpu_ptr;           /* Original GPU VA -- unmap identity */
-    __s32  dmabuf_fd;         /* DMA-buf fd from HSA export */
+    __s32  dmabuf_fd;         /* DMA-buf fd from export */
     __u32  __pad;             /* Alignment */
     __u64  dmabuf_offset;     /* Offset within dmabuf allocation */
     __u64  size;              /* Total buffer size in bytes */
     __u64  ioaddrs_capacity;  /* Max entries in ioaddrs buffer */
     __u64  ioaddrs;           /* Output: DMA bus addresses (__user pointer) */
 };
-#endif
 
 /* Bind/unbind an eventfd to an MSI-X interrupt vector (interrupt mode). */
 struct nvm_ioctl_irq
@@ -48,9 +49,7 @@ enum nvm_ioctl_type
     NVM_MAP_DEVICE_MEMORY       = _IOW(NVM_IOCTL_TYPE, 2, struct nvm_ioctl_map),
 #endif
     NVM_UNMAP_MEMORY            = _IOW(NVM_IOCTL_TYPE, 3, uint64_t),
-#ifdef _HIP
     NVM_MAP_DMABUF_MEMORY       = _IOWR(NVM_IOCTL_TYPE, 4, struct nvm_ioctl_dmabuf),
-#endif
     NVM_REGISTER_INTERRUPT      = _IOW(NVM_IOCTL_TYPE, 5, struct nvm_ioctl_irq),
     NVM_UNREGISTER_INTERRUPT    = _IOW(NVM_IOCTL_TYPE, 6, struct nvm_ioctl_irq),
     NVM_GET_NUM_VECTORS         = _IOR(NVM_IOCTL_TYPE, 7, __u32),

--- a/drv/map.c
+++ b/drv/map.c
@@ -573,7 +573,7 @@ struct map* map_device_memory(const struct ctrl* ctrl, u64 vaddr, unsigned long 
 
 /* - AMD HIP / DMA-buf backend ------------------ */
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
 #include <linux/dma-buf.h>
 #include <linux/scatterlist.h>
 #include <linux/dma-resv.h>
@@ -587,28 +587,13 @@ struct dmabuf_region
 
 
 /*
- * move_notify callback -- called by the exporter if it needs to move the buffer.
- * With dma_buf_pin() held for the mapping lifetime, the exporter cannot move
- * the buffer, so this callback should never fire. If it does, we set the
- * invalid flag. The setup-time check in pci.c returns -EIO if invalid is
- * set before addresses are copied to userspace.
+ * We intentionally do NOT provide move_notify / invalidate_mappings.
+ * The buffer is pinned (dma_buf_pin) for the entire mapping lifetime,
+ * so the exporter cannot move it. If the kernel ever requires this
+ * callback, the attachment will fail at dma_buf_attach time.
  */
-static void ugds_dmabuf_move_notify(struct dma_buf_attachment* attachment)
-{
-    struct map* map = (struct map*) attachment->importer_priv;
-
-    if (map)
-    {
-        atomic_set(&map->invalid, 1);
-        WARN_ONCE(1, "uGDS: dmabuf move_notify -- mapping %llx invalidated. "
-                     "Pinned VRAM must not migrate.\n", map->vaddr);
-    }
-}
-
-
 static const struct dma_buf_attach_ops ugds_dmabuf_attach_ops = {
     .allow_peer2peer = true,
-    .move_notify     = ugds_dmabuf_move_notify,
 };
 
 
@@ -744,8 +729,9 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
     dr->dmabuf = dma_buf_get(dmabuf_fd);
     if (IS_ERR(dr->dmabuf))
     {
+        int ret = PTR_ERR(dr->dmabuf);
         kfree(dr);
-        return PTR_ERR(dr->dmabuf);
+        return ret;
     }
 
     /* Cross-check requested range against actual dma-buf size.
@@ -766,9 +752,10 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
                                              &ugds_dmabuf_attach_ops, map);
     if (IS_ERR(dr->attachment))
     {
+        int ret = PTR_ERR(dr->attachment);
         dma_buf_put(dr->dmabuf);
         kfree(dr);
-        return PTR_ERR(dr->attachment);
+        return ret;
     }
 
     /*

--- a/drv/map.h
+++ b/drv/map.h
@@ -69,7 +69,7 @@ struct map* map_device_memory(const struct ctrl* ctrl, u64 vaddr, unsigned long 
 
 
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
 /*
  * Map GPU memory via standard Linux DMA-buf framework.
  * Used by AMD HIP/ROCm backend.
@@ -82,7 +82,7 @@ struct map* map_dmabuf(const struct ctrl* ctrl,
 
 
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
 /* Forward declaration -- avoids pulling <linux/scatterlist.h> into map.h */
 struct sg_table;
 

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -21,6 +21,7 @@
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/version.h>
+#include <linux/overflow.h>
 #include <linux/uaccess.h>
 #include "irq.h"
 #include <asm/io.h>
@@ -34,8 +35,12 @@
 
 MODULE_DESCRIPTION("UserSpace-GDS NVMe DMA helper");
 MODULE_LICENSE("Dual BSD/GPL");
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF) && LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
 MODULE_IMPORT_NS(DMA_BUF);
+#endif
 #endif
 MODULE_VERSION("1.0");
 
@@ -118,6 +123,7 @@ struct map_handle
     struct map*         map;
     int                 type;           /* enum handle_type */
     u64                 vaddr;          /* Raw user address (MAP == UNMAP key) */
+    size_t              size;           /* Range size for overlap detection */
     unsigned long       n_pages;
     int                 dmabuf_fd;      /* -1 unless HANDLE_DMABUF */
     u64                 dmabuf_offset;
@@ -125,6 +131,14 @@ struct map_handle
 };
 
 
+/* Page size for a given handle type.
+ * HOST/DMABUF use the system page size; CUDA uses GPU_PAGE_SIZE (64 KiB). */
+#ifdef _CUDA
+#define GPU_PAGE_SIZE_PER_TYPE(t) \
+    ((t) == HANDLE_CUDA ? (1UL << 16) : PAGE_SIZE)
+#else
+#define GPU_PAGE_SIZE_PER_TYPE(t)  PAGE_SIZE
+#endif
 static struct map_handle* handle_find(struct ugds_file_ctx* ctx, u64 vaddr)
 {
     struct map_handle* handle;
@@ -132,6 +146,34 @@ static struct map_handle* handle_find(struct ugds_file_ctx* ctx, u64 vaddr)
     list_for_each_entry(handle, &ctx->handles, node)
     {
         if (handle->vaddr == vaddr)
+        {
+            return handle;
+        }
+    }
+
+    return NULL;
+}
+
+/* Check if a proposed [vaddr, vaddr+size) range overlaps any existing
+ * mapping. Returns the conflicting handle or NULL. */
+static struct map_handle* handle_find_overlap(struct ugds_file_ctx* ctx,
+                                               u64 vaddr, u64 size)
+{
+    struct map_handle* handle;
+
+    if (size == 0)
+        return NULL;
+
+    /* Guard against overflow in end computation */
+    if (vaddr > U64_MAX - size)
+        return (struct map_handle*)1;  /* invalid range, reject */
+
+    u64 vaddr_end = vaddr + size;
+
+    list_for_each_entry(handle, &ctx->handles, node)
+    {
+        u64 h_end = handle->vaddr + handle->size;
+        if (vaddr < h_end && vaddr_end > handle->vaddr)
         {
             return handle;
         }
@@ -325,6 +367,24 @@ static long do_map(struct ugds_file_ctx* ctx, enum handle_type type,
         goto out;
     }
 
+    /* New mapping: reject if range overlaps an existing one */
+    {
+        u64 page_sz = GPU_PAGE_SIZE_PER_TYPE(type);
+        u64 map_size;
+        if (check_mul_overflow((u64)n_pages, page_sz, &map_size))
+        {
+            retval = -EINVAL;
+            goto out;
+        }
+        if (handle_find_overlap(ctx, vaddr, map_size) != NULL)
+        {
+            printk(KERN_WARNING "uGDS: address %llx+%llu overlaps "
+                   "existing mapping\n", vaddr, map_size);
+            retval = -EEXIST;
+            goto out;
+        }
+    }
+
     switch (type)
     {
         case HANDLE_HOST:
@@ -337,8 +397,13 @@ static long do_map(struct ugds_file_ctx* ctx, enum handle_type type,
             break;
 #endif
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
         case HANDLE_DMABUF:
+            if (!ctx->ctrl->dmabuf_supported)
+            {
+                map = ERR_PTR(-EOPNOTSUPP);
+                break;
+            }
             map = map_dmabuf(ctx->ctrl, vaddr, dmabuf_fd, dmabuf_offset,
                              n_pages, ioaddrs_capacity);
             break;
@@ -403,6 +468,7 @@ static long do_map(struct ugds_file_ctx* ctx, enum handle_type type,
     handle->map = map;
     handle->type = (int) type;
     handle->vaddr = vaddr;
+    handle->size = (size_t)n_pages * GPU_PAGE_SIZE_PER_TYPE(type);
     handle->n_pages = n_pages;
     handle->dmabuf_fd = dmabuf_fd;
     handle->dmabuf_offset = dmabuf_offset;
@@ -488,7 +554,7 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                           (void __user*) request.ioaddrs, SIZE_MAX);
 #endif
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
         case NVM_MAP_DMABUF_MEMORY:
         {
             struct nvm_ioctl_dmabuf dreq;
@@ -534,6 +600,9 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                           (void __user*)(uintptr_t) dreq.ioaddrs,
                           dreq.ioaddrs_capacity);
         }
+#else
+        case NVM_MAP_DMABUF_MEMORY:
+            return -EOPNOTSUPP;
 #endif
 
         case NVM_UNMAP_MEMORY:
@@ -660,6 +729,30 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
         return -EIO;
+    }
+    ctrl->dmabuf_supported = 1;
+#elif defined(UGDS_HAVE_DMABUF)
+    /* CUDA dmabuf: try 64-bit DMA, fall back to 32-bit.
+     * dmabuf export is disabled if 64-bit DMA fails. */
+    if (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(64)))
+    {
+        if (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(32)))
+        {
+            printk(KERN_ERR DRIVER_NAME " failed to set DMA mask\n");
+            pci_clear_master(dev);
+            ctrl_chrdev_remove(ctrl);
+            pci_disable_device(dev);
+            pci_release_region(dev, 0);
+            ctrl_put(ctrl);
+            return -EIO;
+        }
+        printk(KERN_WARNING DRIVER_NAME " using 32-bit DMA mask "
+               "(dmabuf export disabled)\n");
+        ctrl->dmabuf_supported = 0;
+    }
+    else
+    {
+        ctrl->dmabuf_supported = 1;
     }
 #else
     /* Default CUDA: try 64-bit, fall back to 32-bit. */

--- a/examples/rdma_example.cu
+++ b/examples/rdma_example.cu
@@ -1,0 +1,171 @@
+/* GPUDirect RDMA Example -- Producer/Consumer Pattern
+ *
+ * Build: Requires UGDS_ENABLE_RDMA=ON and libibverbs.
+ */
+
+#include <ugds.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#ifdef UGDS_ENABLE_RDMA
+#include <infiniband/verbs.h>
+
+int main(int argc, char** argv)
+{
+    const char* dev_path = (argc > 1) ? argv[1] : "/dev/ugds_drv0";
+    const char* rdma_dev = (argc > 2) ? argv[2] : "mlx5_0";
+    const size_t buf_size = 1 << 20;
+
+    int rc = 1;
+    uGDSHandle_t fh = NULL;
+    int nvme_fd = -1;
+    void* d_buf = NULL;
+    int dmabuf_fd = -1;
+    struct ibv_mr* mr = NULL;
+    struct ibv_pd* pd = NULL;
+    struct ibv_context* ctx = NULL;
+    struct ibv_device** dev_list = NULL;
+    bool buf_registered = false;
+
+    printf("uGDS GPUDirect RDMA Example\n");
+
+    /* Use do-while(0) to allow break-based cleanup without goto */
+    do {
+        /* -- Initialize uGDS -- */
+        uGDSError_t st = uGDSDriverOpen();
+        if (st.err != UGDS_SUCCESS) {
+            fprintf(stderr, "uGDSDriverOpen failed: %s\n", UGDS_ERRSTR(st.err));
+            break;
+        }
+
+        /* -- Open NVMe handle -- */
+        nvme_fd = open(dev_path, O_RDWR);
+        if (nvme_fd < 0) { perror("open NVMe"); break; }
+
+        uGDSDescr_t descr;
+        memset(&descr, 0, sizeof(descr));
+        descr.type = UGDS_HANDLE_TYPE_OPAQUE_FD;
+        descr.handle.fd = nvme_fd;
+        st = uGDSHandleRegister(&fh, &descr);
+        if (st.err != UGDS_SUCCESS) {
+            fprintf(stderr, "uGDSHandleRegister failed: %s\n", UGDS_ERRSTR(st.err));
+            break;
+        }
+
+        /* -- Allocate GPU memory -- */
+        if (cudaMalloc(&d_buf, buf_size) != cudaSuccess) {
+            fprintf(stderr, "cudaMalloc failed\n");
+            break;
+        }
+
+        /* -- Register buffer with RDMA enabled -- */
+        uGDSBufConfig_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        cfg.backend = UGDS_BACKEND_CUDA;
+        cfg.enable_export = true;
+        st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+        if (st.err != UGDS_SUCCESS) {
+            fprintf(stderr, "uGDSBufRegisterEx failed: %s\n", UGDS_ERRSTR(st.err));
+            break;
+        }
+        buf_registered = true;
+
+        /* -- Export dma-buf handle -- */
+        uGDSDmabufExport_t exp;
+        memset(&exp, 0, sizeof(exp));
+        st = uGDSExportDmabuf(d_buf, &exp);
+        if (st.err != UGDS_SUCCESS) {
+            fprintf(stderr, "uGDSExportDmabuf failed: %s\n", UGDS_ERRSTR(st.err));
+            break;
+        }
+        dmabuf_fd = exp.fd;
+        printf("  Export: fd=%d, offset=%lu, length=%zu\n",
+               exp.fd, (unsigned long)exp.offset, exp.length);
+
+        /* -- Open RDMA device -- */
+        dev_list = ibv_get_device_list(NULL);
+        if (!dev_list) { fprintf(stderr, "ibv_get_device_list failed\n"); break; }
+        for (int i = 0; dev_list[i]; i++) {
+            if (strcmp(ibv_get_device_name(dev_list[i]), rdma_dev) == 0) {
+                ctx = ibv_open_device(dev_list[i]);
+                break;
+            }
+        }
+        if (!ctx) { fprintf(stderr, "RDMA device %s not found\n", rdma_dev); break; }
+
+        pd = ibv_alloc_pd(ctx);
+        if (!pd) { perror("ibv_alloc_pd"); break; }
+
+        mr = ibv_reg_dmabuf_mr(pd, exp.offset, exp.length, (uint64_t)d_buf,
+            dmabuf_fd,
+            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+            IBV_ACCESS_REMOTE_WRITE);
+        if (!mr) { fprintf(stderr, "ibv_reg_dmabuf_mr failed\n"); break; }
+        printf("  MR: lkey=%u, rkey=%u\n", mr->lkey, mr->rkey);
+
+        /* -- Producer: NVMe Read -> GPU VRAM -- */
+        printf("Phase 1: NVMe Read (producer)...\n");
+        ssize_t bytes = uGDSRead(fh, d_buf, 4096, 0, 0);
+        if (bytes != 4096) {
+            fprintf(stderr, "uGDSRead failed: %zd\n", bytes);
+            break;
+        }
+        printf("  NVMe Read completed: %zd bytes\n", bytes);
+
+        /* -- Consumer: RDMA Send (safe after NVMe completion) -- */
+        printf("Phase 2: RDMA Send (consumer) - safe after NVMe completion\n");
+        printf("  (RDMA send omitted - requires QP setup)\n");
+
+        /* -- Success -- */
+        printf("\nSuccess.\n");
+        rc = 0;
+    } while (0);
+
+    /* Single cleanup path */
+    printf("Phase 3: Teardown\n");
+    if (mr) {
+        int dereg_err = ibv_dereg_mr(mr);
+        if (dereg_err != 0) {
+            fprintf(stderr, "Error: ibv_dereg_mr failed: %s\n", strerror(dereg_err));
+            fprintf(stderr, "  Aborting teardown -- MR may still reference GPU memory\n");
+            return 1;
+        }
+        printf("  MR deregistered\n");
+    }
+    if (dmabuf_fd >= 0) { close(dmabuf_fd); printf("  Export fd closed\n"); }
+    if (buf_registered) {
+        uGDSError_t dst = uGDSBufDeregister(d_buf);
+        if (dst.err != UGDS_SUCCESS) {
+            fprintf(stderr, "Error: uGDSBufDeregister failed: %s\n", UGDS_ERRSTR(dst.err));
+            fprintf(stderr, "  Aborting teardown -- buffer may still be in use\n");
+            return 1;
+        }
+        printf("  uGDS buffer deregistered\n");
+    }
+    if (d_buf) { cudaFree(d_buf); printf("  GPU memory freed\n"); }
+    if (fh) uGDSHandleDeregister(fh);
+    if (nvme_fd >= 0) close(nvme_fd);
+    if (pd) ibv_dealloc_pd(pd);
+    if (ctx) ibv_close_device(ctx);
+    if (dev_list) ibv_free_device_list(dev_list);
+    uGDSDriverClose();
+
+    if (rc == 0) printf("\nDone. All resources cleaned up.\n");
+    return rc;
+}
+
+#else /* !UGDS_ENABLE_RDMA */
+
+int main(void)
+{
+    printf("This example requires UGDS_ENABLE_RDMA=ON at build time.\n");
+    printf("Rebuild with: cmake .. -DUGDS_ENABLE_RDMA=ON\n");
+    return 0;
+}
+
+#endif /* UGDS_ENABLE_RDMA */

--- a/include/libnvm/nvm_dma.h
+++ b/include/libnvm/nvm_dma.h
@@ -87,8 +87,12 @@ int nvm_dma_map_device(nvm_dma_t** map, const nvm_ctrl_t* ctrl, void* devptr, si
  * Extended version with flags for backend selection.
  * flags: 0 for NVIDIA CUDA (default), NVM_MAP_DMABUF for AMD HIP.
  */
-#define NVM_MAP_DMABUF  0x1
+#define NVM_MAP_DMABUF      0x1
+#define NVM_MAP_RDMA        0x2    /* Retain dmabuf fd for RDMA use */
+#define NVM_MAP_FORCE_CUDA  0x4    /* Force CUDA path (skip auto-probe) */
 int nvm_dma_map_device_ex(nvm_dma_t** map, const nvm_ctrl_t* ctrl, void* devptr, size_t size, int flags);
+
+/* (nvm_dma_get_dmabuf_info is internal-only -- declared in internal/dma.h) */
 
 //#endif /* __CUDA__ */
 

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -65,6 +65,7 @@ typedef enum uGDSOpError {
     UGDS_GPU_MEMORY_PINNING_FAILED   = UGDS_BASE_ERR + 36,
 
     UGDS_BATCH_CAPACITY_EXCEEDED     = UGDS_BASE_ERR + 40,
+    UGDS_RDMA_MR_STILL_ACTIVE        = UGDS_BASE_ERR + 41,
     UGDS_BUSY                        = UGDS_BASE_ERR + 42,
     UGDS_OUT_OF_MEMORY               = UGDS_BASE_ERR + 43,
 } uGDSOpError;
@@ -89,6 +90,7 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_BATCH_CAPACITY_EXCEEDED:     return "batch capacity exceeded";
 
     case UGDS_BUSY:                        return "resource busy, retry";
+    case UGDS_RDMA_MR_STILL_ACTIVE:       return "RDMA MR still active";
     case UGDS_OUT_OF_MEMORY:               return "out of memory";
     default:                                  return "unknown uGDS error";
     }
@@ -141,6 +143,12 @@ uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 /* Flag for uGDSBufRegister: use AMD HIP/dma-buf path */
 #define UGDS_REGISTER_DMABUF  NVM_MAP_DMABUF
 
+/* Buffer registration flags (defined locally to avoid pulling in
+ * libnvm/nvm_dma.h, which transitively includes C++ <atomic>) */
+#define NVM_MAP_DMABUF      0x1
+#define NVM_MAP_RDMA        0x2    /* Retain dmabuf fd for RDMA use */
+#define NVM_MAP_FORCE_CUDA  0x4    /* Force CUDA path (skip auto-probe) */
+
 uGDSError_t uGDSBufDeregister(const void* bufPtr_base);
 
 /* Backend identifier for dual-backend dispatch. */
@@ -149,6 +157,50 @@ typedef enum uGDSBackend {
     UGDS_BACKEND_CUDA    = 1,
     UGDS_BACKEND_HIP     = 2,
 } uGDSBackend_t;
+
+/* Extended buffer registration with backend selection and export flag */
+typedef struct uGDSBufConfig {
+    uGDSBackend_t   backend;
+    bool            enable_export;
+} uGDSBufConfig_t;
+
+uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,
+                               const uGDSBufConfig_t* config);
+
+/* dma-buf export handle for RDMA registration.
+ * fd is dup()'d -- caller owns it and MUST close after use. */
+typedef struct uGDSDmabufExport {
+    int       fd;
+    uint64_t  offset;
+    size_t    length;
+} uGDSDmabufExport_t;
+
+uGDSError_t uGDSExportDmabuf(const void* bufPtr_base,
+                              uGDSDmabufExport_t* out);
+
+/* RDMA MR registration handle.
+ *
+ * Lifecycle: uGDSRDMARegister() creates an MR via ibv_reg_dmabuf_mr()
+ * and records it. uGDSRDMAUnregister() calls ibv_dereg_mr() and removes
+ * the record. The caller MUST ensure that:
+ *   1. No new work requests are posted to this MR before unregistering.
+ *   2. All outstanding completions for this MR have been reaped.
+ * Deregistering an MR that still has in-flight WRs is undefined
+ * behavior (NIC may still be accessing the memory). */
+typedef struct uGDSRDMARegion {
+    void*           mr;          /* ibv_mr* (opaque) */
+    uint64_t        iova;        /* IOVA / buffer VA for post-recv */
+    uint32_t        lkey;
+    uint32_t        rkey;
+    uint64_t        token;       /* internal generation token */
+} uGDSRDMARegion_t;
+
+uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
+                              void* pd, int access_flags,
+                              uGDSRDMARegion_t* region);
+
+uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
+                                uGDSRDMARegion_t* region);
 
 ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                    off_t file_offset, off_t bufPtr_offset);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -3,14 +3,24 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <time.h>
-#if defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
-#include <hip/hip_runtime.h>
-typedef hipStream_t cudaStream_t;
-#else
-#include <cuda_runtime.h>
-#endif
+
+/* Buffer registration flags (defined locally to avoid pulling in
+ * libnvm/nvm_dma.h, which transitively includes C++ <atomic>) */
+#define NVM_MAP_DMABUF      0x1
+/* GPU runtime headers are NOT included in the public header.
+ * cuda_runtime.h and hip_runtime_api.h define conflicting types
+ * (vector types, stream types) that cannot coexist in a single TU.
+ *
+ * The async API uses void* for streams. Callers pass cudaStream_t
+ * (CUDA) or hipStream_t (HIP), which implicitly convert to void*.
+ * Backend-specific runtime headers are included only in internal
+ * source files that need them.
+ *
+ * Migration note: applications that previously relied on ugds.h to
+ * transitively include cuda_runtime.h must now include it directly. */
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,6 +65,8 @@ typedef enum uGDSOpError {
     UGDS_GPU_MEMORY_PINNING_FAILED   = UGDS_BASE_ERR + 36,
 
     UGDS_BATCH_CAPACITY_EXCEEDED     = UGDS_BASE_ERR + 40,
+    UGDS_BUSY                        = UGDS_BASE_ERR + 42,
+    UGDS_OUT_OF_MEMORY               = UGDS_BASE_ERR + 43,
 } uGDSOpError;
 
 static inline const char* uGDS_status_error(uGDSOpError status) {
@@ -66,6 +78,8 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_DRIVER_VERSION_MISMATCH:     return "driver version mismatch";
     case UGDS_DRIVER_CLOSING:              return "driver closing";
     case UGDS_IO_NOT_SUPPORTED:            return "IO not supported";
+    case UGDS_PLATFORM_NOT_SUPPORTED:      return "platform not supported";
+    case UGDS_DEVICE_NOT_SUPPORTED:        return "device not supported";
     case UGDS_INVALID_FILE_TYPE:           return "unsupported file type";
     case UGDS_INVALID_VALUE:               return "invalid arguments";
     case UGDS_MEMORY_ALREADY_REGISTERED:   return "memory already registered";
@@ -73,6 +87,9 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_INTERNAL_ERROR:              return "internal error";
     case UGDS_GPU_MEMORY_PINNING_FAILED:   return "GPU memory pinning failed";
     case UGDS_BATCH_CAPACITY_EXCEEDED:     return "batch capacity exceeded";
+
+    case UGDS_BUSY:                        return "resource busy, retry";
+    case UGDS_OUT_OF_MEMORY:               return "out of memory";
     default:                                  return "unknown uGDS error";
     }
 }
@@ -109,12 +126,29 @@ uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
 
 void uGDSHandleDeregister(uGDSHandle_t fh);
 
+/* Deregister a handle with a drain timeout.
+ * Returns UGDS_OK on success, or UGDS_BUSY if the timeout expires
+ * before all in-flight operations (including batch handles) complete.
+ * timeout_sec == 0 means non-blocking check only.
+ * timeout_sec < 0 means infinite wait (equivalent to uGDSHandleDeregister).
+ * timeout_sec < -1 means force teardown: skip wedged/in-flight checks
+ * and free all resources unconditionally.  The caller must guarantee
+ * that no NVMe command is still executing (e.g. after a controller reset). */
+uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
+
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 
 /* Flag for uGDSBufRegister: use AMD HIP/dma-buf path */
-#define UGDS_REGISTER_DMABUF  0x1   /* Use AMD HIP/dma-buf path */
+#define UGDS_REGISTER_DMABUF  NVM_MAP_DMABUF
 
 uGDSError_t uGDSBufDeregister(const void* bufPtr_base);
+
+/* Backend identifier for dual-backend dispatch. */
+typedef enum uGDSBackend {
+    UGDS_BACKEND_DEFAULT = 0,
+    UGDS_BACKEND_CUDA    = 1,
+    UGDS_BACKEND_HIP     = 2,
+} uGDSBackend_t;
 
 ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                    off_t file_offset, off_t bufPtr_offset);
@@ -122,7 +156,7 @@ ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                     off_t file_offset, off_t bufPtr_offset);
 
-/* ── Batch IO ── */
+/* -- Batch IO -- */
 
 typedef void* uGDSBatchHandle_t;
 
@@ -167,24 +201,48 @@ uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
 
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
-/* ── Async Stream IO ──
+/* -- Async Stream IO --
  * Pointer params (size_p, file_offset_p, etc.) must be host-accessible.
- * Use cudaHostAlloc for GPU-writable pinned memory (late binding).
- */
+ * Use cudaHostAlloc/hipHostMalloc for GPU-writable pinned memory (late binding).
+ *
+ * Stream parameter is void* to support both CUDA and HIP backends.
+ * Pass cudaStream_t (CUDA) or hipStream_t (HIP) -- both implicitly
+ * convert to void*.
+ *
+ * Backend dispatch:
+ *   - CUDA-only build: uses cudaLaunchHostFunc
+ *   - HIP-only build: uses hipLaunchHostFunc
+ *   - Dual-backend build: dispatches based on the buffer's registered
+ *     backend (UGDS_BACKEND_CUDA -> cudaLaunchHostFunc,
+ *     UGDS_BACKEND_HIP -> hipLaunchHostFunc). */
 
 uGDSError_t uGDSReadAsync(uGDSHandle_t fh, void *bufPtr_base,
                            size_t *size_p, off_t *file_offset_p,
                            off_t *bufPtr_offset_p, ssize_t *bytes_read_p,
-                           cudaStream_t stream);
+                           void* stream);
 
 uGDSError_t uGDSWriteAsync(uGDSHandle_t fh, void *bufPtr_base,
                             size_t *size_p, off_t *file_offset_p,
                             off_t *bufPtr_offset_p, ssize_t *bytes_written_p,
-                            cudaStream_t stream);
+                            void* stream);
 
-uGDSError_t uGDSStreamRegister(cudaStream_t stream);
+/* Register a stream without a backend hint (treated as default).
+ * In dual-backend builds, streams registered via this function are
+ * not validated against the buffer's backend. Use uGDSStreamRegisterEx
+ * to enable cross-backend mismatch detection. */
+uGDSError_t uGDSStreamRegister(void* stream);
 
-uGDSError_t uGDSStreamDeregister(cudaStream_t stream);
+/* Register a stream with an explicit backend for dual-backend validation.
+ * In dual-backend builds, uGDSReadAsync/uGDSWriteAsync will reject
+ * stream/buffer backend mismatches when the stream has been registered
+ * with an explicit backend. Streams registered via uGDSStreamRegister
+ * or not registered at all bypass the check.
+ *
+ * In single-backend builds, this validates that the requested backend
+ * matches the compiled-in backend (e.g. CUDA-only rejects HIP). */
+uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend);
+
+uGDSError_t uGDSStreamDeregister(void* stream);
 
 #ifdef __cplusplus
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -172,6 +172,13 @@ run_functional() {
         test_cq_dw11
         test_interrupt_ioctls
         test_interrupt_mode
+        test_dmabuf_export
+    )
+
+    # RDMA tests (only if built)
+    local rdma_tests=(
+        test_rdma_export
+        test_rdma_tracked
     )
 
     for t in "${tests[@]}"; do
@@ -189,6 +196,21 @@ run_functional() {
                     found=1
                     continue
                 fi
+                run_test "$t${suffix}" "$BUILD_DIR/${t}${suffix}" "$ugds_dev" "$GPU_ID"
+                found=1
+            fi
+        done
+        if [ $found -eq 0 ]; then
+            printf "  %-40s ${Y}SKIP${N} (not built)\n" "$t"
+            SKIPPED=$((SKIPPED + 1))
+        fi
+    done
+    for t in "${rdma_tests[@]}"; do
+        # RDMA tests may not be built in non-RDMA configs.
+        # In dual-backend builds, both _cuda and _hip variants may exist.
+        local found=0
+        for suffix in "" "_cuda" "_hip"; do
+            if [ -x "$BUILD_DIR/${t}${suffix}" ]; then
                 run_test "$t${suffix}" "$BUILD_DIR/${t}${suffix}" "$ugds_dev" "$GPU_ID"
                 found=1
             fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -124,9 +124,16 @@ run_test() {
         printf "${G}PASS${N}\n"
         PASSED=$((PASSED + 1))
     else
-        printf "${R}FAIL${N}\n"
-        echo "$output" | tail -5 | sed 's/^/    /'
-        FAILED=$((FAILED + 1))
+        local rc=$?
+        if [ $rc -eq 77 ]; then
+            printf "${Y}SKIP${N}\n"
+            echo "$output" | tail -3 | sed 's/^/    /'
+            SKIPPED=$((SKIPPED + 1))
+        else
+            printf "${R}FAIL${N}\n"
+            echo "$output" | tail -5 | sed 's/^/    /'
+            FAILED=$((FAILED + 1))
+        fi
     fi
 }
 
@@ -168,7 +175,28 @@ run_functional() {
     )
 
     for t in "${tests[@]}"; do
-        run_test "$t" "$BUILD_DIR/$t" "$ugds_dev" "$GPU_ID"
+        # In dual-backend builds, targets may be suffixed (_cuda/_hip)
+        local found=0
+        for suffix in "" "_cuda" "_hip"; do
+            if [ -x "$BUILD_DIR/${t}${suffix}" ]; then
+                # Skip on-the-fly unregistered test for HIP in dual builds:
+                # nvm_dma_map_device() defaults to CUDA (flags=0), so HIP
+                # unregistered I/O would route to the wrong backend.
+                # AMD buffers must be explicitly registered via uGDSBufRegister.
+                if [ "$t" = "test_read_write_unregistered" ] && [ "$suffix" = "_hip" ]; then
+                    printf "  %-40s ${Y}SKIP${N} (unregistered HIP I/O unsupported in dual mode)\n" "${t}${suffix}"
+                    SKIPPED=$((SKIPPED + 1))
+                    found=1
+                    continue
+                fi
+                run_test "$t${suffix}" "$BUILD_DIR/${t}${suffix}" "$ugds_dev" "$GPU_ID"
+                found=1
+            fi
+        done
+        if [ $found -eq 0 ]; then
+            printf "  %-40s ${Y}SKIP${N} (not built)\n" "$t"
+            SKIPPED=$((SKIPPED + 1))
+        fi
     done
     echo ""
 }
@@ -182,7 +210,16 @@ run_perf_ugds() {
     local ugds_dev
     ugds_dev=$(ensure_ugds "$slot")
 
-    if [ ! -x "$BUILD_DIR/bench_ugds" ]; then
+    # Find bench_ugds (may be suffixed in dual-backend builds)
+    local bench_bin=""
+    for suffix in "" "_cuda" "_hip"; do
+        if [ -x "$BUILD_DIR/bench_ugds${suffix}" ]; then
+            bench_bin="$BUILD_DIR/bench_ugds${suffix}"
+            break
+        fi
+    done
+
+    if [ -z "$bench_bin" ]; then
         echo "  SKIP (bench_ugds not built)"
         echo ""
         return
@@ -193,7 +230,7 @@ run_perf_ugds() {
 
     for sz in 4K 128K 1M; do
         echo "[UGDS - ${sz} seq read]"
-        "$BUILD_DIR/bench_ugds" -f "$ugds_dev" -l 128M -s "$sz" -t 1 -d "$GPU_ID" -m read
+        "$bench_bin" -f "$ugds_dev" -l 128M -s "$sz" -t 1 -d "$GPU_ID" -m read
     done
     echo ""
 }

--- a/src/libnvm/dma.cpp
+++ b/src/libnvm/dma.cpp
@@ -34,6 +34,16 @@ struct map
 
     va_range_free_t     release;// Callback for releasing address range
     va_unmap_t          unmap;// Callback for unmapping address range
+
+    /* dmabuf export metadata (valid only for MAP_TYPE_DMABUF*) */
+    int                 dmabuf_fd;       /* -1 if not dmabuf */
+    uint64_t            dmabuf_offset;   /* 0 if not dmabuf */
+    size_t              dmabuf_length;   /* 0 if not dmabuf */
+
+    /* Backend origin tag: true if mapping went through the HIP/dmabuf
+     * path (regardless of whether fd was retained). Used by dual-backend
+     * dispatch to select the correct async launch function. */
+    bool                hip_origin;
 };
 
 
@@ -100,6 +110,11 @@ static int create_map(struct map** md, const nvm_ctrl_t* ctrl, struct va_range* 
     m->va = va;
     m->release = release;
     m->unmap = NULL;
+
+    m->dmabuf_fd = -1;
+    m->dmabuf_offset = 0;
+    m->dmabuf_length = 0;
+    m->hip_origin = false;
 
     *md = m;
     return 0;
@@ -478,5 +493,45 @@ const struct va_range* _nvm_dma_va(const nvm_dma_t* handle)
     }
 
     return NULL;
+}
+
+
+int _nvm_dma_set_dmabuf_info(nvm_dma_t* handle,
+                              int fd, uint64_t offset, size_t length)
+{
+    if (handle == NULL) return -1;
+    struct container* c = _nvm_container_of(handle, struct container, handle);
+    c->map->dmabuf_fd = fd;
+    c->map->dmabuf_offset = offset;
+    c->map->dmabuf_length = length;
+    return 0;
+}
+
+int nvm_dma_get_dmabuf_info(const nvm_dma_t* handle,
+                             int* out_fd, uint64_t* out_offset, size_t* out_length)
+{
+    if (handle == NULL) return -1;
+    const struct container* c = _nvm_container_of(handle, struct container, handle);
+
+    if (c->map->dmabuf_fd < 0) return -1;
+
+    if (out_fd)     *out_fd = c->map->dmabuf_fd;
+    if (out_offset) *out_offset = c->map->dmabuf_offset;
+    if (out_length) *out_length = c->map->dmabuf_length;
+    return 0;
+}
+
+bool nvm_dma_is_hip_origin(const nvm_dma_t* handle)
+{
+    if (handle == NULL) return false;
+    const struct container* c = _nvm_container_of(handle, struct container, handle);
+    return c->map->hip_origin;
+}
+
+void _nvm_dma_set_hip_origin(nvm_dma_t* handle)
+{
+    if (handle == NULL) return;
+    struct container* c = _nvm_container_of(handle, struct container, handle);
+    c->map->hip_origin = true;
 }
 

--- a/src/libnvm/internal/dma.h
+++ b/src/libnvm/internal/dma.h
@@ -54,4 +54,33 @@ int _nvm_dma_init(nvm_dma_t** handle,
 const struct va_range* _nvm_dma_va(const nvm_dma_t* handle);
 
 
+/*
+ * Set dmabuf metadata on a DMA handle's internal map.
+ * Called by linux_dma.cpp AFTER the retain/close decision.
+ */
+int _nvm_dma_set_dmabuf_info(nvm_dma_t* handle,
+                              int fd, uint64_t offset, size_t length);
+
+/*
+ * Tag a DMA handle as originating from the HIP/dmabuf path.
+ * Called after _nvm_dma_init for HIP mappings, regardless of
+ * whether the dmabuf fd was retained or closed.
+ */
+void _nvm_dma_set_hip_origin(nvm_dma_t* handle);
+
+/*
+ * Retrieve dmabuf metadata from a DMA handle (internal only).
+ * Returns 0 on success, -1 if handle is not dmabuf-backed.
+ * Does NOT dup() -- returns internal fd. Callers must NOT close it.
+ */
+int nvm_dma_get_dmabuf_info(const nvm_dma_t* handle,
+                             int* out_fd, uint64_t* out_offset, size_t* out_length);
+
+/*
+ * Query whether a DMA handle was created through the HIP/dmabuf path.
+ * Returns true even if the fd was closed after kernel import.
+ * Used by dual-backend dispatch to select the correct async launch.
+ */
+bool nvm_dma_is_hip_origin(const nvm_dma_t* handle);
+
 #endif /* __NVM_INTERNAL_DMA_H__ */

--- a/src/libnvm/internal/ioctl.h
+++ b/src/libnvm/internal/ioctl.h
@@ -17,18 +17,19 @@ struct nvm_ioctl_map
     uint64_t*   ioaddrs;
 };
 
-#ifdef _HIP
+/* Always define the dmabuf struct so the ioctl enum can reference it
+ * unconditionally. The handler body is only compiled when
+ * UGDS_HAVE_DMABUF is set, but the type must exist for the enum. */
 struct nvm_ioctl_dmabuf
 {
     uint64_t  gpu_ptr;           /* Original GPU VA -- unmap identity */
-    int32_t   dmabuf_fd;         /* DMA-buf fd from HSA export */
+    int32_t   dmabuf_fd;         /* DMA-buf fd from GPU export */
     uint32_t  __pad;             /* Alignment */
     uint64_t  dmabuf_offset;     /* Offset within dmabuf allocation */
     uint64_t  size;              /* Total buffer size in bytes */
     uint64_t  ioaddrs_capacity;  /* Max entries in ioaddrs buffer */
     uint64_t  ioaddrs;           /* Output: DMA bus addresses (pointer) */
 };
-#endif
 
 /* Bind/unbind an eventfd to an MSI-X interrupt vector (interrupt mode).
  * Must match struct nvm_ioctl_irq in drv/ioctl.h. */
@@ -46,9 +47,7 @@ enum nvm_ioctl_type
     NVM_MAP_HOST_MEMORY         = _IOW(NVM_IOCTL_TYPE, 1, struct nvm_ioctl_map),
     NVM_MAP_DEVICE_MEMORY       = _IOW(NVM_IOCTL_TYPE, 2, struct nvm_ioctl_map),
     NVM_UNMAP_MEMORY            = _IOW(NVM_IOCTL_TYPE, 3, uint64_t),
-#ifdef _HIP
     NVM_MAP_DMABUF_MEMORY       = _IOWR(NVM_IOCTL_TYPE, 4, struct nvm_ioctl_dmabuf),
-#endif
     NVM_REGISTER_INTERRUPT      = _IOW(NVM_IOCTL_TYPE, 5, struct nvm_ioctl_irq),
     NVM_UNREGISTER_INTERRUPT    = _IOW(NVM_IOCTL_TYPE, 6, struct nvm_ioctl_irq),
     NVM_GET_NUM_VECTORS         = _IOR(NVM_IOCTL_TYPE, 7, __u32),

--- a/src/libnvm/internal/map.h
+++ b/src/libnvm/internal/map.h
@@ -11,10 +11,10 @@
  */
 enum mapping_type
 {
-    MAP_TYPE_CUDA   =   0x1,   // CUDA device memory (NVIDIA)
-    MAP_TYPE_HOST   =   0x2,   // Host memory (RAM)
-    MAP_TYPE_API    =   0x4,   // Allocated by the API (RAM)
-    MAP_TYPE_DMABUF =   0x8    // DMA-buf (AMD HIP / standard Linux)
+    MAP_TYPE_CUDA        =   0x1,
+    MAP_TYPE_HOST        =   0x2,
+    MAP_TYPE_API         =   0x4,
+    MAP_TYPE_DMABUF      =   0x8,
 };
 
 
@@ -24,13 +24,12 @@ enum mapping_type
  */
 struct ioctl_mapping
 {
-    enum mapping_type   type;   // What kind of memory
-    void*               buffer; // GPU pointer (unmap identity) or host buffer
-    struct va_range     range;  // Memory range descriptor
+    enum mapping_type   type;
+    void*               buffer;
+    struct va_range     range;
 
-    /* DMABUF-specific fields */
-    int       dmabuf_fd;        // HSA-exported dma-buf file descriptor
-    uint64_t  dmabuf_offset;    // Offset within dmabuf allocation
+    int       dmabuf_fd;
+    uint64_t  dmabuf_offset;
 };
 
 

--- a/src/libnvm/internal/map.h
+++ b/src/libnvm/internal/map.h
@@ -15,7 +15,10 @@ enum mapping_type
     MAP_TYPE_HOST        =   0x2,
     MAP_TYPE_API         =   0x4,
     MAP_TYPE_DMABUF      =   0x8,
+    MAP_TYPE_DMABUF_CUDA =   0x10
 };
+
+typedef int (*dmabuf_close_fn)(int fd);
 
 
 
@@ -30,6 +33,9 @@ struct ioctl_mapping
 
     int       dmabuf_fd;
     uint64_t  dmabuf_offset;
+
+    bool                retain_fd;
+    dmabuf_close_fn     close_fn;
 };
 
 

--- a/src/libnvm/linux_device.cpp
+++ b/src/libnvm/linux_device.cpp
@@ -64,10 +64,13 @@ static int ioctl_map(const struct device* dev, const struct va_range* va, uint64
             type = NVM_MAP_DEVICE_MEMORY;
             break;
 
-#ifdef _HIP
+#if defined(UGDS_HAVE_DMABUF)
         case MAP_TYPE_DMABUF:
+        case MAP_TYPE_DMABUF_CUDA:
         {
-            /* DMA-buf path: pass fd + offset + gpu_ptr to kernel */
+            /* DMA-buf path: pass fd + offset + gpu_ptr to kernel.
+             * Both HIP (MAP_TYPE_DMABUF) and CUDA (MAP_TYPE_DMABUF_CUDA)
+             * go through the same NVM_MAP_DMABUF_MEMORY ioctl. */
             struct nvm_ioctl_dmabuf request = {
                 .gpu_ptr          = (uint64_t) m->buffer,
                 .dmabuf_fd        = m->dmabuf_fd,

--- a/src/libnvm/linux_dma.cpp
+++ b/src/libnvm/linux_dma.cpp
@@ -17,12 +17,22 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
 #include "internal/lib_util.h"
 #include "internal/lib_ctrl.h"
 #include "internal/dma.h"
 #include "internal/map.h"
 #include "internal/dprintf.h"
 
+#ifdef _CUDA
+#include <cuda.h>
+#endif
+
+
+static int posix_close_adapter(int fd)
+{
+    return close(fd);
+}
 
 
 static void remove_mapping_descriptor(struct ioctl_mapping* md)
@@ -30,6 +40,15 @@ static void remove_mapping_descriptor(struct ioctl_mapping* md)
     if (md->type == MAP_TYPE_API)
     {
         free((void*) md->buffer);
+    }
+
+    /* Close retained dmabuf fd exactly once via typed adapter */
+    if (md->retain_fd && md->dmabuf_fd >= 0 && md->close_fn != NULL)
+    {
+        int close_err = md->close_fn(md->dmabuf_fd);
+        if (close_err != 0)
+            dprintf("Warning: dmabuf close failed (fd=%d)\n", md->dmabuf_fd);
+        md->dmabuf_fd = -1;  /* prevent double-close */
     }
 
     free(md);
@@ -67,6 +86,8 @@ static int create_mapping_descriptor(struct ioctl_mapping** handle, size_t page_
     md->range.n_pages = n_pages;
     md->dmabuf_fd = -1;
     md->dmabuf_offset = 0;
+    md->retain_fd = false;
+    md->close_fn = NULL;
 
     *handle = md;
     return 0;
@@ -157,6 +178,12 @@ int nvm_dma_map_host(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* vaddr, si
 #include <hsa/hsa_ext_amd.h>
 #include <hip/hip_runtime_api.h>
 
+static int hsa_dmabuf_close_adapter(int fd)
+{
+    hsa_status_t s = hsa_amd_portable_close_dmabuf(fd);
+    return (s == HSA_STATUS_SUCCESS) ? 0 : -1;
+}
+
 /* Use runtime page size -- must match kernel PAGE_SIZE for ioctl contract.
  * Thread-safe initialization via C++11 function-local static. */
 static long hip_page_size()
@@ -189,17 +216,68 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
 #endif
 
     /* Reject unknown flags */
-    if (flags & ~NVM_MAP_DMABUF)
+    if (flags & ~(NVM_MAP_DMABUF | NVM_MAP_RDMA | NVM_MAP_FORCE_CUDA))
     {
         dprintf("nvm_dma_map_device: unknown flags 0x%x\n", flags);
         return EINVAL;
     }
 
+    /* Reject conflicting backend flags */
+    if ((flags & NVM_MAP_DMABUF) && (flags & NVM_MAP_FORCE_CUDA))
+    {
+        dprintf("nvm_dma_map_device: NVM_MAP_DMABUF and NVM_MAP_FORCE_CUDA are mutually exclusive\n");
+        return EINVAL;
+    }
+
+    /* Reject FORCE_CUDA when CUDA is not compiled in */
+#ifndef _CUDA
+    if (flags & NVM_MAP_FORCE_CUDA)
+    {
+        dprintf("nvm_dma_map_device: NVM_MAP_FORCE_CUDA requested but CUDA backend not compiled in\n");
+        return ENOTSUP;
+    }
+#endif
+
     /* Determine which backend to use at runtime */
     int use_hip = 0;
 #ifdef _HIP
   #ifdef _CUDA
-    use_hip = (flags & NVM_MAP_DMABUF) ? 1 : 0;
+    /* Dual-backend: explicit flag wins, otherwise probe pointer origin.
+     * cuPointerGetAttribute succeeds for CUDA pointers; HIP pointers
+     * fail it, so we fall back to HIP path. This handles on-the-fly
+     * (unregistered) mappings where the caller doesn't know the backend.
+     * Uses driver API to avoid CUDA/HIP runtime header conflicts. */
+    if (flags & NVM_MAP_DMABUF)
+    {
+        use_hip = 1;
+    }
+    else if (flags & NVM_MAP_FORCE_CUDA)
+    {
+        /* Explicit CUDA selection -- skip auto-probe to avoid accepting
+         * a HIP pointer or rejecting a valid non-current-context CUDA
+         * pointer. */
+        use_hip = 0;
+    }
+    else if (!(flags & NVM_MAP_RDMA))
+    {
+        unsigned int mem_type = 0;
+        CUresult cu_err = cuPointerGetAttribute(&mem_type,
+            CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)devptr);
+        if (cu_err != CUDA_SUCCESS)
+        {
+            /* Only treat as HIP if CUDA confirms the pointer is not
+             * a CUDA pointer. Other errors (not initialized, invalid
+             * context, deinitialized) indicate a real CUDA failure. */
+            if (cu_err == CUDA_ERROR_INVALID_VALUE)
+                use_hip = 1;
+            else
+                return EINVAL;
+        }
+        else
+        {
+            use_hip = 0;
+        }
+    }
   #else
     use_hip = 1;  /* HIP-only build */
   #endif
@@ -289,6 +367,9 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
         if (status != HSA_STATUS_SUCCESS || dmabuf_fd < 0)
         {
             dprintf("hsa_amd_portable_export_dmabuf_v2() failed: %d\n", status);
+            /* Device does not support dmabuf export (e.g., no Large BAR) */
+            if (status == HSA_STATUS_ERROR_INVALID_AGENT)
+                return ENOTSUP;
             return EIO;
         }
 
@@ -299,7 +380,8 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
         if (fd_flags < 0 || fcntl(dmabuf_fd, F_SETFD, fd_flags | FD_CLOEXEC) < 0)
         {
             dprintf("failed to set FD_CLOEXEC on dmabuf fd: %s\n", strerror(errno));
-            hsa_amd_portable_close_dmabuf(dmabuf_fd);
+            if (hsa_amd_portable_close_dmabuf(dmabuf_fd) != HSA_STATUS_SUCCESS)
+                dprintf("Warning: hsa_amd_portable_close_dmabuf failed\n");
             return EIO;
         }
 #endif
@@ -309,30 +391,182 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
         {
             dprintf("HSA dmabuf offset %llu is not page-aligned\n",
                     (unsigned long long)dmabuf_offset);
-            hsa_amd_portable_close_dmabuf(dmabuf_fd);
+            if (hsa_amd_portable_close_dmabuf(dmabuf_fd) != HSA_STATUS_SUCCESS)
+                dprintf("Warning: hsa_amd_portable_close_dmabuf failed\n");
             return EINVAL;
         }
 
         err = create_mapping_descriptor(&md, HPS, MAP_TYPE_DMABUF, devptr, size);
         if (err != 0)
         {
-            hsa_amd_portable_close_dmabuf(dmabuf_fd);
+            if (hsa_amd_portable_close_dmabuf(dmabuf_fd) != HSA_STATUS_SUCCESS)
+                dprintf("Warning: hsa_amd_portable_close_dmabuf failed\n");
             return err;
         }
 
         md->dmabuf_fd = dmabuf_fd;
         md->dmabuf_offset = dmabuf_offset;
+
+        /* RDMA: retain fd for later export; set typed close adapter */
+        if (flags & NVM_MAP_RDMA)
+        {
+            md->retain_fd = true;
+            md->close_fn = hsa_dmabuf_close_adapter;
+        }
     }
 #endif /* _HIP */
 
 #ifdef _CUDA
     if (!use_hip)
     {
-        /* NVIDIA CUDA path */
-        err = create_mapping_descriptor(&md, 1ULL << 16, MAP_TYPE_CUDA, devptr, size);
-        if (err != 0)
+        if (flags & NVM_MAP_RDMA)
         {
-            return err;
+#ifdef HAVE_CUDA_DMABUF
+            /* CUDA dma-buf export path for RDMA. */
+            /* device attribute -- query the device that owns devptr,
+             * not the currently active context (multi-GPU safe) */
+            int cu_dev_ordinal = -1;
+            int dma_buf_supported = 0;
+            CUresult cu_err;
+
+            cu_err = cuPointerGetAttribute(&cu_dev_ordinal,
+                CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)devptr);
+            if (cu_err != CUDA_SUCCESS) {
+                dprintf("cuPointerGetAttribute(DEVICE_ORDINAL) failed: %d\n", cu_err);
+                return EIO;
+            }
+            cu_err = cuDeviceGetAttribute(&dma_buf_supported,
+                CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cu_dev_ordinal);
+            if (cu_err != CUDA_SUCCESS || !dma_buf_supported) {
+                dprintf("CUDA device does not support dma-buf export\n");
+                return ENOTSUP;
+            }
+
+            /* pointer type validation */
+            unsigned int mem_type = 0;
+            cu_err = cuPointerGetAttribute(&mem_type,
+                CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)devptr);
+            if (cu_err != CUDA_SUCCESS) {
+                dprintf("cuPointerGetAttribute(MEMORY_TYPE) failed: %d\n", cu_err);
+                return EIO;
+            }
+            if (mem_type != CU_MEMORYTYPE_DEVICE) {
+                dprintf("Pointer %p is not device memory (type=%u)\n", devptr, mem_type);
+                return EINVAL;
+            }
+
+            /* reject managed memory */
+            int is_managed = 0;
+            cu_err = cuPointerGetAttribute(&is_managed,
+                CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)devptr);
+            if (cu_err == CUDA_SUCCESS && is_managed) {
+                dprintf("Managed memory not supported for GPUDirect RDMA\n");
+                return EINVAL;
+            }
+
+            /* allocation range + host page alignment */
+            CUdeviceptr base_ptr;
+            size_t alloc_size;
+            cu_err = cuMemGetAddressRange(&base_ptr, &alloc_size,
+                                          (CUdeviceptr)devptr);
+            if (cu_err != CUDA_SUCCESS) {
+                dprintf("cuMemGetAddressRange failed: %d\n", cu_err);
+                return EIO;
+            }
+
+            long hps = sysconf(_SC_PAGESIZE);
+            if (hps <= 0) {
+                dprintf("sysconf(_SC_PAGESIZE) failed\n");
+                return EINVAL;
+            }
+            /* Overflow guard: size + hps - 1 can wrap for huge sizes */
+            if ((size_t)hps > 0 && size > SIZE_MAX - ((size_t)hps - 1)) {
+                dprintf("Buffer size %zu overflows alignment computation\n", size);
+                return EINVAL;
+            }
+            size_t offset_in_alloc = (uintptr_t)devptr - (uintptr_t)base_ptr;
+            size_t aligned_size = (size + (size_t)hps - 1) & ~((size_t)hps - 1);
+
+            /* Overflow-safe bounds check: validate offset first, then
+             * use subtraction to avoid offset + size overflow */
+            if (offset_in_alloc > alloc_size ||
+                aligned_size > alloc_size - offset_in_alloc) {
+                dprintf("Buffer range %p+%zu exceeds CUDA allocation %p+%zu\n",
+                        devptr, size, (void*)base_ptr, alloc_size);
+                return EIO;
+            }
+            if ((uintptr_t)devptr % (size_t)hps != 0) {
+                dprintf("CUDA pointer %p not host-page-aligned (%ld)\n", devptr, hps);
+                return EINVAL;
+            }
+
+            /* export with PCIe BAR mapping flag */
+            dmabuf_fd = -1;
+            cu_err = cuMemGetHandleForAddressRange(
+                (void*)&dmabuf_fd,
+                (CUdeviceptr)devptr,
+                aligned_size,
+                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+
+            if (cu_err != CUDA_SUCCESS || dmabuf_fd < 0) {
+                dprintf("cuMemGetHandleForAddressRange failed: %d\n", cu_err);
+                /* CUDA_ERROR_NOT_SUPPORTED means the GPU/driver supports
+                 * the query but not the PCIe dmabuf export path. Translate
+                 * to ENOTSUP so callers get UGDS_IO_NOT_SUPPORTED and can
+                 * skip or fall back gracefully. */
+                if (cu_err == CUDA_ERROR_NOT_SUPPORTED)
+                    return ENOTSUP;
+                return EIO;
+            }
+            dmabuf_offset = 0;
+
+            /* FD_CLOEXEC */
+            int fd_flags = fcntl(dmabuf_fd, F_GETFD);
+            if (fd_flags < 0 ||
+                fcntl(dmabuf_fd, F_SETFD, fd_flags | FD_CLOEXEC) < 0) {
+                dprintf("failed to set FD_CLOEXEC on CUDA dmabuf fd: %s\n",
+                        strerror(errno));
+                close(dmabuf_fd);
+                return EIO;
+            }
+
+            /* SYNC_MEMOPS: fatal for RDMA (BAR consistency) */
+            int sync_val = 1;
+            cu_err = cuPointerSetAttribute(&sync_val,
+                CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, (CUdeviceptr)devptr);
+            if (cu_err != CUDA_SUCCESS) {
+                dprintf("cuPointerSetAttribute(SYNC_MEMOPS) failed: %d -- "
+                        "required for GPUDirect RDMA consistency\n", cu_err);
+                close(dmabuf_fd);
+                return EIO;
+            }
+
+            /* Create mapping with host PAGE_SIZE (not 64KiB) */
+            err = create_mapping_descriptor(&md, (size_t)hps,
+                                            MAP_TYPE_DMABUF_CUDA, devptr, size);
+            if (err != 0) {
+                close(dmabuf_fd);
+                return err;
+            }
+
+            md->dmabuf_fd = dmabuf_fd;
+            md->dmabuf_offset = 0;
+            md->retain_fd = true;
+            md->close_fn = posix_close_adapter;
+#else
+            dprintf("CUDA dma-buf export not compiled in (HAVE_CUDA_DMABUF undefined)\n");
+            return ENOTSUP;
+#endif
+        }
+        else
+        {
+            /* Standard NVIDIA CUDA path via kernel P2P */
+            err = create_mapping_descriptor(&md, 1ULL << 16, MAP_TYPE_CUDA, devptr, size);
+            if (err != 0)
+            {
+                return err;
+            }
         }
     }
 #endif /* _CUDA */
@@ -340,12 +574,16 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
     err = _nvm_dma_init(handle, ctrl, &md->range, &release_mapping_descriptor);
     if (err != 0)
     {
-        /* Save type before free -- remove_mapping_descriptor frees md */
+        /* Ownership transferred to md. remove_mapping_descriptor will close
+         * fd if retain_fd. Only close here if NOT retained (old behavior). */
         enum mapping_type saved_type = md->type;
+        bool was_retained = md->retain_fd;
         remove_mapping_descriptor(md);
 #ifdef _HIP
-        if (saved_type == MAP_TYPE_DMABUF && dmabuf_fd >= 0)
-            hsa_amd_portable_close_dmabuf(dmabuf_fd);
+        if (saved_type == MAP_TYPE_DMABUF && !was_retained && dmabuf_fd >= 0) {
+            if (hsa_amd_portable_close_dmabuf(dmabuf_fd) != HSA_STATUS_SUCCESS)
+                dprintf("Warning: hsa_amd_portable_close_dmabuf failed\n");
+        }
 #endif
         return err;
     }
@@ -353,16 +591,45 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
 #ifdef _HIP
     if (md->type == MAP_TYPE_DMABUF)
     {
-        /* Kernel holds its own refcount via dma_buf_get().
-         * Close userspace fd via HSA runtime API. */
-        hsa_status_t close_status = hsa_amd_portable_close_dmabuf(dmabuf_fd);
-        if (close_status != HSA_STATUS_SUCCESS) {
-            dprintf("hsa_amd_portable_close_dmabuf() failed: %d\n", close_status);
-            /* Unmap and release the handle we just initialized */
-            nvm_dma_unmap(*handle);
-            *handle = NULL;
-            return EIO;
+        /* Tag as HIP-origin for dual-backend async dispatch,
+         * regardless of fd retention. */
+        _nvm_dma_set_hip_origin(*handle);
+
+        if (!md->retain_fd)
+        {
+            /* Non-RDMA: kernel holds refcount, close userspace fd */
+            hsa_status_t close_status = hsa_amd_portable_close_dmabuf(dmabuf_fd);
+            if (close_status != HSA_STATUS_SUCCESS) {
+                dprintf("hsa_amd_portable_close_dmabuf() failed: %d\n", close_status);
+                /* Unmap and release the handle we just initialized */
+                nvm_dma_unmap(*handle);
+                *handle = NULL;
+                return EIO;
+            }
+            md->dmabuf_fd = -1;  /* cleared */
+            _nvm_dma_set_dmabuf_info(*handle, -1, 0, 0);
         }
+        else
+        {
+            /* RDMA: fd retained. Set map metadata with live fd.
+             * Use the original requested size, not the page-rounded
+             * mapping length, so RDMA MR registration does not
+             * authorize access beyond the caller's buffer. */
+            _nvm_dma_set_dmabuf_info(*handle,
+                dmabuf_fd, md->dmabuf_offset,
+                size);
+        }
+    }
+#endif
+
+#ifdef _CUDA
+    /* CUDA dmabuf: fd is always retained (RDMA-only path).
+     * Use original size for RDMA MR registration. */
+    if (md->type == MAP_TYPE_DMABUF_CUDA)
+    {
+        _nvm_dma_set_dmabuf_info(*handle,
+            dmabuf_fd, 0,
+            size);
     }
 #endif
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -1,5 +1,9 @@
 #include "ugds_internal.h"
-#if defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend: avoid both cuda_runtime.h and hip_runtime.h in this TU
+ * to prevent type conflicts. Functions are declared extern "C" below. */
+#define CUDART_CB
+#elif defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
 #include <hip/hip_runtime.h>
 #define CUDART_CB
 #define cudaLaunchHostFunc hipLaunchHostFunc
@@ -11,7 +15,17 @@ typedef hipStream_t cudaStream_t;
 #endif
 #include <mutex>
 
-static void CUDART_CB async_io_callback(void* userData)
+/* Forward declaration for dual-backend stream validation */
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+static uGDSError_t async_check_stream_backend(void* stream, const void* bufPtr_base);
+#endif
+
+/* Backend-neutral async IO.
+ * Public API accepts void* for stream -- callers pass cudaStream_t
+ * or hipStream_t, which implicitly convert. Internal dispatch
+ * selects the correct backend launch function at compile time. */
+
+static void async_io_callback(void* userData)
 {
     AsyncRequest* req = static_cast<AsyncRequest*>(userData);
     size_t size = *req->size_p;
@@ -21,13 +35,27 @@ static void CUDART_CB async_io_callback(void* userData)
     ssize_t ret = do_io_internal(req->fh, req->bufPtr_base, size,
                                   file_offset, bufPtr_offset, req->opcode);
     *req->bytes_done_p = ret;
+
+    /* Release the in-flight reference held by async_validate.
+     * do_io_internal manages its own reference for registered buffers,
+     * so this accounts for the enqueue-time increment only. */
+    {
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        auto it = g_driver.buf_registry.find(req->bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    /* Release handle reference so HandleDeregister can proceed. */
+    handle_release(static_cast<HandleState*>(req->fh));
+
     delete req;
 }
 
-static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
-                             size_t* size_p, off_t* file_offset_p,
-                             off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
-                             cudaStream_t stream, uint8_t opcode)
+static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
+                                   size_t* size_p, off_t* file_offset_p,
+                                   off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
+                                   std::shared_ptr<HandleState>* hs_sp_out)
 {
     if (!g_driver.initialized)
         return make_error(UGDS_DRIVER_NOT_INITIALIZED);
@@ -37,18 +65,115 @@ static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
         bufPtr_offset_p == nullptr || bytes_done_p == nullptr)
         return make_error(UGDS_INVALID_VALUE);
 
-    {
-        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
-        if (g_driver.buf_registry.find(bufPtr_base) == g_driver.buf_registry.end())
-            return make_error(UGDS_INVALID_VALUE);
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(bufPtr_base);
+    if (it == g_driver.buf_registry.end())
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Hold in-flight reference from enqueue until callback completes.
+     * This prevents uGDSBufDeregister from unmapping the buffer
+     * while the async request is queued but not yet executed. */
+    it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+
+    /* Also hold a handle reference so HandleDeregister cannot free
+     * the HandleState (QPs, controller) while the async callback
+     * is pending. Use handle_lookup_locked since we already hold
+     * g_driver.lock from the buffer registry lookup above. */
+    HandleState* hs = handle_lookup_locked(fh, hs_sp_out);
+    if (!hs) {
+        /* Roll back buffer in_flight ref on handle acquire failure */
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        return make_error(UGDS_INVALID_VALUE);
     }
 
-    AsyncRequest* req = new AsyncRequest{
-        fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-        bytes_done_p, opcode
-    };
+    return UGDS_OK;
+}
 
-    cudaError_t err = cudaLaunchHostFunc(stream, async_io_callback, req);
+static AsyncRequest* make_async_request(uGDSHandle_t fh, void* bufPtr_base,
+                                         size_t* size_p, off_t* file_offset_p,
+                                         off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
+                                         uint8_t opcode,
+                                         std::shared_ptr<HandleState> hs_sp)
+{
+    AsyncRequest* req = new (std::nothrow) AsyncRequest{
+        fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
+        bytes_done_p, opcode, std::move(hs_sp)
+    };
+    return req;
+}
+
+/* -- Backend-specific host function launch --
+ * Uses ugsd_stream_t (void*) internally. In dual-backend builds,
+ * dispatches based on the buffer's registered backend. */
+
+#if defined(__HIP_PLATFORM_AMD__) && !defined(_CUDA)
+/* HIP-only build */
+#include <hip/hip_runtime_api.h>
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)opcode;
+    hipError_t err = hipLaunchHostFunc((hipStream_t)stream,
+                                       async_io_callback, req);
+    if (err != hipSuccess) {
+        delete req;
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+}
+
+#elif defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend build: runtime dispatch based on buffer's backend.
+ * Cannot include both cuda_runtime.h and hip_runtime_api.h in the same
+ * TU due to vector type conflicts. Declare the runtime functions as
+ * extern "C" -- both libcudart and libamdhip64 export them.
+ *
+ * NOTE: On ROCm, hipLaunchHostFunc can map to hipLaunchHostFunc_spt
+ * when HIP_API_PER_THREAD_DEFAULT_STREAM is enabled. This declaration
+ * matches the default (non-SPT) ABI. For SPT support, build HIP-only. */
+
+/* Declare the runtime launch functions directly without their headers.
+ * Both accept (stream_ptr, callback, user_data) and return int-like. */
+extern "C" {
+int cudaLaunchHostFunc(void* stream, void (*callback)(void*), void* userData);
+int hipLaunchHostFunc(void* stream, void (*callback)(void*), void* userData);
+}
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode,
+                                           uGDSBackend_t backend)
+{
+    (void)opcode;
+    int err;
+    if (backend == UGDS_BACKEND_HIP) {
+        err = hipLaunchHostFunc(stream, async_io_callback, req);
+    } else {
+        err = cudaLaunchHostFunc(stream, async_io_callback, req);
+    }
+    if (err != 0) {
+        delete req;
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = err;
+        return e;
+    }
+    return UGDS_OK;
+}
+
+#elif defined(_CUDA) || defined(__CUDACC__)
+/* CUDA-only build */
+#include <cuda_runtime.h>
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)opcode;
+    cudaError_t err = cudaLaunchHostFunc((cudaStream_t)(uintptr_t)stream,
+                                         async_io_callback, req);
     if (err != cudaSuccess) {
         delete req;
         uGDSError_t e;
@@ -56,36 +181,248 @@ static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
         e.cu_err = static_cast<int>(err);
         return e;
     }
-
     return UGDS_OK;
 }
+
+#else
+/* No GPU backend: async IO not available */
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)stream; (void)opcode;
+    delete req;
+    return make_error(UGDS_IO_NOT_SUPPORTED);
+}
+#endif
+
+static void async_release_inflight(void* bufPtr_base,
+                                    std::shared_ptr<HandleState>* hs_sp)
+{
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(bufPtr_base);
+    if (it != g_driver.buf_registry.end())
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+
+    if (hs_sp && *hs_sp) {
+        handle_release(hs_sp->get());
+        hs_sp->reset();
+    }
+}
+
+/* -- Public async API (void* stream for dual-backend support) -- */
 
 extern "C" uGDSError_t uGDSReadAsync(uGDSHandle_t fh, void* bufPtr_base,
                                        size_t* size_p, off_t* file_offset_p,
                                        off_t* bufPtr_offset_p, ssize_t* bytes_read_p,
-                                       cudaStream_t stream)
+                                       void* stream)
 {
-    return do_async(fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-                    bytes_read_p, stream, NVM_IO_READ);
+    std::shared_ptr<HandleState> hs_sp;
+    uGDSError_t st = async_validate(fh, bufPtr_base, size_p, file_offset_p,
+                                     bufPtr_offset_p, bytes_read_p, &hs_sp);
+    if (st.err != UGDS_SUCCESS) return st;
+
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: check stream/buffer backend compatibility BEFORE
+     * allocating request to avoid leak on mismatch. */
+    {
+        uGDSError_t sbe = async_check_stream_backend(stream, bufPtr_base);
+        if (sbe.err != UGDS_SUCCESS) {
+            async_release_inflight(bufPtr_base, &hs_sp);
+            return sbe;
+        }
+    }
+#endif
+
+    /* Keep a copy of hs_sp so we can release on launch failure.
+     * The request also holds a copy. */
+    AsyncRequest* req = make_async_request(fh, bufPtr_base, size_p, file_offset_p,
+                                            bufPtr_offset_p, bytes_read_p, NVM_IO_READ,
+                                            hs_sp);
+    if (req == nullptr) {
+        async_release_inflight(bufPtr_base, &hs_sp);
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: look up buffer's registered backend */
+    uGDSBackend_t backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            backend = it->second.backend;
+    }
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_READ, backend);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#else
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_READ);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#endif
 }
 
 extern "C" uGDSError_t uGDSWriteAsync(uGDSHandle_t fh, void* bufPtr_base,
                                         size_t* size_p, off_t* file_offset_p,
                                         off_t* bufPtr_offset_p, ssize_t* bytes_written_p,
-                                        cudaStream_t stream)
+                                        void* stream)
 {
-    return do_async(fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-                    bytes_written_p, stream, NVM_IO_WRITE);
+    std::shared_ptr<HandleState> hs_sp;
+    uGDSError_t st = async_validate(fh, bufPtr_base, size_p, file_offset_p,
+                                     bufPtr_offset_p, bytes_written_p, &hs_sp);
+    if (st.err != UGDS_SUCCESS) return st;
+
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: check stream/buffer backend compatibility BEFORE
+     * allocating request to avoid leak on mismatch. */
+    {
+        uGDSError_t sbe = async_check_stream_backend(stream, bufPtr_base);
+        if (sbe.err != UGDS_SUCCESS) {
+            async_release_inflight(bufPtr_base, &hs_sp);
+            return sbe;
+        }
+    }
+#endif
+
+    AsyncRequest* req = make_async_request(fh, bufPtr_base, size_p, file_offset_p,
+                                            bufPtr_offset_p, bytes_written_p, NVM_IO_WRITE,
+                                            hs_sp);
+    if (req == nullptr) {
+        async_release_inflight(bufPtr_base, &hs_sp);
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: look up buffer's registered backend */
+    uGDSBackend_t backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            backend = it->second.backend;
+    }
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_WRITE, backend);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#else
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_WRITE);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#endif
 }
 
-extern "C" uGDSError_t uGDSStreamRegister(cudaStream_t stream)
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend: track stream->backend mapping for cross-backend detection.
+ * Users register streams via uGDSStreamRegisterEx with an explicit backend.
+ * Unregistered streams are treated as UGDS_BACKEND_DEFAULT (no check). */
+#include <unordered_map>
+
+static std::mutex                                   s_stream_map_lock;
+static std::unordered_map<void*, uGDSBackend_t>     s_stream_backends;
+
+extern "C" uGDSError_t uGDSStreamRegister(void* stream)
+{
+    /* In dual-backend mode, StreamRegister without a backend hint
+     * just records the stream as default. Use uGDSStreamRegisterEx
+     * to associate an explicit backend. */
+    if (stream != nullptr) {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        s_stream_backends[stream] = UGDS_BACKEND_DEFAULT;
+    }
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend)
+{
+    if (stream == nullptr)
+        return UGDS_OK;
+    if (backend != UGDS_BACKEND_CUDA && backend != UGDS_BACKEND_HIP)
+        return make_error(UGDS_INVALID_VALUE);
+    std::lock_guard<std::mutex> g(s_stream_map_lock);
+    s_stream_backends[stream] = backend;
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
+{
+    if (stream != nullptr) {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        s_stream_backends.erase(stream);
+    }
+    return UGDS_OK;
+}
+
+/* Validate that the stream's backend matches the buffer's backend.
+ * Returns UGDS_OK if compatible, error otherwise. */
+static uGDSError_t async_check_stream_backend(void* stream, const void* bufPtr_base)
+{
+    /* NULL stream means default stream -- always allowed */
+    if (stream == nullptr)
+        return UGDS_OK;
+
+    /* Look up buffer backend */
+    uGDSBackend_t buf_backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(const_cast<void*>(bufPtr_base));
+        if (it != g_driver.buf_registry.end())
+            buf_backend = it->second.backend;
+    }
+
+    /* Look up stream backend */
+    uGDSBackend_t stream_backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        auto it = s_stream_backends.find(stream);
+        if (it != s_stream_backends.end())
+            stream_backend = it->second;
+    }
+
+    /* If both are known (non-default), they must match */
+    if (buf_backend != UGDS_BACKEND_DEFAULT &&
+        stream_backend != UGDS_BACKEND_DEFAULT &&
+        buf_backend != stream_backend)
+        return make_error(UGDS_INVALID_VALUE);
+
+    return UGDS_OK;
+}
+#else
+/* Single-backend: stream/backend mismatch cannot occur at runtime,
+ * but validate the backend enum for API consistency. */
+#if defined(__HIP_PLATFORM_AMD__)
+#define UGDS_ACTIVE_BACKEND UGDS_BACKEND_HIP
+#else
+#define UGDS_ACTIVE_BACKEND UGDS_BACKEND_CUDA
+#endif
+
+extern "C" uGDSError_t uGDSStreamRegister(void* stream)
 {
     (void)stream;
     return UGDS_OK;
 }
 
-extern "C" uGDSError_t uGDSStreamDeregister(cudaStream_t stream)
+extern "C" uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend)
+{
+    (void)stream;
+    if (backend != UGDS_ACTIVE_BACKEND)
+        return make_error(UGDS_INVALID_VALUE);
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
 {
     (void)stream;
     return UGDS_OK;
 }
+#undef UGDS_ACTIVE_BACKEND
+#endif

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -6,6 +6,17 @@
 #include <algorithm>
 #include <atomic>
 #include <time.h>
+#include <cstdio>
+
+/* Release in-flight reference held by batch submit.
+ * Called on validation failure or when batch entry completes. */
+static void async_release_inflight_batch(void* devPtr_base)
+{
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(devPtr_base);
+    if (it != g_driver.buf_registry.end())
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
 
 static void cleanup_prp_pool(BatchState* bs)
 {
@@ -64,6 +75,8 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
         }
         entry.error_code = entry.bytes_done;
         bs->n_completed++;
+        /* Release in-flight reference when all sub-commands complete */
+        async_release_inflight_batch(entry.devPtr_base);
     }
 
     return true;
@@ -92,23 +105,34 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
         return make_error(UGDS_INVALID_VALUE);
 
-    HandleState* hs = static_cast<HandleState*>(fh);
+    /* Look up handle via global registry to safely acquire a shared_ptr.
+     * This prevents UAF if HandleDeregister races with us. */
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs)
+        return make_error(UGDS_INVALID_VALUE);
 
-    if (!hs->batch_qp)
+    if (!hs->batch_qp) {
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
+    }
 
     bool expected = false;
-    if (!hs->batch_active.compare_exchange_strong(expected, true))
+    if (!hs->batch_active.compare_exchange_strong(expected, true)) {
+        handle_release(hs);
         return make_error(UGDS_INVALID_VALUE);
+    }
 
     auto bs = new (std::nothrow) BatchState();
     if (!bs) {
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
 
     bs->capacity = nr;
     bs->hs = hs;
+    bs->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
     bs->entries.resize(nr);
     bs->cmd_map.resize(hs->batch_queue_depth);
 
@@ -119,6 +143,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
         delete bs;
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
     std::memset(pool.buf, 0, pool_bytes);
@@ -129,6 +154,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         pool.buf = nullptr;
         delete bs;
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
     pool.n_pages = UGDS_PRP_POOL_PAGES;
@@ -136,6 +162,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
     *batch = static_cast<uGDSBatchHandle_t>(bs);
+
     return UGDS_OK;
 }
 
@@ -147,6 +174,10 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
 
     BatchState* bs = static_cast<BatchState*>(batch);
     std::lock_guard<std::mutex> batch_lock(bs->lock);
+
+    if (bs->hs->wedged.load(std::memory_order_acquire) ||
+        bs->hs->closing.load(std::memory_order_acquire))
+        return make_error(UGDS_BUSY);
 
     if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
         bs->n_entries = 0;
@@ -195,8 +226,11 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.n_cmds_done = 0;
         entry.event_returned = false;
 
-        size_t n_cmds = (p.size + max_xfer - 1) / max_xfer;
-        if (n_cmds == 0) n_cmds = 1;
+        /* Overflow-safe ceil division for n_cmds */
+        size_t n_cmds = (p.size - 1) / max_xfer + 1;
+        if (n_cmds > UINT16_MAX) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
         entry.n_cmds = static_cast<uint16_t>(n_cmds);
     }
 
@@ -224,8 +258,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         {
             std::lock_guard<std::mutex> drv_lock(g_driver.lock);
             auto it = g_driver.buf_registry.find(entry.devPtr_base);
-            if (it != g_driver.buf_registry.end())
-                buf_dma = it->second;
+            if (it != g_driver.buf_registry.end()) {
+                buf_dma = it->second.dma;
+                /* Hold in-flight reference until batch completions are drained
+                 * or destroy finishes. Prevents Deregister from unmapping
+                 * while batch commands retain PRPs from this buffer. */
+                it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+            }
         }
 
         if (buf_dma == nullptr) {
@@ -243,18 +282,21 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            async_release_inflight_batch(entry.devPtr_base);
             continue;
         }
         buf_page_start = static_cast<size_t>(entry.devPtr_offset) / page_size;
 
-        size_t total_pages_needed = buf_page_start +
-            (entry.size + page_size - 1) / page_size;
-        if (total_pages_needed > buf_dma->n_ioaddrs) {
+        /* Overflow-safe bounds check */
+        size_t batch_pages_needed = (entry.size - 1) / page_size + 1;
+        if (batch_pages_needed > buf_dma->n_ioaddrs ||
+            buf_page_start > buf_dma->n_ioaddrs - batch_pages_needed) {
             entry.status = UGDS_BATCH_FAILED;
             entry.error_code = -EINVAL;
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            async_release_inflight_batch(entry.devPtr_base);
             continue;
         }
 
@@ -296,6 +338,20 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
                         if (!drain_one_completion(qp, bs)) {
                             if (++spins > max_spins) {
+                                /* Release in_flight refs only for entries
+                                 * that are still WAITING (ref acquired but
+                                 * not yet submitted). PENDING entries have
+                                 * commands in the SQ -- keep ref until drain.
+                                 * COMPLETE entries were already released by
+                                 * drain_one_completion. FAILED already done. */
+                                for (unsigned i = 0; i < nr; ++i) {
+                                    BatchIOEntry& e = bs->entries[base + i];
+                                    if (e.status == UGDS_BATCH_WAITING) {
+                                        async_release_inflight_batch(e.devPtr_base);
+                                        e.status = UGDS_BATCH_FAILED;
+                                        e.n_cmds = 0;
+                                    }
+                                }
                                 bs->n_entries += nr;
                                 return make_error(UGDS_INTERNAL_ERROR);
                             }
@@ -323,6 +379,15 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     } else if (++spins > max_spins) {
                         if (prp_idx != UINT16_MAX)
                             prp_pool_free(&bs->prp_pool, prp_idx);
+                        /* Release in_flight refs only for WAITING entries. */
+                        for (unsigned i = 0; i < nr; ++i) {
+                            BatchIOEntry& e = bs->entries[base + i];
+                            if (e.status == UGDS_BATCH_WAITING) {
+                                async_release_inflight_batch(e.devPtr_base);
+                                e.status = UGDS_BATCH_FAILED;
+                                e.n_cmds = 0;
+                            }
+                        }
                         bs->n_entries += nr;
                         return make_error(UGDS_INTERNAL_ERROR);
                     } else {
@@ -336,6 +401,15 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                 if (cmd == nullptr) {
                     if (prp_idx != UINT16_MAX)
                         prp_pool_free(&bs->prp_pool, prp_idx);
+                    /* Release in_flight refs only for WAITING entries. */
+                    for (unsigned i = 0; i < nr; ++i) {
+                        BatchIOEntry& e = bs->entries[base + i];
+                        if (e.status == UGDS_BATCH_WAITING) {
+                            async_release_inflight_batch(e.devPtr_base);
+                            e.status = UGDS_BATCH_FAILED;
+                            e.n_cmds = 0;
+                        }
+                    }
                     bs->n_entries += nr;
                     return make_error(UGDS_INTERNAL_ERROR);
                 }
@@ -478,7 +552,56 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
         }
     }
 
+    /* Best-effort: release in-flight references for entries that were
+     * submitted but never fully completed (e.g., submit phase-3 early
+     * return). Check n_cmds_done < n_cmds rather than status alone.
+     *
+     * IMPORTANT: do NOT release refs for entries that have commands
+     * still outstanding in the NVMe SQ (bs->in_flight > 0 after drain).
+     * Those commands may still DMA. Leaking the refs (blocking
+     * deregister) is strictly safer than freeing mappings while the
+     * device may still access them. The caller should reset the
+     * controller if truly stuck. */
+    if (bs->in_flight == 0) {
+        for (unsigned i = 0; i < bs->n_entries; ++i) {
+            BatchIOEntry& entry = bs->entries[i];
+            if (entry.n_cmds > 0 && entry.n_cmds_done < entry.n_cmds) {
+                async_release_inflight_batch(entry.devPtr_base);
+                entry.status = UGDS_BATCH_FAILED;
+            }
+        }
+    } else {
+        /* Commands still in flight after drain timeout.
+         * The NVMe device may still DMA through the PRP list and CQ,
+         * so we must NOT: free the PRP pool, release handle ref,
+         * delete the batch state, or clear batch_active.
+         *
+         * Keeping batch_active=true prevents a new BatchIOSetUp from
+         * reusing the same QP while old completions may still arrive.
+         * Keeping the handle ref prevents HandleDeregister from freeing
+         * the QP while DMA is in progress.
+         *
+         * This wedges the handle until the caller resets the controller.
+         * BatchIODestroy is void so the caller cannot detect this --
+         * the warning is the only signal. This is the safest option:
+         * a wedged handle is strictly better than DMA-after-unmap. */
+        fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
+                "flight after drain timeout -- handle is now wedged "
+                "to prevent DMA-after-unmap. Controller reset required.\n",
+                bs->in_flight);
+        hs->wedged.store(true, std::memory_order_release);
+        return;
+    }
+
     cleanup_prp_pool(bs);
+
+    /* Mark batch inactive before releasing handle ref.
+     * HandleDeregister waits on handle_in_flight==0, so we must not
+     * touch hs after release. */
     hs->batch_active.store(false);
+
+    /* Release handle reference acquired in BatchIOSetUp */
+    handle_release(hs);
+
     delete bs;
 }

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -1,4 +1,7 @@
 #include "ugds_internal.h"
+#include "internal/dma.h"
+#include <unistd.h>
+#include <fcntl.h>
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
     if (!g_driver.initialized) {
@@ -24,10 +27,14 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
                                        const_cast<void*>(bufPtr_base), length,
                                        flags);
     if (status != 0 || dma == nullptr) {
+        if (status == ENOTSUP || status == EOPNOTSUPP)
+            return make_error(UGDS_IO_NOT_SUPPORTED);
         return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
     }
 
-    g_driver.buf_registry[bufPtr_base] = dma;
+    g_driver.buf_registry[bufPtr_base].dma = dma;
+    g_driver.buf_registry[bufPtr_base].backend =
+        (flags & NVM_MAP_DMABUF) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
     return UGDS_OK;
 }
 
@@ -43,7 +50,13 @@ extern "C" uGDSError_t uGDSBufDeregister(const void* bufPtr_base) {
         return make_error(UGDS_MEMORY_NOT_REGISTERED);
     }
 
-    nvm_dma_unmap(it->second);
+    /* Reject deregister if IO is in-flight on this buffer.
+     * Caller must wait for outstanding operations to complete. */
+    if (it->second.in_flight.load(std::memory_order_acquire) > 0) {
+        return make_error(UGDS_BUSY);
+    }
+
+    nvm_dma_unmap(it->second.dma);
     g_driver.buf_registry.erase(it);
 
     return UGDS_OK;

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -34,8 +34,53 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
 
     g_driver.buf_registry[bufPtr_base].dma = dma;
     g_driver.buf_registry[bufPtr_base].backend =
-        (flags & NVM_MAP_DMABUF) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+        nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
     return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,
+                                          const uGDSBufConfig_t* config) {
+    if (!g_driver.initialized) {
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    }
+    if (bufPtr_base == nullptr || length == 0 || config == nullptr) {
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Build flags from config -- validate backend */
+    int flags = 0;
+    switch (config->backend) {
+    case UGDS_BACKEND_DEFAULT:
+        /* Export requires an explicit backend so the correct dma-buf
+         * path is selected. DEFAULT relies on auto-probe which does
+         * not retain an exportable fd. */
+        if (config->enable_export)
+            return make_error(UGDS_INVALID_VALUE);
+        break;
+    case UGDS_BACKEND_HIP:
+#ifndef _HIP
+        return make_error(UGDS_PLATFORM_NOT_SUPPORTED);
+#else
+        flags |= NVM_MAP_DMABUF;
+        if (config->enable_export)
+            flags |= NVM_MAP_RDMA;  /* retain dmabuf fd for export/RDMA */
+#endif
+        break;
+    case UGDS_BACKEND_CUDA:
+#ifndef _CUDA
+        return make_error(UGDS_PLATFORM_NOT_SUPPORTED);
+#else
+        flags |= NVM_MAP_FORCE_CUDA;  /* skip auto-probe in dual-backend */
+        if (config->enable_export)
+            flags |= NVM_MAP_RDMA;    /* enable dmabuf export/RDMA path */
+#endif
+        break;
+    default:
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    uGDSError_t st = uGDSBufRegister(bufPtr_base, length, flags);
+    return st;
 }
 
 extern "C" uGDSError_t uGDSBufDeregister(const void* bufPtr_base) {
@@ -56,8 +101,65 @@ extern "C" uGDSError_t uGDSBufDeregister(const void* bufPtr_base) {
         return make_error(UGDS_BUSY);
     }
 
+    /* Reject deregister if active RDMA MRs reference this buffer.
+     * Caller must uGDSRDMAUnregister all MRs first.
+     * DEREGISTERING state also blocks: ibv_dereg_mr may still be
+     * in progress on another thread, and buffer unmap could race. */
+    auto rdma_it = g_driver.rdma_records.find(bufPtr_base);
+    if (rdma_it != g_driver.rdma_records.end()) {
+        for (const auto& rec : rdma_it->second) {
+            if (rec.state == DriverState::RDMA_REC_ACTIVE ||
+                rec.state == DriverState::RDMA_REC_PENDING ||
+                rec.state == DriverState::RDMA_REC_DEREGISTERING)
+            {
+                return make_error(UGDS_RDMA_MR_STILL_ACTIVE);
+            }
+        }
+        /* All records are empty -- safe to clean up */
+        g_driver.rdma_records.erase(rdma_it);
+    }
+
     nvm_dma_unmap(it->second.dma);
     g_driver.buf_registry.erase(it);
 
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSExportDmabuf(const void* bufPtr_base,
+                                         uGDSDmabufExport_t* out) {
+    if (!g_driver.initialized) {
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    }
+    if (!out) {
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    std::lock_guard<std::mutex> guard(g_driver.lock);
+
+    auto it = g_driver.buf_registry.find(bufPtr_base);
+    if (it == g_driver.buf_registry.end()) {
+        return make_error(UGDS_MEMORY_NOT_REGISTERED);
+    }
+
+    /* Get internal dmabuf metadata */
+    int internal_fd = -1;
+    uint64_t offset = 0;
+    size_t length = 0;
+
+    if (nvm_dma_get_dmabuf_info(it->second.dma, &internal_fd, &offset, &length) != 0
+        || internal_fd < 0) {
+        return make_error(UGDS_IO_NOT_SUPPORTED);
+    }
+
+    /* Atomically dup with CLOEXEC to prevent fd leaking into child
+     * processes across fork/exec in multithreaded callers. */
+    int dup_fd = fcntl(internal_fd, F_DUPFD_CLOEXEC, 0);
+    if (dup_fd < 0) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+
+    out->fd     = dup_fd;
+    out->offset = offset;
+    out->length = length;
     return UGDS_OK;
 }

--- a/src/ugds_driver.cpp
+++ b/src/ugds_driver.cpp
@@ -16,10 +16,28 @@ extern "C" uGDSError_t uGDSDriverClose(void) {
     if (!g_driver.initialized) {
         return make_error(UGDS_DRIVER_NOT_INITIALIZED);
     }
+
+    /* Reject close if any buffer has outstanding IO.
+     * Caller must ensure all async/batch operations are complete
+     * and all buffers are deregistered before closing the driver. */
     for (auto& entry : g_driver.buf_registry) {
-        nvm_dma_unmap(entry.second);
+        if (entry.second.in_flight.load(std::memory_order_acquire) > 0) {
+            return make_error(UGDS_BUSY);
+        }
+    }
+
+    /* Reject close if any handle is still registered.
+     * Allowing close while handles exist would drop shared_ptrs without
+     * running HandleDeregister cleanup, leaking QPs/admin queues/controller. */
+    if (!g_driver.handle_registry.empty()) {
+        return make_error(UGDS_BUSY);
+    }
+
+    for (auto& entry : g_driver.buf_registry) {
+        nvm_dma_unmap(entry.second.dma);
     }
     g_driver.buf_registry.clear();
+    g_driver.handle_registry.clear();
     g_driver.default_ctrl = nullptr;
     g_driver.initialized = false;
     return UGDS_OK;

--- a/src/ugds_driver.cpp
+++ b/src/ugds_driver.cpp
@@ -33,11 +33,19 @@ extern "C" uGDSError_t uGDSDriverClose(void) {
         return make_error(UGDS_BUSY);
     }
 
+    /* Check ALL outstanding RDMA MRs before cleanup */
+    for (const auto& pair : g_driver.rdma_records) {
+        if (!pair.second.empty()) {
+            return make_error(UGDS_RDMA_MR_STILL_ACTIVE);
+        }
+    }
+
     for (auto& entry : g_driver.buf_registry) {
         nvm_dma_unmap(entry.second.dma);
     }
     g_driver.buf_registry.clear();
     g_driver.handle_registry.clear();
+    g_driver.rdma_records.clear();
     g_driver.default_ctrl = nullptr;
     g_driver.initialized = false;
     return UGDS_OK;

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -9,6 +9,7 @@
 #include <sys/ioctl.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <time.h>
 
 static void cleanup_qp(nvm_aq_ref aq_ref, IOQueuePair* qp, int dev_fd) {
     if (qp->sq_dma) {
@@ -55,7 +56,7 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     if (descr->type != UGDS_HANDLE_TYPE_OPAQUE_FD)
         return make_error(UGDS_INVALID_FILE_TYPE);
 
-    auto hs = std::make_unique<HandleState>();
+    auto hs = std::make_shared<HandleState>();
     hs->fd = descr->handle.fd;
     hs->ns_id = 1;
     hs->ctrl = nullptr;
@@ -330,21 +331,159 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     batch_done:;
     }
 
+    /* Register in global handle registry so handle_lookup() can find
+     * the shared_ptr. The raw pointer serves as the key and the public
+     * opaque handle.
+     *
+     * Re-check g_driver.initialized under lock: DriverClose may have
+     * run between the initial check (line 41) and here, after a long
+     * NVMe admin/setup sequence. */
+    HandleState* raw = hs.get();
     {
         std::lock_guard<std::mutex> g(g_driver.lock);
+        if (!g_driver.initialized)
+        {
+            /* Driver was closed during setup. Roll back all resources
+             * that were allocated above, including sync QPs and batch QP
+             * (same sequence as batch_fail). */
+            cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
+            for (auto& done : hs->qps)
+                cleanup_qp(hs->aq_ref, done.get(), hs->fd);
+            hs->qps.clear();
+            nvm_aq_destroy(hs->aq_ref);
+            nvm_dma_unmap(hs->aq_dma);
+            free(hs->aq_buf);
+            nvm_ctrl_free(hs->ctrl);
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+        try {
+            g_driver.handle_registry[raw] = hs;
+        } catch (const std::bad_alloc&) {
+            /* Registry insertion failed (out of memory). Roll back
+             * all NVMe resources allocated above. */
+            cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
+            for (auto& done : hs->qps)
+                cleanup_qp(hs->aq_ref, done.get(), hs->fd);
+            hs->qps.clear();
+            nvm_aq_destroy(hs->aq_ref);
+            nvm_dma_unmap(hs->aq_dma);
+            free(hs->aq_buf);
+            nvm_ctrl_free(hs->ctrl);
+            return make_error(UGDS_OUT_OF_MEMORY);
+        }
         if (g_driver.default_ctrl == nullptr)
             g_driver.default_ctrl = hs->ctrl;
     }
 
-    *fh = reinterpret_cast<uGDSHandle_t>(hs.release());
+    *fh = reinterpret_cast<uGDSHandle_t>(raw);
     return UGDS_OK;
 }
 
 extern "C" void uGDSHandleDeregister(uGDSHandle_t fh)
 {
-    if (fh == nullptr) return;
+    /* Legacy API: infinite wait. This void API cannot return an error
+     * to the caller.  If the handle is wedged (I/O timeout with commands
+     * still in flight), the underlying NVMe resources (QPs, DMA mappings)
+     * remain live and the caller must NOT close the device fd or free GPU
+     * memory until a successful DeregisterEx.  Use uGDSHandleDeregisterEx
+     * for a status-returning variant. */
+    uGDSError_t err = uGDSHandleDeregisterEx(fh, -1);
+    if (err.err != UGDS_SUCCESS) {
+        fprintf(stderr, "uGDS: HandleDeregister returned %d -- resources "
+                "still live, controller reset required\n", (int)err.err);
+    }
+}
 
-    HandleState* hs = reinterpret_cast<HandleState*>(fh);
+extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
+{
+    if (fh == nullptr) return UGDS_OK;
+
+    HandleState* raw = reinterpret_cast<HandleState*>(fh);
+
+    /* timeout_sec semantics:
+     *   > 0  -- wait up to N seconds, then return UGDS_BUSY
+     *   0    -- non-blocking, return UGDS_BUSY immediately if in-flight
+     *  -1    -- infinite wait (legacy behaviour)
+     *  <-1   -- force teardown: skip wedged/in-flight checks and free all
+     *           resources unconditionally (caller guarantees no NVMe
+     *           command is still executing, e.g. after controller reset) */
+    bool force = (timeout_sec < -1);
+
+    /* Set closing=true under g_driver.lock so new IO entrypoints are
+     * blocked via handle_lookup/handle_lookup_locked. Keep the handle
+     * in the registry during drain so DriverClose's UGDS_BUSY guard
+     * still sees it. Remove from registry only after all cleanup. */
+    std::shared_ptr<HandleState> hs_sp;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        auto it = g_driver.handle_registry.find(raw);
+        if (it == g_driver.handle_registry.end())
+            return UGDS_OK;  /* already deregistered or invalid */
+        /* Atomic single-owner claim: if closing was already true,
+         * another thread is draining. Report busy, not success. */
+        if (it->second->closing.exchange(true, std::memory_order_acq_rel))
+            return make_error(UGDS_BUSY);
+        hs_sp = it->second;  /* copy shared_ptr, keep in registry */
+    }
+
+    HandleState* hs = hs_sp.get();
+
+    /* Wait for outstanding operations with optional timeout. */
+    if (!force && hs->wedged.load(std::memory_order_acquire)) {
+        fprintf(stderr, "uGDS: HandleDeregisterEx: handle is wedged "
+                "(batch timeout with commands in flight). "
+                "Controller reset required.\n");
+        hs->closing.store(false, std::memory_order_release);
+        return make_error(UGDS_BUSY);
+    }
+    if (!force) {
+        struct timespec deadline = {};
+        if (timeout_sec > 0) {
+            clock_gettime(CLOCK_MONOTONIC, &deadline);
+            deadline.tv_sec += timeout_sec;
+        }
+        uint64_t warn_counter = 0;
+        while (hs->handle_in_flight.load(std::memory_order_acquire) > 0) {
+            if (hs->wedged.load(std::memory_order_acquire)) {
+                fprintf(stderr, "uGDS: HandleDeregisterEx: handle became "
+                        "wedged during drain (batch/sync timeout with "
+                        "commands in flight). Controller reset required.\n");
+                hs->closing.store(false, std::memory_order_release);
+                return make_error(UGDS_BUSY);
+            }
+            if (timeout_sec == 0) {
+                hs->closing.store(false, std::memory_order_release);
+                return make_error(UGDS_BUSY);
+            }
+            if (timeout_sec > 0) {
+                struct timespec now;
+                clock_gettime(CLOCK_MONOTONIC, &now);
+                if (now.tv_sec > deadline.tv_sec ||
+                    (now.tv_sec == deadline.tv_sec &&
+                     now.tv_nsec >= deadline.tv_nsec)) {
+                    fprintf(stderr, "uGDS: HandleDeregisterEx: timed out "
+                            "waiting for %u in-flight operations\n",
+                            hs->handle_in_flight.load());
+                    hs->closing.store(false, std::memory_order_release);
+                    return make_error(UGDS_BUSY);
+                }
+            }
+            if ((++warn_counter % 100000000ULL) == 0) {
+                fprintf(stderr, "uGDS: HandleDeregister waiting for %u "
+                        "in-flight operations\n",
+                        hs->handle_in_flight.load());
+            }
+            __builtin_ia32_pause();
+        }
+        /* Re-check wedged before cleanup: concurrent timeout may
+         * have set it after the last in-flight reference dropped. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            fprintf(stderr, "uGDS: HandleDeregisterEx: handle became wedged "
+                    "during drain. Controller reset required.\n");
+            hs->closing.store(false, std::memory_order_release);
+            return make_error(UGDS_BUSY);
+        }
+    }
 
     if (hs->batch_qp)
         cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
@@ -365,5 +504,16 @@ extern "C" void uGDSHandleDeregister(uGDSHandle_t fh)
     free(hs->aq_buf);
     if (hs->ctrl) nvm_ctrl_free(hs->ctrl);
 
-    delete hs;
+    /* Now that all resources are freed, remove from the registry.
+     * This must happen after cleanup so DriverClose's UGDS_BUSY guard
+     * keeps the handle visible during the entire drain+cleanup window. */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        g_driver.handle_registry.erase(raw);
+    }
+
+    /* hs_sp (the last local shared_ptr) drops here. The registry entry
+     * was the other copy; since we just erased it, this drop frees
+     * HandleState. */
+    return UGDS_OK;
 }

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -102,6 +102,27 @@ struct DriverState {
         std::atomic<uint32_t> in_flight{0};
     };
     std::unordered_map<const void*, BufEntry>     buf_registry;
+
+    /* RDMA MR tracking */
+    typedef enum {
+        RDMA_REC_PENDING       = 0,   /* in-flight registration */
+        RDMA_REC_ACTIVE        = 1,   /* MR registered, in use */
+        RDMA_REC_DEREGISTERING = 2,   /* dereg in progress */
+    } RDMARecordState;
+
+    struct RDMARecord {
+        const void*         bufPtr;
+        void*               mr;         /* ibv_mr*, NULL while pending */
+        int                 dup_fd;     /* -1 while pending */
+        uint64_t            iova;
+        uint64_t            offset;
+        size_t              length;
+        RDMARecordState     state;
+        uint64_t            token;      /* unique per registration */
+    };
+
+    std::unordered_map<const void*, std::vector<RDMARecord>>  rdma_records;
+    std::atomic<uint64_t>                                      rdma_token_counter{0};
 };
 
 extern DriverState g_driver;

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -33,7 +33,7 @@
  * reports MDTS = 0 (no limit). Keeps one transfer within a single PRP list. */
 #define UGDS_DEFAULT_MAX_TRANSFER_SIZE (128UL * 1024)
 
-/* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec §4.6.1. */
+/* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec section 4.6.1. */
 #define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 
 struct IOQueuePair {
@@ -77,16 +77,77 @@ struct HandleState {
     uint16_t                    batch_queue_depth;
     std::atomic<bool>           batch_active{false};
     bool                        interrupt_mode = false;  /* UGDS_INTERRUPT_MODE */
+    std::atomic<bool>           wedged{false};          /* batch timeout: handle poisoned, controller reset required */
+    std::atomic<uint32_t>       handle_in_flight{0};  /* IO refcount for safe deregister */
+    std::atomic<bool>           closing{false};        /* set by Deregister to block new ops */
 };
 
 struct DriverState {
-    bool                                          initialized = false;
+    std::atomic<bool>                              initialized{false};
     std::mutex                                    lock;
     nvm_ctrl_t*                                   default_ctrl = nullptr;
-    std::unordered_map<const void*, nvm_dma_t*>   buf_registry;
+
+    /* Handle registry: maps raw pointer -> shared_ptr to keep handles alive.
+     * handle_lookup acquires under g_driver.lock so Deregister cannot
+     * destroy the HandleState while an IO entrypoint is dereferencing it. */
+    std::unordered_map<HandleState*,
+                       std::shared_ptr<HandleState>>  handle_registry;
+
+    /* Buffer registry with backend tracking for dual-backend dispatch.
+     * in_flight counts active IO references to prevent use-after-free
+     * during concurrent Deregister. */
+    struct BufEntry {
+        nvm_dma_t*           dma;
+        uGDSBackend_t        backend;
+        std::atomic<uint32_t> in_flight{0};
+    };
+    std::unordered_map<const void*, BufEntry>     buf_registry;
 };
 
 extern DriverState g_driver;
+
+/* Look up a handle in the global registry and acquire a reference.
+ * Returns the raw HandleState* on success (and stores a shared_ptr copy
+ * in *out_sp to keep the handle alive). Returns nullptr if the handle
+ * is invalid or being deregistered.
+ *
+ * The caller MUST keep *out_sp alive for the duration of the operation
+ * and call handle_release() when done. */
+static inline HandleState* handle_lookup(uGDSHandle_t fh,
+                                          std::shared_ptr<HandleState>* out_sp) {
+    std::lock_guard<std::mutex> g(g_driver.lock);
+    auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+    if (it == g_driver.handle_registry.end())
+        return nullptr;
+    if (it->second->closing.load(std::memory_order_acquire))
+        return nullptr;
+    if (it->second->wedged.load(std::memory_order_acquire))
+        return nullptr;
+    *out_sp = it->second;
+    it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+    return it->second.get();
+}
+
+/* Same as handle_lookup but assumes the caller already holds g_driver.lock.
+ * Use to avoid deadlock when called from a context that already holds
+ * the driver mutex (e.g. async_validate). */
+static inline HandleState* handle_lookup_locked(uGDSHandle_t fh,
+                                                  std::shared_ptr<HandleState>* out_sp) {
+    auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+    if (it == g_driver.handle_registry.end())
+        return nullptr;
+    if (it->second->closing.load(std::memory_order_acquire))
+        return nullptr;
+    if (it->second->wedged.load(std::memory_order_acquire))
+        return nullptr;
+    *out_sp = it->second;
+    it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+    return it->second.get();
+}
+
+static inline void handle_release(HandleState* hs) {
+    hs->handle_in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
 
 struct PRPPool {
     nvm_dma_t*  dma       = nullptr;
@@ -130,6 +191,7 @@ struct BatchState {
     PRPPool                   prp_pool;
 
     HandleState* hs = nullptr;
+    std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive for batch lifetime */
     std::mutex   lock;
 };
 
@@ -153,7 +215,11 @@ struct AsyncRequest {
     off_t*          bufPtr_offset_p;
     ssize_t*        bytes_done_p;
     uint8_t         opcode;
+    std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
 };
+
+/* Internal stream type -- void* for backend neutrality */
+typedef void* ugsd_stream_t;
 
 void* hugepage_alloc(size_t size, size_t* alloc_size_out);
 void  hugepage_free(void* ptr, size_t alloc_size);

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -1,6 +1,7 @@
 #include "ugds_internal.h"
 
 #include <cstring>
+#include <cstdio>
 #include <cerrno>
 #include <atomic>
 #include <algorithm>
@@ -112,17 +113,30 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         std::lock_guard<std::mutex> drv_lock(g_driver.lock);
         auto it = g_driver.buf_registry.find(bufPtr_base);
         if (it != g_driver.buf_registry.end()) {
-            buf_dma = it->second;
+            buf_dma = it->second.dma;
+            it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
         }
     }
 
     if (buf_dma != nullptr) {
         if ((static_cast<size_t>(bufPtr_offset) % page_size) != 0) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(bufPtr_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
             return -EINVAL;
         }
         buf_page_start = static_cast<size_t>(bufPtr_offset) / page_size;
-        size_t total_pages_needed = buf_page_start + (size + page_size - 1) / page_size;
-        if (total_pages_needed > buf_dma->n_ioaddrs) {
+        /* Overflow-safe bounds check: compute pages_needed separately,
+         * then verify buf_page_start + pages_needed <= n_ioaddrs
+         * without risking wrap. */
+        size_t pages_needed = (size - 1) / page_size + 1;
+        if (pages_needed > buf_dma->n_ioaddrs ||
+            buf_page_start > buf_dma->n_ioaddrs - pages_needed) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(bufPtr_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
             return -EINVAL;
         }
     } else {
@@ -161,12 +175,20 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     IOQueuePair& qp = *hs->qps[qp_idx];
 
     ssize_t result = 0;
+    bool timed_out = false;
     size_t bytes_done = 0;
     uint64_t current_lba = start_lba;
     size_t current_page = buf_page_start;
 
     {
         std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        /* Re-check wedged after acquiring QP lock: a previous
+         * operation may have timed out while we waited. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            result = -EBADF;
+            goto out;
+        }
 
         while (bytes_done < size) {
             size_t remaining = size - bytes_done;
@@ -230,6 +252,10 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             nvm_cpl_t* cpl = wait_for_completion(hs, qp);
             if (cpl == nullptr) {
                 result = -EIO;
+                timed_out = true;
+                /* Mark wedged while still holding qp.lock to prevent
+                 * QP reuse before the flag is visible. */
+                hs->wedged.store(true, std::memory_order_release);
                 goto out;
             }
 
@@ -253,8 +279,20 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     out:;
     }
 
-    if (on_the_fly && buf_dma != nullptr) {
+    if (timed_out) {
+        /* NVMe command may still be executing. wedged was set
+         * under qp.lock. Retain all resources. */
+        fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
+                "Controller reset required.\n");
+        /* Do NOT unmap on-the-fly buffer or release in-flight ref. */
+    } else if (on_the_fly && buf_dma != nullptr) {
         nvm_dma_unmap(buf_dma);
+    } else if (buf_dma != nullptr) {
+        /* Registered buffer: release in-flight reference. */
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     return result;
@@ -263,12 +301,24 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 extern "C" ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                               off_t file_offset, off_t bufPtr_offset)
 {
-    return do_io_internal(fh, bufPtr_base, size, file_offset, bufPtr_offset, NVM_IO_READ);
+    if (fh == nullptr) return -EINVAL;
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs) return -EBADF;
+    ssize_t ret = do_io_internal(fh, bufPtr_base, size, file_offset, bufPtr_offset, NVM_IO_READ);
+    handle_release(hs);
+    return ret;
 }
 
 extern "C" ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                                off_t file_offset, off_t bufPtr_offset)
 {
-    return do_io_internal(fh, const_cast<void*>(bufPtr_base), size, file_offset, bufPtr_offset,
+    if (fh == nullptr) return -EINVAL;
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs) return -EBADF;
+    ssize_t ret = do_io_internal(fh, const_cast<void*>(bufPtr_base), size, file_offset, bufPtr_offset,
                  NVM_IO_WRITE);
+    handle_release(hs);
+    return ret;
 }

--- a/src/ugds_rdma.cpp
+++ b/src/ugds_rdma.cpp
@@ -1,0 +1,228 @@
+#include "ugds_internal.h"
+
+#ifdef _RDMA
+#include <infiniband/verbs.h>
+#include <unistd.h>
+#include <errno.h>
+#include <algorithm>
+
+extern "C" uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
+                              void* pd,
+                              int access_flags,
+                              uGDSRDMARegion_t* region)
+{
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (!bufPtr_base || !pd || !region)
+        return make_error(UGDS_INVALID_VALUE);
+
+    struct ibv_pd* ibv_pd = static_cast<struct ibv_pd*>(pd);
+
+    /* Use a local temp for output -- only overwrite region on success */
+    uGDSRDMARegion_t result = {};
+
+    /* Generate unique token + insert PENDING under lock */
+    uint64_t my_token = g_driver.rdma_token_counter.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+
+        // Verify buffer is registered
+        if (g_driver.buf_registry.find(bufPtr_base) == g_driver.buf_registry.end())
+            return make_error(UGDS_MEMORY_NOT_REGISTERED);
+
+        DriverState::RDMARecord pending = {
+            bufPtr_base, NULL, -1, 0, 0, 0,
+            DriverState::RDMA_REC_PENDING, my_token
+        };
+        g_driver.rdma_records[bufPtr_base].push_back(pending);
+    }
+
+    /* Export dmabuf (outside lock) */
+    uGDSDmabufExport_t exp;
+    uGDSError_t st = uGDSExportDmabuf(bufPtr_base, &exp);
+    if (st.err != UGDS_SUCCESS) goto rollback_pending;
+
+    /* Register MR (outside lock) */
+    {
+        struct ibv_mr* mr = ibv_reg_dmabuf_mr(ibv_pd, exp.offset, exp.length,
+            (uint64_t)bufPtr_base, exp.fd, access_flags);
+        if (!mr) {
+            /* Save errno before any cleanup */
+            int mr_errno = errno;
+            close(exp.fd);
+            /* Map errno to meaningful uGDS errors */
+            if (mr_errno == EOPNOTSUPP || mr_errno == ENOTSUP)
+                st = make_error(UGDS_IO_NOT_SUPPORTED);
+            else
+                st = make_error(UGDS_INTERNAL_ERROR);
+            goto rollback_pending;
+        }
+
+        /* Complete MY pending record */
+        {
+            std::lock_guard<std::mutex> guard(g_driver.lock);
+            auto map_it = g_driver.rdma_records.find(bufPtr_base);
+
+            // Fail-closed: record vanished during registration
+            if (map_it == g_driver.rdma_records.end()) {
+                ibv_dereg_mr(mr);
+                close(exp.fd);
+                return make_error(UGDS_INTERNAL_ERROR);
+            }
+
+            auto& vec = map_it->second;
+            bool found = false;
+            for (auto& r : vec) {
+                if (r.token == my_token && r.state == DriverState::RDMA_REC_PENDING) {
+                    r.mr     = mr;
+                    r.dup_fd = exp.fd;
+                    r.iova   = 0;
+                    r.offset = exp.offset;
+                    r.length = exp.length;
+                    r.state  = DriverState::RDMA_REC_ACTIVE;
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                // Fail-closed: our record vanished, clean up and
+                // erase any stale token to avoid blocking deregister
+                ibv_dereg_mr(mr);
+                close(exp.fd);
+                vec.erase(std::remove_if(vec.begin(), vec.end(),
+                    [my_token](const DriverState::RDMARecord& r) {
+                        return r.token == my_token;
+                    }), vec.end());
+                return make_error(UGDS_INTERNAL_ERROR);
+            }
+        }
+
+        result.mr   = mr;
+        result.lkey = mr->lkey;
+        result.rkey = mr->rkey;
+        result.iova = (uint64_t)bufPtr_base;
+        result.token = my_token;
+    }
+    /* Only overwrite caller's region on success */
+    *region = result;
+    return UGDS_OK;
+
+rollback_pending:
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto map_it = g_driver.rdma_records.find(bufPtr_base);
+        if (map_it != g_driver.rdma_records.end()) {
+            auto& vec = map_it->second;
+            vec.erase(std::remove_if(vec.begin(), vec.end(),
+                [my_token](const DriverState::RDMARecord& r) {
+                    return r.token == my_token;
+                }), vec.end());
+        }
+    }
+    return (st.err != UGDS_SUCCESS) ? st : make_error(UGDS_INTERNAL_ERROR);
+}
+
+extern "C" uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
+                                uGDSRDMARegion_t* region)
+{
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (!bufPtr_base || !region || !region->mr)
+        return make_error(UGDS_INVALID_VALUE);
+
+    struct ibv_mr* target_mr = (struct ibv_mr*)region->mr;
+    uint64_t region_token = region->token;
+    int saved_dup_fd = -1;
+
+    /* Find + claim under lock */
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+
+        auto map_it = g_driver.rdma_records.find(bufPtr_base);
+        if (map_it == g_driver.rdma_records.end())
+            return make_error(UGDS_MEMORY_NOT_REGISTERED);
+
+        auto& vec = map_it->second;
+        auto rec_it = std::find_if(vec.begin(), vec.end(),
+            [&](const DriverState::RDMARecord& r) {
+                return r.mr == target_mr && r.token == region_token;
+            });
+
+        if (rec_it == vec.end())
+            return make_error(UGDS_HANDLE_NOT_REGISTERED);
+
+        // Check state
+        if (rec_it->state == DriverState::RDMA_REC_DEREGISTERING)
+            return make_error(UGDS_BUSY);
+        if (rec_it->state == DriverState::RDMA_REC_PENDING)
+            return make_error(UGDS_BUSY);
+
+        // Mark DEREGISTERING
+        rec_it->state = DriverState::RDMA_REC_DEREGISTERING;
+        saved_dup_fd = rec_it->dup_fd;
+    }
+
+    /* ibv_dereg_mr outside lock */
+    int result = ibv_dereg_mr(target_mr);
+
+    if (result != 0) {
+        // Failure: restore ACTIVE
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto map_it = g_driver.rdma_records.find(bufPtr_base);
+        if (map_it != g_driver.rdma_records.end()) {
+            for (auto& r : map_it->second) {
+                if (r.mr == target_mr && r.token == region_token &&
+                    r.state == DriverState::RDMA_REC_DEREGISTERING) {
+                    r.state = DriverState::RDMA_REC_ACTIVE;
+                    break;
+                }
+            }
+        }
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+
+    /* Remove record + close fd */
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto map_it = g_driver.rdma_records.find(bufPtr_base);
+        if (map_it != g_driver.rdma_records.end()) {
+            auto& vec = map_it->second;
+            vec.erase(std::remove_if(vec.begin(), vec.end(),
+                [&](const DriverState::RDMARecord& r) {
+                    return r.mr == target_mr && r.token == region_token &&
+                           r.state == DriverState::RDMA_REC_DEREGISTERING;
+                }), vec.end());
+        }
+    }
+
+    if (saved_dup_fd >= 0)
+        close(saved_dup_fd);
+
+    region->mr   = NULL;
+    region->lkey = 0;
+    region->rkey = 0;
+    region->iova = 0;
+    region->token = 0;
+    return UGDS_OK;
+}
+
+#else /* !_RDMA -- stubs for non-RDMA builds */
+
+extern "C" uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
+                              void* pd,
+                              int access_flags,
+                              uGDSRDMARegion_t* region)
+{
+    (void)bufPtr_base; (void)pd; (void)access_flags; (void)region;
+    return make_error(UGDS_IO_NOT_SUPPORTED);
+}
+
+extern "C" uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
+                                uGDSRDMARegion_t* region)
+{
+    (void)bufPtr_base; (void)region;
+    return make_error(UGDS_IO_NOT_SUPPORTED);
+}
+
+#endif /* _RDMA */

--- a/test/functional/test_async_basic.cu
+++ b/test/functional/test_async_basic.cu
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_async_errors.cu
+++ b/test/functional/test_async_errors.cu
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     {
         void* d_buf;
         cudaMalloc(&d_buf, 65536);
-        ASSERT_OK(uGDSBufRegister(d_buf, 65536, 0), "BufRegister");
+        ASSERT_OK(uGDSBufRegister(d_buf, 65536, TEST_BUF_FLAGS), "BufRegister");
 
         ssize_t bytes = 0;
         uGDSError_t st = uGDSReadAsync(fh, d_buf, &size, &file_off, &buf_off,

--- a/test/functional/test_async_late_binding.cu
+++ b/test/functional/test_async_late_binding.cu
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_async_multi_stream.cu
+++ b/test/functional/test_async_multi_stream.cu
@@ -17,7 +17,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t streams[N_STREAMS];
     for (int i = 0; i < N_STREAMS; i++)

--- a/test/functional/test_async_stream_order.cu
+++ b/test/functional/test_async_stream_order.cu
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_batch_basic.cu
+++ b/test/functional/test_batch_basic.cu
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Step 1: sync-write a known pattern to offset 0

--- a/test/functional/test_batch_deep.cu
+++ b/test/functional/test_batch_deep.cu
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, total);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, total, 0);
+    st = uGDSBufRegister(d_buf, total, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Sync-write 128 distinct patterns

--- a/test/functional/test_batch_mixed_ops.cu
+++ b/test/functional/test_batch_mixed_ops.cu
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     uGDSBatchHandle_t batch = nullptr;

--- a/test/functional/test_batch_mixed_sizes.cu
+++ b/test/functional/test_batch_mixed_sizes.cu
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, total);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, total, 0);
+    st = uGDSBufRegister(d_buf, total, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Step 1: sync-write each region with a distinct pattern

--- a/test/functional/test_batch_reuse.cu
+++ b/test/functional/test_batch_reuse.cu
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     uGDSBatchHandle_t batch = nullptr;

--- a/test/functional/test_dmabuf_export.cu
+++ b/test/functional/test_dmabuf_export.cu
@@ -1,0 +1,166 @@
+#include "test_utils.h"
+#include <sys/stat.h>
+#include <errno.h>
+#include <dirent.h>
+
+/* Test: dmabuf export lifecycle
+ *
+ * Verifies:
+ * - uGDSBufRegisterEx produces a valid dmabuf export
+ * - uGDSExportDmabuf returns a dup'd fd (different from internal)
+ * - Export fd is valid (can be used for ioctl)
+ * - NVMe I/O still works after export
+ * - Deregister after export close succeeds
+ * - Export on non-dmabuf buffer returns UGDS_IO_NOT_SUPPORTED
+ * - Export on unregistered buffer returns UGDS_MEMORY_NOT_REGISTERED
+ */
+int main(int argc, char** argv) {
+    if (!parse_args(argc, argv)) return 1;
+    cudaSetDevice(g_gpu_id);
+
+    uGDSError_t st = uGDSDriverOpen();
+    ASSERT_OK(st, "DriverOpen");
+
+    uGDSHandle_t fh = open_handle();
+    if (!fh) TEST_FAIL("open_handle failed");
+
+    const size_t buf_size = 65536;
+    void* d_buf = nullptr;
+    cudaMalloc(&d_buf, buf_size);
+    if (!d_buf) TEST_FAIL("cudaMalloc failed");
+
+    /* -- 1. Register with dmabuf backend -- */
+    uGDSBufConfig_t cfg = {};
+    cfg.backend =
+#ifdef __HIP_PLATFORM_AMD__
+        UGDS_BACKEND_HIP;
+#else
+        UGDS_BACKEND_CUDA;
+#endif
+    cfg.enable_export = true;  /* request dma-buf fd for export test */
+
+    st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+    if (st.err != UGDS_SUCCESS) {
+        /* Runtime may return NOT_SUPPORTED even when the API exists at
+         * compile time (e.g., GPU driver lacks dmabuf support). */
+        if (st.err == UGDS_IO_NOT_SUPPORTED ||
+            st.err == UGDS_PLATFORM_NOT_SUPPORTED) {
+            printf("SKIP: dma-buf export not supported on this device\n");
+            cudaFree(d_buf);
+            close_handle(fh);
+            uGDSDriverClose();
+            return 77;  /* skip exit code (automake convention) */
+        }
+        TEST_FAIL("BufRegisterEx: %s", UGDS_ERRSTR(st.err));
+    }
+
+    /* -- 2. Export dmabuf handle -- */
+    uGDSDmabufExport_t exp = {};
+    st = uGDSExportDmabuf(d_buf, &exp);
+    ASSERT_OK(st, "ExportDmabuf");
+
+    if (exp.fd < 0)
+        TEST_FAIL("export fd < 0");
+    if (exp.length != buf_size)
+        TEST_FAIL("export length mismatch: %zu != %zu", exp.length, buf_size);
+#ifdef __HIP_PLATFORM_AMD__
+    /* HIP may have non-zero offset */
+    if (exp.offset % getpagesize() != 0)
+        TEST_FAIL("HIP offset not page-aligned: %lu", exp.offset);
+#else
+    /* CUDA offset should be 0 */
+    if (exp.offset != 0)
+        TEST_FAIL("CUDA offset != 0: %lu", exp.offset);
+#endif
+
+    /* -- 3. Verify fd is usable (basic fstat) -- */
+    struct stat fd_stat;
+    if (fstat(exp.fd, &fd_stat) != 0)
+        TEST_FAIL("fstat on export fd failed: %s", strerror(errno));
+
+    /* -- 4. NVMe I/O still works after export -- */
+    /* Write pattern to GPU buffer */
+    cudaMemset(d_buf, 0xAB, buf_size);
+    cudaDeviceSynchronize();
+
+    ssize_t wr = uGDSWrite(fh, d_buf, 4096, 0, 0);
+    if (wr != 4096)
+        TEST_FAIL("uGDSWrite after export: %zd", wr);
+
+    /* Read back to verify */
+    cudaMemset(d_buf, 0x00, buf_size);
+    cudaDeviceSynchronize();
+
+    ssize_t rd = uGDSRead(fh, d_buf, 4096, 0, 0);
+    if (rd != 4096)
+        TEST_FAIL("uGDSRead after export: %zd", rd);
+
+    /* -- 5. Close export fd, then deregister -- */
+    close(exp.fd);
+
+    st = uGDSBufDeregister(d_buf);
+    ASSERT_OK(st, "BufDeregister after export close");
+
+    /* -- 6. Export on non-dmabuf buffer -> IO_NOT_SUPPORTED --
+     * On CUDA builds, TEST_BUF_FLAGS=0 so the buffer is mapped via
+     * the standard CUDA P2P path (no dmabuf fd retained).
+     * On HIP builds, TEST_BUF_FLAGS=UGDS_REGISTER_DMABUF but the fd
+     * is not retained (no NVM_MAP_RDMA), so export still fails. */
+    void* d_buf2 = nullptr;
+    cudaMalloc(&d_buf2, buf_size);
+    if (!d_buf2) TEST_FAIL("cudaMalloc(2) failed");
+
+    st = uGDSBufRegister(d_buf2, buf_size, TEST_BUF_FLAGS);
+    ASSERT_OK(st, "BufRegister (non-dmabuf)");
+
+    uGDSDmabufExport_t exp2 = {};
+    st = uGDSExportDmabuf(d_buf2, &exp2);
+    ASSERT_ERR(st, UGDS_IO_NOT_SUPPORTED, "export on non-dmabuf buffer");
+
+    st = uGDSBufDeregister(d_buf2);
+    ASSERT_OK(st, "BufDeregister (non-dmabuf)");
+
+    /* -- 7. Export on unregistered buffer -- */
+    uGDSDmabufExport_t exp3 = {};
+    st = uGDSExportDmabuf(d_buf2, &exp3);
+    ASSERT_ERR(st, UGDS_MEMORY_NOT_REGISTERED, "export on unregistered buffer");
+
+    /* -- 8. fd leak check: count /proc/self/fd before/after -- */
+    auto count_fds = []() -> int {
+        DIR* d = opendir("/proc/self/fd");
+        if (!d) return -1;
+        int count = 0;
+        struct dirent* ent;
+        while ((ent = readdir(d)) != nullptr) {
+            if (ent->d_name[0] != '.') count++;
+        }
+        closedir(d);
+        return count;
+    };
+
+    int fd_before = count_fds();
+    for (int i = 0; i < 10; i++) {
+        st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+        ASSERT_OK(st, "BufRegisterEx loop");
+
+        uGDSDmabufExport_t exp_l = {};
+        st = uGDSExportDmabuf(d_buf, &exp_l);
+        ASSERT_OK(st, "ExportDmabuf loop");
+
+        close(exp_l.fd);
+        st = uGDSBufDeregister(d_buf);
+        ASSERT_OK(st, "BufDeregister loop");
+    }
+
+    int fd_after = count_fds();
+    /* Allow runtime libraries to hold internal fds, but flag large leaks */
+    if (fd_before > 0 && fd_after > fd_before + 2)
+        TEST_FAIL("fd leak: before=%d after=%d", fd_before, fd_after);
+
+    cudaFree(d_buf);
+    cudaFree(d_buf2);
+    close_handle(fh);
+    uGDSDriverClose();
+
+    TEST_PASS();
+}

--- a/test/functional/test_rdma_export.cu
+++ b/test/functional/test_rdma_export.cu
@@ -1,0 +1,160 @@
+#include "test_utils.h"
+#include <sys/stat.h>
+#include <errno.h>
+#include <dirent.h>
+
+/* Test: RDMA dmabuf export lifecycle
+ *
+ * Verifies:
+ * - uGDSBufRegisterEx with enable_export produces a valid dmabuf export
+ * - uGDSExportDmabuf returns a dup'd fd (different from internal)
+ * - Export fd is valid (can be used for ioctl)
+ * - NVMe I/O still works after export
+ * - Deregister after export close succeeds
+ * - Export on non-RDMA buffer returns UGDS_IO_NOT_SUPPORTED
+ * - Export on unregistered buffer returns UGDS_MEMORY_NOT_REGISTERED
+ */
+int main(int argc, char** argv) {
+    if (!parse_args(argc, argv)) return 1;
+    cudaSetDevice(g_gpu_id);
+
+    uGDSError_t st = uGDSDriverOpen();
+    ASSERT_OK(st, "DriverOpen");
+
+    uGDSHandle_t fh = open_handle();
+    if (!fh) TEST_FAIL("open_handle failed");
+
+    const size_t buf_size = 65536;
+    void* d_buf = nullptr;
+    cudaMalloc(&d_buf, buf_size);
+    if (!d_buf) TEST_FAIL("cudaMalloc failed");
+
+    /* -- 1. Register with RDMA enabled -- */
+    uGDSBufConfig_t cfg = {};
+    cfg.backend =
+#ifdef __HIP_PLATFORM_AMD__
+        UGDS_BACKEND_HIP;
+#else
+        UGDS_BACKEND_CUDA;
+#endif
+    cfg.enable_export = true;
+
+    st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+    if (st.err != UGDS_SUCCESS) {
+        /* If dma-buf export is not supported on this GPU, skip gracefully */
+        if (st.err == UGDS_IO_NOT_SUPPORTED || st.err == UGDS_PLATFORM_NOT_SUPPORTED) {
+            printf("SKIP: dma-buf export not supported on this device\n");
+            cudaFree(d_buf);
+            close_handle(fh);
+            uGDSDriverClose();
+            return 77;  /* skip exit code (automake convention) */
+        }
+        TEST_FAIL("BufRegisterEx (RDMA): %s", UGDS_ERRSTR(st.err));
+    }
+
+    /* -- 2. Export dmabuf handle -- */
+    uGDSDmabufExport_t exp = {};
+    st = uGDSExportDmabuf(d_buf, &exp);
+    ASSERT_OK(st, "ExportDmabuf");
+
+    if (exp.fd < 0)
+        TEST_FAIL("export fd < 0");
+    if (exp.length != buf_size)
+        TEST_FAIL("export length mismatch: %zu != %zu", exp.length, buf_size);
+#ifdef __HIP_PLATFORM_AMD__
+    /* HIP may have non-zero offset */
+    if (exp.offset % getpagesize() != 0)
+        TEST_FAIL("HIP offset not page-aligned: %lu", exp.offset);
+#else
+    /* CUDA offset should be 0 */
+    if (exp.offset != 0)
+        TEST_FAIL("CUDA offset != 0: %lu", exp.offset);
+#endif
+
+    /* -- 3. Verify fd is usable (basic fstat) -- */
+    struct stat fd_stat;
+    if (fstat(exp.fd, &fd_stat) != 0)
+        TEST_FAIL("fstat on export fd failed: %s", strerror(errno));
+
+    /* -- 4. NVMe I/O still works after export -- */
+    /* Write pattern to GPU buffer */
+    cudaMemset(d_buf, 0xAB, buf_size);
+    cudaDeviceSynchronize();
+
+    ssize_t wr = uGDSWrite(fh, d_buf, 4096, 0, 0);
+    if (wr != 4096)
+        TEST_FAIL("uGDSWrite after export: %zd", wr);
+
+    /* Read back to verify */
+    cudaMemset(d_buf, 0x00, buf_size);
+    cudaDeviceSynchronize();
+
+    ssize_t rd = uGDSRead(fh, d_buf, 4096, 0, 0);
+    if (rd != 4096)
+        TEST_FAIL("uGDSRead after export: %zd", rd);
+
+    /* -- 5. Close export fd, then deregister -- */
+    close(exp.fd);
+
+    st = uGDSBufDeregister(d_buf);
+    ASSERT_OK(st, "BufDeregister after export close");
+
+    /* -- 6. Export on non-RDMA buffer -> IO_NOT_SUPPORTED -- */
+    void* d_buf2 = nullptr;
+    cudaMalloc(&d_buf2, buf_size);
+    if (!d_buf2) TEST_FAIL("cudaMalloc(2) failed");
+
+    st = uGDSBufRegister(d_buf2, buf_size, TEST_BUF_FLAGS);
+    ASSERT_OK(st, "BufRegister (non-RDMA)");
+
+    uGDSDmabufExport_t exp2 = {};
+    st = uGDSExportDmabuf(d_buf2, &exp2);
+    ASSERT_ERR(st, UGDS_IO_NOT_SUPPORTED, "export on non-RDMA buffer");
+
+    st = uGDSBufDeregister(d_buf2);
+    ASSERT_OK(st, "BufDeregister (non-RDMA)");
+
+    /* -- 7. Export on unregistered buffer -- */
+    uGDSDmabufExport_t exp3 = {};
+    st = uGDSExportDmabuf(d_buf2, &exp3);
+    ASSERT_ERR(st, UGDS_MEMORY_NOT_REGISTERED, "export on unregistered buffer");
+
+    /* -- 8. fd leak check: count /proc/self/fd before/after -- */
+    auto count_fds = []() -> int {
+        DIR* d = opendir("/proc/self/fd");
+        if (!d) return -1;
+        int count = 0;
+        struct dirent* ent;
+        while ((ent = readdir(d)) != nullptr) {
+            if (ent->d_name[0] != '.') count++;
+        }
+        closedir(d);
+        return count;
+    };
+
+    int fd_before = count_fds();
+    for (int i = 0; i < 10; i++) {
+        st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+        ASSERT_OK(st, "BufRegisterEx loop");
+
+        uGDSDmabufExport_t exp_l = {};
+        st = uGDSExportDmabuf(d_buf, &exp_l);
+        ASSERT_OK(st, "ExportDmabuf loop");
+
+        close(exp_l.fd);
+        st = uGDSBufDeregister(d_buf);
+        ASSERT_OK(st, "BufDeregister loop");
+    }
+
+    int fd_after = count_fds();
+    /* Allow runtime libraries to hold internal fds, but flag large leaks */
+    if (fd_before > 0 && fd_after > fd_before + 2)
+        TEST_FAIL("fd leak: before=%d after=%d", fd_before, fd_after);
+
+    cudaFree(d_buf);
+    cudaFree(d_buf2);
+    close_handle(fh);
+    uGDSDriverClose();
+
+    TEST_PASS();
+}

--- a/test/functional/test_rdma_tracked.cu
+++ b/test/functional/test_rdma_tracked.cu
@@ -1,0 +1,132 @@
+#include "test_utils.h"
+#include <sys/stat.h>
+#include <errno.h>
+#include <dirent.h>
+
+#ifdef _RDMA
+#include <infiniband/verbs.h>
+
+/* Test: Tracked RDMA MR lifecycle
+ *
+ * Verifies:
+ * - uGDSRDMARegister returns a valid MR
+ * - uGDSRDMAUnregister succeeds after quiescence
+ * - uGDSBufDeregister fails with UGDS_RDMA_MR_STILL_ACTIVE while MR is live
+ * - uGDSBufDeregister succeeds after unregister
+ *
+ * NOTE: This test does NOT post any WRs, so quiescence is trivially satisfied.
+ * Requires libibverbs but NOT a real RDMA NIC -- ibv_alloc_pd works on any
+ * verbs device (or fails gracefully if none present).
+ */
+int main(int argc, char** argv) {
+    if (!parse_args(argc, argv)) return 1;
+    cudaSetDevice(g_gpu_id);
+
+    uGDSError_t st = uGDSDriverOpen();
+    ASSERT_OK(st, "DriverOpen");
+
+    uGDSHandle_t fh = open_handle();
+    if (!fh) TEST_FAIL("open_handle failed");
+
+    /* Find a verbs device for PD allocation */
+    struct ibv_device** dev_list = ibv_get_device_list(NULL);
+    if (!dev_list || !dev_list[0]) {
+        printf("SKIP: no RDMA device available\n");
+        if (dev_list) ibv_free_device_list(dev_list);
+        close_handle(fh);
+        uGDSDriverClose();
+        return 77;
+    }
+
+    struct ibv_context* ctx = ibv_open_device(dev_list[0]);
+    ibv_free_device_list(dev_list);
+    if (!ctx) TEST_FAIL("ibv_open_device failed");
+
+    struct ibv_pd* pd = ibv_alloc_pd(ctx);
+    if (!pd) TEST_FAIL("ibv_alloc_pd failed");
+
+    const size_t buf_size = 65536;
+    void* d_buf = nullptr;
+    cudaMalloc(&d_buf, buf_size);
+    if (!d_buf) TEST_FAIL("cudaMalloc failed");
+
+    /* -- 1. Register buffer with RDMA -- */
+    uGDSBufConfig_t cfg = {};
+    cfg.backend =
+#ifdef __HIP_PLATFORM_AMD__
+        UGDS_BACKEND_HIP;
+#else
+        UGDS_BACKEND_CUDA;
+#endif
+    cfg.enable_export = true;
+
+    st = uGDSBufRegisterEx(d_buf, buf_size, &cfg);
+    if (st.err != UGDS_SUCCESS) {
+        if (st.err == UGDS_IO_NOT_SUPPORTED || st.err == UGDS_PLATFORM_NOT_SUPPORTED) {
+            printf("SKIP: dma-buf export not supported\n");
+            ibv_dealloc_pd(pd);
+            ibv_close_device(ctx);
+            cudaFree(d_buf);
+            close_handle(fh);
+            uGDSDriverClose();
+            return 77;
+        }
+        TEST_FAIL("BufRegisterEx: %s", UGDS_ERRSTR(st.err));
+    }
+
+    /* -- 2. Tracked RDMA Register -- */
+    uGDSRDMARegion_t region = {};
+    st = uGDSRDMARegister(d_buf, pd,
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+        IBV_ACCESS_REMOTE_WRITE, &region);
+    if (st.err == UGDS_IO_NOT_SUPPORTED) {
+        printf("SKIP: verbs provider does not support dmabuf MR\n");
+        ibv_dealloc_pd(pd);
+        ibv_close_device(ctx);
+        uGDSBufDeregister(d_buf);
+        cudaFree(d_buf);
+        close_handle(fh);
+        uGDSDriverClose();
+        return 77;
+    }
+    ASSERT_OK(st, "RDMARegister");
+
+    if (!region.mr) TEST_FAIL("MR is null");
+    if (region.iova == 0) TEST_FAIL("iova is 0 (should be buffer ptr)");
+
+    /* -- 3. Deregister must fail while MR is active -- */
+    st = uGDSBufDeregister(d_buf);
+    ASSERT_ERR(st, UGDS_RDMA_MR_STILL_ACTIVE, "deregister with active MR");
+
+    /* -- 4. Tracked RDMA Unregister -- */
+    st = uGDSRDMAUnregister(d_buf, &region);
+    ASSERT_OK(st, "RDMAUnregister");
+
+    if (region.mr != nullptr) TEST_FAIL("MR not cleared after unregister");
+
+    /* -- 5. Deregister now succeeds -- */
+    st = uGDSBufDeregister(d_buf);
+    ASSERT_OK(st, "BufDeregister after unregister");
+
+    /* -- 6. Double unregister fails (region->mr already cleared) -- */
+    st = uGDSRDMAUnregister(d_buf, &region);
+    ASSERT_ERR(st, UGDS_INVALID_VALUE, "double unregister (mr already cleared)");
+
+    /* Cleanup */
+    cudaFree(d_buf);
+    ibv_dealloc_pd(pd);
+    ibv_close_device(ctx);
+    close_handle(fh);
+    uGDSDriverClose();
+
+    TEST_PASS();
+}
+
+#else /* !_RDMA */
+
+int main(void) {
+    printf("SKIP: build with UGDS_ENABLE_RDMA=ON for tracked MR tests\n");
+    return 77;
+}
+
+#endif /* _RDMA */

--- a/test/functional/test_utils.h
+++ b/test/functional/test_utils.h
@@ -9,21 +9,21 @@
   #define cudaFree              hipFree
   #define cudaMemcpy           hipMemcpy
   #define cudaMemset            hipMemset
+  #define cudaMemsetAsync       hipMemsetAsync
   #define cudaSetDevice         hipSetDevice
   #define cudaDeviceSynchronize hipDeviceSynchronize
   #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
   #define cudaSuccess           hipSuccess
   #define cudaError_t           hipError_t
   #define cudaGetErrorString    hipGetErrorString
-  #define cudaStreamSynchronize hipStreamSynchronize
+  #define cudaStream_t          hipStream_t
   #define cudaStreamCreate      hipStreamCreate
   #define cudaStreamDestroy     hipStreamDestroy
-  #define cudaMemsetAsync       hipMemsetAsync
+  #define cudaStreamSynchronize hipStreamSynchronize
   #define cudaHostAlloc         hipHostMalloc
   #define cudaHostAllocDefault  hipHostMallocDefault
   #define cudaFreeHost          hipHostFree
   #define cudaLaunchHostFunc    hipLaunchHostFunc
-  #define cudaStream_t          hipStream_t
   /* HIP builds must use dmabuf path */
   #define TEST_BUF_FLAGS  UGDS_REGISTER_DMABUF
 #else

--- a/test/perf/cufile_bench.cu
+++ b/test/perf/cufile_bench.cu
@@ -19,10 +19,10 @@
   #define cudaSuccess           hipSuccess
   #define cudaError_t           hipError_t
   #define cudaGetErrorString    hipGetErrorString
-  #define cudaStreamSynchronize hipStreamSynchronize
+  #define cudaStream_t          hipStream_t
   #define cudaStreamCreate      hipStreamCreate
   #define cudaStreamDestroy     hipStreamDestroy
-  #define cudaStream_t          hipStream_t
+  #define cudaStreamSynchronize hipStreamSynchronize
   /* HIP builds must use dmabuf path */
   #define TEST_BUF_FLAGS  UGDS_REGISTER_DMABUF
 #else


### PR DESCRIPTION
Closes #17.

## Summary

dma-buf fd export for registered GPU buffers. The exported fd can be passed to `ibv_reg_dmabuf_mr` for RDMA, other kernel drivers, or `SCM_RIGHTS` for inter-process sharing.

Builds on:
- ~~#19 (kernel-hardening)~~ (merged)
- #21 (dual-backend-infra): void* stream abstraction and handle lifetime management

> **Note:** Since these are fork-based PRs targeting `main`, the GitHub "Files changed" tab includes changes from #21. To review only the export-specific changes, see the [incremental diff](https://github.com/potatogim/uGDS/compare/dual-backend-infra...fd-export).

### Stack order

1. ~~#19: kernel hardening~~ (merged)
2. #21: dual-backend infra
3. **#16** (this PR): fd export

### dma-buf export

* `uGDSExportDmabuf()`: obtain a dma-buf fd from a registered buffer (duplicated with `F_DUPFD_CLOEXEC`)
* CUDA path: `cuMemGetHandleForAddressRange()` to dma-buf export
* ROCm path: HIP memory to dma-buf export via existing DMA-buf framework
* `CUDA_ERROR_NOT_SUPPORTED` translated to `UGDS_IO_NOT_SUPPORTED`

### Registration API

* `uGDSBufRegisterEx()`: new registration API with `enable_export` flag and explicit backend selection (`UGDS_BACKEND_CUDA`, `UGDS_BACKEND_HIP`)
* Backend recorded via `nvm_dma_is_hip_origin()` for correct dual-backend dispatch
* Conflicting and unsupported backend flag combinations rejected

### RDMA memory registration

* `uGDSRDMARegister()` / `uGDSRDMAUnregister()`: tracked MR lifecycle built on top of dma-buf export and `ibv_reg_dmabuf_mr`
* Token-based pending/active state machine prevents deregister races
* `uGDSBufDeregister()` returns `UGDS_RDMA_MR_STILL_ACTIVE` if MRs are outstanding
* `UGDS_ENABLE_RDMA` CMake option with pkg-config libibverbs detection

### Build system

* Per-backend test suffixes (`*_cuda`, `*_hip`) auto-generated in dual mode; unsuffixed in single-backend mode
* CMake probes `HAVE_CUDA_DMABUF`; Makefile consumes `HAVE_CUDA_DMABUF=1` for kernel module builds

### Tests

* `test_dmabuf_export`: functional test for buffer registration, fd export, and basic IO
* `test_rdma_export`: RDMA MR registration and deregistration lifecycle
* `test_rdma_tracked`: tracked MR state machine (pending, active, deregister-blocking)
* `examples/rdma_example.cu`: producer/consumer RDMA pattern
* `run_tests.sh`: graceful skip for missing test targets; dual-backend suffix discovery

## Requirements

* Linux kernel 5.12+ (recommended 6.4+ for `MODULE_IMPORT_NS`)
* CUDA 12.2+ with `cuMemGetHandleForAddressRange`
* ROCm 7.0+, Large BAR enabled
* CMake 3.21+ for HIP language support
* libibverbs-dev (for RDMA support)

## Build verification

| Configuration | Status |
|---|---|
| CUDA-only | Pass |
| HIP-only | Pass |
| CUDA + HIP dual | Pass |