### PR TITLE
feat: harden kernel driver with atomic map operations and safety guards

### DIFF
--- a/drv/ctrl.c
+++ b/drv/ctrl.c
@@ -12,11 +12,22 @@
 #include <linux/fs.h>
 #include <linux/device.h>
 #include <linux/slab.h>
+#include <linux/kref.h>
 #include <asm/errno.h>
 
 
 
-struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev, int number)
+static void ctrl_release(struct kref* ref)
+{
+    struct ctrl* ctrl = container_of(ref, struct ctrl, ref);
+
+    pci_dev_put(ctrl->pdev);
+    kfree(ctrl);
+}
+
+
+
+struct ctrl* ctrl_get(struct class* cls, struct pci_dev* pdev, int number)
 {
     struct ctrl* ctrl = NULL;
 
@@ -28,11 +39,13 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     }
 
     list_node_init(&ctrl->list);
+    kref_init(&ctrl->ref);
 
-    ctrl->pdev = pdev;
+    ctrl->pdev = pci_dev_get(pdev);
     ctrl->number = number;
     ctrl->rdev = 0;
     ctrl->cls = cls;
+    ctrl->cdev = NULL;
     ctrl->chrdev = NULL;
 
     snprintf(ctrl->name, sizeof(ctrl->name), "%s%d", KBUILD_MODNAME, ctrl->number);
@@ -54,9 +67,7 @@ void ctrl_put(struct ctrl* ctrl)
 {
     if (ctrl != NULL)
     {
-        list_remove(&ctrl->list);
-        ctrl_chrdev_remove(ctrl);
-        kfree(ctrl);
+        kref_put(&ctrl->ref, ctrl_release);
     }
 }
 
@@ -88,26 +99,33 @@ struct ctrl* ctrl_find_by_pci_dev(const struct list* list, const struct pci_dev*
 
 
 
-struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* inode)
+struct ctrl* ctrl_find_and_get_by_inode(struct list* list, const struct inode* inode)
 {
     const struct list_node* element;
     struct ctrl* ctrl;
 
-    spin_lock(&((struct list*)list)->lock);
+    spin_lock(&list->lock);
     element = list_next(&list->head);
     while (element != NULL)
     {
         ctrl = container_of(element, struct ctrl, list);
 
-        if (&ctrl->cdev == inode->i_cdev)
+        if (ctrl->cdev == inode->i_cdev)
         {
-            spin_unlock(&((struct list*)list)->lock);
+            /* Same lock domain as list removal in remove_pci_dev,
+             * so a controller found here cannot have dropped its
+             * final reference yet. */
+            if (!kref_get_unless_zero(&ctrl->ref))
+            {
+                break;
+            }
+            spin_unlock(&list->lock);
             return ctrl;
         }
 
         element = list_next(element);
     }
-    spin_unlock(&((struct list*)list)->lock);
+    spin_unlock(&list->lock);
 
     return NULL;
 }
@@ -127,10 +145,20 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
 
     ctrl->rdev = MKDEV(MAJOR(first), MINOR(first) + ctrl->number);
 
-    cdev_init(&ctrl->cdev, fops);
-    err = cdev_add(&ctrl->cdev, ctrl->rdev, 1);
+    ctrl->cdev = cdev_alloc();
+    if (ctrl->cdev == NULL)
+    {
+        printk(KERN_ERR "Failed to allocate cdev\n");
+        return -ENOMEM;
+    }
+    ctrl->cdev->owner = fops->owner;
+    ctrl->cdev->ops = fops;
+
+    err = cdev_add(ctrl->cdev, ctrl->rdev, 1);
     if (err != 0)
     {
+        kobject_put(&ctrl->cdev->kobj);
+        ctrl->cdev = NULL;
         printk(KERN_ERR "Failed to add cdev\n");
         return err;
     }
@@ -138,7 +166,8 @@ int ctrl_chrdev_create(struct ctrl* ctrl, dev_t first, const struct file_operati
     chrdev = device_create(ctrl->cls, NULL, ctrl->rdev, NULL, ctrl->name);
     if (IS_ERR(chrdev))
     {
-        cdev_del(&ctrl->cdev);
+        cdev_del(ctrl->cdev);
+        ctrl->cdev = NULL;
         printk(KERN_ERR "Failed to create character device\n");
         return PTR_ERR(chrdev);
     }
@@ -158,11 +187,11 @@ void ctrl_chrdev_remove(struct ctrl* ctrl)
     if (ctrl->chrdev != NULL)
     {
         device_destroy(ctrl->cls, ctrl->rdev);
-        cdev_del(&ctrl->cdev);
+        cdev_del(ctrl->cdev);
+        ctrl->cdev = NULL;
         ctrl->chrdev = NULL;
 
         printk(KERN_DEBUG "Character device /dev/%s removed (%d.%d)\n",
                 ctrl->name, MAJOR(ctrl->rdev), MINOR(ctrl->rdev));
     }
 }
-

--- a/drv/ctrl.c
+++ b/drv/ctrl.c
@@ -38,9 +38,14 @@ struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev
     snprintf(ctrl->name, sizeof(ctrl->name), "%s%d", KBUILD_MODNAME, ctrl->number);
     ctrl->name[sizeof(ctrl->name) - 1] = '\0';
 
-    list_insert(list, &ctrl->list);
-
+    /* NOTE: caller must call ctrl_publish() after probe completes
+     * (DMA mask, chrdev, etc.) to make the controller visible. */
     return ctrl;
+}
+
+void ctrl_publish(struct list* list, struct ctrl* ctrl)
+{
+    list_insert(list, &ctrl->list);
 }
 
 
@@ -59,20 +64,24 @@ void ctrl_put(struct ctrl* ctrl)
 
 struct ctrl* ctrl_find_by_pci_dev(const struct list* list, const struct pci_dev* pdev)
 {
-    const struct list_node* element = list_next(&list->head);
+    const struct list_node* element;
     struct ctrl* ctrl;
 
+    spin_lock(&((struct list*)list)->lock);
+    element = list_next(&list->head);
     while (element != NULL)
     {
         ctrl = container_of(element, struct ctrl, list);
 
         if (ctrl->pdev == pdev)
         {
+            spin_unlock(&((struct list*)list)->lock);
             return ctrl;
         }
 
         element = list_next(element);
     }
+    spin_unlock(&((struct list*)list)->lock);
 
     return NULL;
 }
@@ -81,20 +90,24 @@ struct ctrl* ctrl_find_by_pci_dev(const struct list* list, const struct pci_dev*
 
 struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* inode)
 {
-    const struct list_node* element = list_next(&list->head);
+    const struct list_node* element;
     struct ctrl* ctrl;
 
+    spin_lock(&((struct list*)list)->lock);
+    element = list_next(&list->head);
     while (element != NULL)
     {
         ctrl = container_of(element, struct ctrl, list);
 
         if (&ctrl->cdev == inode->i_cdev)
         {
+            spin_unlock(&((struct list*)list)->lock);
             return ctrl;
         }
 
         element = list_next(element);
     }
+    spin_unlock(&((struct list*)list)->lock);
 
     return NULL;
 }

--- a/drv/ctrl.h
+++ b/drv/ctrl.h
@@ -13,58 +13,75 @@
 #include <linux/cdev.h>
 #include <linux/fs.h>
 #include <linux/device.h>
+#include <linux/kref.h>
 
 
 /*
  * Represents an NVM controller.
+ *
+ * Lifetime is kref-managed. Holders:
+ *   - ctrl_list holds one ref from probe (initial ref) until remove
+ *   - every open file holds one ref from dev_open until dev_release
+ * The embedded pdev is pinned with pci_dev_get for the ctrl lifetime.
+ *
+ * cdev is allocated separately with cdev_alloc(): inodes in the icache
+ * hold a reference to the cdev kobject via i_cdev and can outlive the
+ * last file AND the ctrl. An embedded cdev would be freed with the
+ * ctrl while such inode references still exist (UAF on inode eviction).
  */
 struct ctrl
 {
     struct list_node    list;       /* Linked list head */
-    struct pci_dev*     pdev;       /* Reference to physical PCI device */
+    struct kref         ref;        /* Lifetime refcount */
+    struct pci_dev*     pdev;       /* Pinned PCI device (pci_dev_get) */
     char                name[64];   /* Character device name */
     int                 number;     /* Controller number */
     dev_t               rdev;       /* Character device register */
     struct class*       cls;        /* Character device class */
-    struct cdev         cdev;       /* Character device */
+    struct cdev*        cdev;       /* Character device (cdev_alloc'd) */
     struct device*      chrdev;     /* Character device handle */
 };
 
 
 
 /*
- * Acquire a controller reference.
+ * Allocate a controller reference (initial kref = 1, pdev pinned).
+ * Caller must ctrl_publish() after probe completes to make it visible.
  */
-struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev, int number);
+struct ctrl* ctrl_get(struct class* cls, struct pci_dev* pdev, int number);
 void ctrl_publish(struct list* list, struct ctrl* ctrl);
 
 
 
 /*
- * Release controller reference.
+ * Drop a controller reference. When the last reference is dropped
+ * the pdev is unpinned and the ctrl is freed.
  */
 void ctrl_put(struct ctrl* ctrl);
 
 
 
 /*
- * Find controller device.
+ * Find controller device (no reference taken; caller must already
+ * hold one, e.g. the probe reference in remove_pci_dev).
  */
 struct ctrl* ctrl_find_by_pci_dev(const struct list* list, const struct pci_dev* pdev);
 
 
 
 /*
- * Find controller reference.
+ * Find controller by inode and take a reference, atomically with
+ * respect to remove (same list lock). Returns NULL if not found
+ * or already dying.
  */
-struct ctrl* ctrl_find_by_inode(const struct list* list, const struct inode* inode);
+struct ctrl* ctrl_find_and_get_by_inode(struct list* list, const struct inode* inode);
 
 
 
 /*
  * Create character device and set up file operations.
  */
-int ctrl_chrdev_create(struct ctrl* ctrl, 
+int ctrl_chrdev_create(struct ctrl* ctrl,
                        dev_t first,
                        const struct file_operations* fops);
 

--- a/drv/ctrl.h
+++ b/drv/ctrl.h
@@ -36,6 +36,7 @@ struct ctrl
  * Acquire a controller reference.
  */
 struct ctrl* ctrl_get(struct list* list, struct class* cls, struct pci_dev* pdev, int number);
+void ctrl_publish(struct list* list, struct ctrl* ctrl);
 
 
 

--- a/drv/map.c
+++ b/drv/map.c
@@ -18,6 +18,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/err.h>
 #include <linux/pci.h>
+#include <linux/jiffies.h>
 
 #ifdef _CUDA
 #include <nv-p2p.h>
@@ -516,8 +517,11 @@ int map_gpu_memory(struct map* map, struct list* list)
         }
     }
 
-    /* Publish gd AFTER all setup completes. */
-    map->data = gd;
+    /* Publish gd AFTER all setup completes. Release ordering pairs
+     * with the xchg (full barrier) in force_release_gpu_memory /
+     * release_gpu_memory, ensuring the callback never sees a
+     * partially initialized gpu_region. */
+    smp_store_release(&map->data, gd);
 
     /* If callback fired during setup, it took gd via xchg and freed
      * it via gpu_region_free_callback. The callback saves n_addrs
@@ -809,9 +813,17 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
      * addresses, so that GPU writes preceding the import are visible
      * at the DMA-buf backing storage when NVMe accesses it. */
     dma_resv_lock(dr->dmabuf->resv, NULL);
+    /* Bounded, interruptible wait: an unbounded uninterruptible wait
+     * puts the caller in unkillable D state if a GPU fence never
+     * signals. 0 means timeout; negative (incl. -ERESTARTSYS) is
+     * returned as-is so the signal layer can restart the syscall. */
     fence_ret = dma_resv_wait_timeout(dr->dmabuf->resv, DMA_RESV_USAGE_WRITE,
-                                 false, MAX_SCHEDULE_TIMEOUT);
-    if (fence_ret < 0 && fence_ret != -ERESTARTSYS)
+                                 true, msecs_to_jiffies(10000));
+    if (fence_ret == 0)
+    {
+        fence_ret = -ETIMEDOUT;
+    }
+    if (fence_ret < 0)
     {
         dma_resv_unlock(dr->dmabuf->resv);
         printk(KERN_ERR "uGDS: dma_resv_wait_timeout failed: %ld\n", fence_ret);

--- a/drv/map.c
+++ b/drv/map.c
@@ -17,6 +17,7 @@
 #include <linux/mm.h>
 #include <linux/dma-mapping.h>
 #include <linux/err.h>
+#include <linux/pci.h>
 
 #ifdef _CUDA
 #include <nv-p2p.h>
@@ -25,7 +26,75 @@ struct gpu_region
 {
     nvidia_p2p_page_table_t* pages;
     nvidia_p2p_dma_mapping_t** mappings;
+    uint32_t n_mappings;       /* count of mappings array */
+    struct pci_dev** pdevs;    /* pdev snapshot for safe teardown */
+    u64 vaddr;                 /* GPU virtual address for put_pages */
 };
+
+/* Callback-safe cleanup: unmap DMA mappings via free_dma_mapping
+ * (deferred-safe) and free the page table via free_page_table.
+ * Called from the NVIDIA invalidation callback only. */
+static void gpu_region_free_callback(struct gpu_region* gd)
+{
+    uint32_t j;
+    if (gd == NULL)
+        return;
+
+    if (gd->mappings != NULL)
+    {
+        for (j = 0; j < gd->n_mappings; j++)
+        {
+            if (gd->mappings[j] != NULL)
+                nvidia_p2p_free_dma_mapping(gd->mappings[j]);
+        }
+        kfree(gd->mappings);
+    }
+
+    if (gd->pdevs != NULL)
+    {
+        for (j = 0; j < gd->n_mappings; j++)
+            pci_dev_put(gd->pdevs[j]);
+        kfree(gd->pdevs);
+    }
+
+    if (gd->pages != NULL)
+        nvidia_p2p_free_page_table(gd->pages);
+
+    kfree(gd);
+}
+
+/* Normal cleanup: unmap DMA mappings via dma_unmap_pages and free
+ * the page table via put_pages. Called from release_gpu_memory and
+ * setup error paths (before the callback can fire, i.e. before
+ * map->data is published). */
+static void gpu_region_free_normal(struct gpu_region* gd)
+{
+    uint32_t j;
+    if (gd == NULL)
+        return;
+
+    if (gd->mappings != NULL)
+    {
+        for (j = 0; j < gd->n_mappings; j++)
+        {
+            if (gd->mappings[j] != NULL)
+                nvidia_p2p_dma_unmap_pages(gd->pdevs[j], gd->pages, gd->mappings[j]);
+        }
+        kfree(gd->mappings);
+    }
+
+    if (gd->pdevs != NULL)
+    {
+        for (j = 0; j < gd->n_mappings; j++)
+            pci_dev_put(gd->pdevs[j]);
+        kfree(gd->pdevs);
+    }
+
+    if (gd->pages != NULL)
+        nvidia_p2p_put_pages(0, 0, gd->vaddr, gd->pages);
+
+    kfree(gd);
+}
 #endif
 
 
@@ -33,13 +102,19 @@ struct gpu_region
 #define GPU_PAGE_SIZE   (1UL << GPU_PAGE_SHIFT)
 #define GPU_PAGE_MASK   ~(GPU_PAGE_SIZE - 1)
 
-uint32_t max_num_ctrls = 64;
-
 
 static struct map* create_descriptor(const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages)
 {
     unsigned long i;
     struct map* map = NULL;
+
+    /* Prevent integer overflow in the flexible-array allocation.
+     * (n_pages - 1) * sizeof(uint64_t) must not overflow unsigned long. */
+    if (n_pages == 0 || n_pages > (ULONG_MAX - sizeof(struct map)) / sizeof(uint64_t) + 1)
+    {
+        printk(KERN_ERR "n_pages overflow: %lu\n", n_pages);
+        return ERR_PTR(-EINVAL);
+    }
 
     map = kvmalloc(sizeof(struct map) + (n_pages - 1) * sizeof(uint64_t), GFP_KERNEL);
     if (map == NULL)
@@ -50,14 +125,16 @@ static struct map* create_descriptor(const struct ctrl* ctrl, u64 vaddr, unsigne
 
     list_node_init(&map->list);
 
-    map->owner = current;
+    map->owner_pid = get_task_pid(current, PIDTYPE_TGID);
     map->vaddr = vaddr;
     map->pdev = ctrl->pdev;
     map->page_size = 0;
     map->data = NULL;
     map->release = NULL;
     map->n_addrs = n_pages;
+    map->n_dma_mapped = 0;
     atomic_set(&map->invalid, 0);
+    atomic_set(&map->refcount, 1);
 
 
     for (i = 0; i < map->n_addrs; ++i)
@@ -79,6 +156,9 @@ void unmap_and_release(struct map* map)
         map->release(map);
     }
 
+    if (map->owner_pid != NULL)
+        put_pid(map->owner_pid);
+
     kvfree(map);
 }
 
@@ -88,31 +168,300 @@ struct map* map_find(const struct list* list, u64 vaddr)
 {
     const struct list_node* element = list_next(&list->head);
     struct map* map = NULL;
+    struct map* exact = NULL;
+    struct map* masked = NULL;
 
+    /* Acquire refcounted pid once. get_task_pid returns a referenced
+     * pointer (via get_pid), so we must put_pid before returning. */
+    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
+
+    /* Two-pass lookup: prefer exact vaddr match, fall back to
+     * page-mask match. This prevents a 64 KiB CUDA mapping from
+     * shadowing a 4 KiB dma-buf mapping in the same region. */
     while (element != NULL)
     {
         map = container_of(element, struct map, list);
 
-        if (map->owner == current)
+        if (map->owner_pid == current_pid)
         {
-            /* Match address using the mapping's own page size.
-             * Previously the unconditional GPU_PAGE_MASK (64 KiB)
-             * could cause HIP-vs-HIP false matches when two 4 KiB
-             * mappings resided in the same 64 KiB region. Each
-             * mapping is now matched only by its own page_size. */
-            if (map->page_size > 0 &&
+            if (map->vaddr == vaddr)
+            {
+                exact = map;
+                break;
+            }
+            if (masked == NULL &&
+                map->page_size > 0 &&
                 map->vaddr == (vaddr & ~((u64)map->page_size - 1)))
             {
-                return map;
+                masked = map;
             }
         }
 
         element = list_next(element);
     }
 
+    if (current_pid != NULL)
+        put_pid(current_pid);
+
+    return exact ? exact : masked;
+}
+
+
+
+/*
+ * Helper: unlink a list_node from the doubly-linked list.
+ * Must be called with the list spinlock held.
+ */
+static void list_unlink(struct list_node* element)
+{
+    element->prev->next = element->next;
+    element->next->prev = element->prev;
+    element->list = NULL;
+    element->next = NULL;
+    element->prev = NULL;
+}
+
+/*
+ * Helper: find a mapping by exact vaddr or page-masked vaddr
+ * for the current task and matching PCI device. Returns the map or NULL.
+ * Must be called with the list spinlock held.
+ *
+ * The pdev match prevents cross-device reuse: two NVMe controllers
+ * in the same process must not share DMA addresses.
+ */
+static struct map* map_lookup_locked(const struct list* list,
+                                      u64 vaddr,
+                                      const struct pci_dev* pdev,
+                                      unsigned long n_pages,
+                                      unsigned long page_size,
+                                      struct list_node** out_element)
+{
+    struct list_node* element = list_next(&list->head);
+    struct map* exact = NULL;
+    struct map* masked = NULL;
+    struct list_node* masked_element = NULL;
+    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
+
+    while (element != NULL)
+    {
+        struct map* map = container_of(element, struct map, list);
+
+        if (map->owner_pid == current_pid &&
+            (pdev == NULL || map->pdev == pdev) &&
+            (n_pages == 0 || map->n_addrs == n_pages) &&
+            (page_size == 0 || map->page_size == page_size))
+        {
+            if (map->vaddr == vaddr)
+            {
+                exact = map;
+                if (out_element)
+                    *out_element = element;
+                break;
+            }
+            if (masked == NULL &&
+                map->page_size > 0 &&
+                map->vaddr == (vaddr & ~((u64)map->page_size - 1)))
+            {
+                masked = map;
+                masked_element = element;
+            }
+        }
+        element = list_next(element);
+    }
+
+    if (current_pid != NULL)
+        put_pid(current_pid);
+
+    if (exact)
+        return exact;
+
+    if (masked)
+    {
+        if (out_element)
+            *out_element = masked_element;
+        return masked;
+    }
+
+    if (out_element)
+        *out_element = NULL;
     return NULL;
 }
 
+/*
+ * Atomically find an existing mapping and increment its refcount.
+ * Matches by (owner_pid, vaddr, pdev). Returns the existing map,
+ * or NULL if not found.
+ */
+struct map* map_find_and_ref(struct list* list, u64 vaddr,
+                             const struct pci_dev* pdev,
+                             unsigned long n_pages,
+                             unsigned long page_size)
+{
+    struct map* result = NULL;
+
+    spin_lock(&list->lock);
+    {
+        result = map_lookup_locked(list, vaddr, pdev, n_pages, page_size, NULL);
+        if (result != NULL)
+        {
+            int old = atomic_read(&result->refcount);
+            if (old >= 0x7FFFFFFF)
+            {
+                spin_unlock(&list->lock);
+                return ERR_PTR(-EMFILE);
+            }
+            atomic_inc(&result->refcount);
+        }
+    }
+    spin_unlock(&list->lock);
+
+    return result;
+}
+
+/*
+ * Decrement a mapping's refcount. If it reaches 0 the mapping is
+ * removed from the list and freed.
+ *
+ * The caller must hold map_create_mutex (or otherwise guarantee no
+ * concurrent force_release) to prevent a race with the NVIDIA P2P
+ * callback path.
+ */
+void map_put_ref(struct map* map)
+{
+    struct list* lst;
+
+    if (map == NULL)
+        return;
+
+    lst = map->list.list;
+    spin_lock(&lst->lock);
+    {
+        if (atomic_dec_and_test(&map->refcount))
+        {
+            list_unlink(&map->list);
+        }
+        else
+        {
+            map = NULL; /* still referenced, don't free */
+        }
+    }
+    spin_unlock(&lst->lock);
+
+    if (map != NULL)
+        unmap_and_release(map);
+}
+
+/*
+ * Atomically find and remove (or decrement) a mapping from the list.
+ *
+ * n_pages=0 and page_size=0 act as wildcards. This is correct for
+ * UNMAP because userspace should never create two maps with the same
+ * VA on the same controller with different backends; if it does, the
+ * exact-match path returns the first matching map deterministically.
+ *
+ * Returns:
+ *   - pointer to the removed map if refcount drops to 0 (caller must
+ *     unmap_and_release)
+ *   - ERR_PTR(-EAGAIN) if the mapping was found but still referenced
+ *     (refcount decremented, not removed)
+ *   - NULL if not found
+ */
+struct map* map_find_and_remove(struct list* list, u64 vaddr,
+                                const struct pci_dev* pdev)
+{
+    struct map* result = NULL;
+    struct list_node* target_element = NULL;
+
+    spin_lock(&list->lock);
+    {
+        result = map_lookup_locked(list, vaddr, pdev, 0, 0, &target_element);
+        if (result != NULL && target_element != NULL)
+        {
+            if (atomic_dec_and_test(&result->refcount))
+            {
+                /* refcount reached 0: safe to remove */
+                list_unlink(target_element);
+            }
+            else
+            {
+                /* Still in use by another on-the-fly user */
+                result = ERR_PTR(-EAGAIN);
+            }
+        }
+        else
+        {
+            result = NULL;
+        }
+    }
+    spin_unlock(&list->lock);
+
+    return result;
+}
+
+
+
+/*
+ * Check if any mapping owned by the current task overlaps the
+ * byte range [vaddr, vaddr + n_bytes) on the given list and pdev.
+ * Uses proper range-overlap detection so mappings at different
+ * page granularities (e.g. 4 KiB dmabuf vs 64 KiB CUDA) are
+ * correctly detected even when their base addresses differ.
+ *
+ * Must be called with map_create_mutex held (serializes against
+ * concurrent MAP/UNMAP that could add/remove entries).
+ */
+bool map_range_exists(struct list* list, u64 vaddr, u64 n_bytes,
+                      const struct pci_dev* pdev)
+{
+    struct list_node* element;
+    struct pid* current_pid;
+    bool found = false;
+    u64 new_end;
+
+    /* Reject wrapping ranges from user-controlled addresses.
+     * Return true so the caller rejects with -EEXIST rather than
+     * allowing a nonsensical wrapped range to be created. */
+    if (vaddr > U64_MAX - n_bytes)
+        return true;
+
+    new_end = vaddr + n_bytes;
+
+    current_pid = get_task_pid(current, PIDTYPE_TGID);
+
+    spin_lock(&list->lock);
+    {
+        element = list_next(&list->head);
+        while (element != NULL)
+        {
+            struct map* map = container_of(element, struct map, list);
+            u64 existing_end;
+
+            if (map->owner_pid != current_pid ||
+                map->pdev != pdev)
+            {
+                element = list_next(element);
+                continue;
+            }
+
+            existing_end = map->vaddr + (u64)map->n_addrs * (u64)map->page_size;
+
+            /* Standard interval overlap: [a, b) vs [c, d) */
+            if (vaddr < existing_end && new_end > map->vaddr)
+            {
+                found = true;
+                break;
+            }
+
+            element = list_next(element);
+        }
+    }
+    spin_unlock(&list->lock);
+
+    if (current_pid != NULL)
+        put_pid(current_pid);
+
+    return found;
+}
 
 
 static void release_user_pages(struct map* map)
@@ -122,21 +471,27 @@ static void release_user_pages(struct map* map)
     struct device* dev;
 
     dev = &map->pdev->dev;
-    for (i = 0; i < map->n_addrs; ++i)
+    /* Only unmap entries that were successfully DMA-mapped. */
+    for (i = 0; i < map->n_dma_mapped; ++i)
     {
         dma_unmap_page(dev, map->addrs[i], PAGE_SIZE, DMA_BIDIRECTIONAL);
     }
 
     pages = (struct page**) map->data;
-    for (i = 0; i < map->n_addrs; ++i)
+    if (pages != NULL)
     {
-        put_page(pages[i]);
+        for (i = 0; i < map->n_addrs; ++i)
+        {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+            unpin_user_page(pages[i]);
+#else
+            put_page(pages[i]);
+#endif
+        }
     }
 
     kvfree(map->data);
     map->data = NULL;
-
-    //printk(KERN_DEBUG "Released %lu host pages\n", map->n_addrs);
 }
 
 
@@ -161,23 +516,37 @@ static long map_user_pages(struct map* map)
 #elif LINUX_VERSION_CODE <= KERNEL_VERSION(4, 8, 17)
 #warning "Building for older kernel, not properly tested"
     retval = get_user_pages(map->vaddr, map->n_addrs, 1, 0, pages, NULL);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)
     retval = get_user_pages(map->vaddr, map->n_addrs, FOLL_WRITE, pages, NULL);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
+    retval = pin_user_pages(map->vaddr, map->n_addrs, FOLL_WRITE | FOLL_LONGTERM, pages, NULL);
 #else
-    retval = get_user_pages(map->vaddr, map->n_addrs, FOLL_WRITE, pages);
+    retval = pin_user_pages(map->vaddr, map->n_addrs, FOLL_WRITE | FOLL_LONGTERM, pages);
 #endif
     if (retval <= 0)
     {
-        kfree(pages);
+        kvfree(pages);
         printk(KERN_ERR "get_user_pages() failed: %ld\n", retval);
         return retval;
     }
 
     if (map->n_addrs != retval)
     {
-        printk(KERN_WARNING "Requested %lu GPU pages, but only got %ld\n", map->n_addrs, retval);
+        /* Partial GUP success: the ioctl ABI returns a fixed-size
+         * buffer and does not communicate the actual mapped count.
+         * Returning partial mappings leaves stale/zero DMA addresses
+         * that userspace would pass to NVMe DMA. Fail hard instead. */
+        unsigned long g;
+        for (g = 0; g < retval; g++)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+            unpin_user_page(pages[g]);
+#else
+            put_page(pages[g]);
+#endif
+        kvfree(pages);
+        printk(KERN_ERR "get_user_pages() got %ld of %lu pages\n", retval, map->n_addrs);
+        return -ENOMEM;
     }
-    map->n_addrs = retval;
     map->page_size = PAGE_SIZE;
     map->data = (void*) pages;
     map->release = release_user_pages;
@@ -191,9 +560,11 @@ static long map_user_pages(struct map* map)
         if (retval != 0)
         {
             printk(KERN_ERR "Failed to map page for some reason\n");
+            /* n_dma_mapped tracks how many were successfully mapped,
+             * so release_user_pages only unmaps those entries. */
             return retval;
         }
-       // printk("map_user_page: device: %02x:%02x.%1x\tvaddr: %llx\ti: %lu\tdma_addr: %llx\n", map->pdev->bus->number, PCI_SLOT(map->pdev->devfn), PCI_FUNC(map->pdev->devfn), (uint64_t) map->vaddr, i, map->addrs[i]);
+        map->n_dma_mapped++;
     }
 
     return 0;
@@ -238,41 +609,30 @@ struct map* map_userspace(struct list* list, const struct ctrl* ctrl, u64 vaddr,
 #ifdef _CUDA
 static void force_release_gpu_memory(struct map* map)
 {
-    struct gpu_region* gd = (struct gpu_region*) map->data;
-    struct list* list = map->ctrl_list;
+    /* NVIDIA force-reclaim callback. Runs in process context.
+     *
+     * Atomically claims gd via xchg. If we get gd, we fully own it
+     * and free it using the callback-safe path (free_dma_mapping +
+     * free_page_table). If we get NULL, setup hasn't published yet
+     * or the normal release path already took it.
+     *
+     * Once published, the setup thread checks map->invalid at every
+     * iteration and on error. If it sees invalid, it knows the
+     * callback has already claimed gd and must not touch it. */
+
+    struct gpu_region* gd;
+    unsigned long n_addrs;
+
+    n_addrs = map->n_addrs;
+    atomic_set(&map->invalid, 1);
+
+    gd = (struct gpu_region*) xchg(&map->data, NULL);
 
     if (gd != NULL)
     {
-        if (gd->mappings != NULL)
-        {
-            const struct list_node* element = list_next(&list->head);
-            struct ctrl* ctrl;
-
-            uint32_t j = 0;
-            while (element != NULL)
-            {
-                ctrl = container_of(element, struct ctrl, list);
-                if (gd->mappings[j] != NULL)
-                    nvidia_p2p_dma_unmap_pages(ctrl->pdev, gd->pages, gd->mappings[j++]);
-
-                element = list_next(element);
-            }
-            kfree(gd->mappings);
-
-        }
-
-        if (gd->pages != NULL)
-        {
-            nvidia_p2p_free_page_table(gd->pages);
-        }
-
-        kfree(gd);
-        map->data = NULL;
-
-        printk(KERN_DEBUG "Nvidia driver forcefully reclaimed %lu GPU pages\n", map->n_addrs);
+        gpu_region_free_callback(gd);
+        printk(KERN_DEBUG "Nvidia driver forcefully reclaimed %lu GPU pages\n", n_addrs);
     }
-
-    unmap_and_release(map);
 }
 #endif
 
@@ -281,39 +641,16 @@ static void force_release_gpu_memory(struct map* map)
 #ifdef _CUDA
 void release_gpu_memory(struct map* map)
 {
-    struct gpu_region* gd = (struct gpu_region*) map->data;
-    struct list* list = map->ctrl_list;
+    /* Normal unregister path. Atomically claim gd. If we win,
+     * free via the normal path (dma_unmap_pages + put_pages).
+     * If we lose, the callback already took and freed it.
+     *
+     * put_pages blocks until any outstanding callback completes. */
+
+    struct gpu_region* gd = (struct gpu_region*) xchg(&map->data, NULL);
 
     if (gd != NULL)
-    {
-        if (gd->mappings != NULL)
-        {
-            const struct list_node* element = list_next(&list->head);
-            struct ctrl* ctrl;
-
-            uint32_t j = 0;
-            while (element != NULL)
-            {
-                ctrl = container_of(element, struct ctrl, list);
-                if (gd->mappings[j] != NULL)
-                    nvidia_p2p_dma_unmap_pages(ctrl->pdev, gd->pages, gd->mappings[j++]);
-
-                element = list_next(element);
-            }
-            kfree(gd->mappings);
-
-        }
-
-        if (gd->pages != NULL)
-        {
-            nvidia_p2p_put_pages(0, 0, map->vaddr, gd->pages);
-        }
-
-        kfree(gd);
-        map->data = NULL;
-
-        //printk(KERN_DEBUG "Released %lu GPU pages\n", map->n_addrs);
-    }
+        gpu_region_free_normal(gd);
 }
 #endif
 
@@ -328,6 +665,23 @@ int map_gpu_memory(struct map* map, struct list* list)
     struct gpu_region* gd;
     const struct list_node* element;
     struct ctrl* ctrl;
+    uint32_t n_ctrls = 0;
+
+    /* Snapshot controllers under spinlock: count + collect pdevs
+     * in a single pass to prevent TOCTOU between count and fill. */
+    spin_lock(&list->lock);
+    {
+        element = list_next(&list->head);
+        while (element != NULL)
+        {
+            n_ctrls++;
+            element = list_next(element);
+        }
+    }
+    spin_unlock(&list->lock);
+
+    if (n_ctrls == 0)
+        return -ENODEV;
 
     gd = kmalloc(sizeof(struct gpu_region), GFP_KERNEL);
     if (gd == NULL)
@@ -336,7 +690,7 @@ int map_gpu_memory(struct map* map, struct list* list)
         return -ENOMEM;
     }
 
-    gd->mappings = (nvidia_p2p_dma_mapping_t**)  kmalloc(sizeof(nvidia_p2p_dma_mapping_t*) * max_num_ctrls, GFP_KERNEL);
+    gd->mappings = (nvidia_p2p_dma_mapping_t**) kmalloc(sizeof(nvidia_p2p_dma_mapping_t*) * n_ctrls, GFP_KERNEL);
     
     if (gd->mappings == NULL)
     {
@@ -344,98 +698,146 @@ int map_gpu_memory(struct map* map, struct list* list)
         kfree(gd);
         return -ENOMEM;
     }
-    for (j = 0; j < max_num_ctrls; j++)
+
+    gd->pdevs = (struct pci_dev**) kmalloc(sizeof(struct pci_dev*) * n_ctrls, GFP_KERNEL);
+    if (gd->pdevs == NULL)
+    {
+        printk(KERN_CRIT "Failed to allocate pdev snapshot\n");
+        kfree(gd->mappings);
+        kfree(gd);
+        return -ENOMEM;
+    }
+
+    gd->n_mappings = n_ctrls;
+
+    for (j = 0; j < n_ctrls; j++)
         gd->mappings[j] = NULL;
 
     gd->pages = NULL;
-    //gd->mappings = NULL;
+    gd->vaddr = map->vaddr;
+
+    /* Collect pdev snapshot under spinlock and pin each device. */
+    spin_lock(&list->lock);
+    {
+        j = 0;
+        element = list_next(&list->head);
+        while (element != NULL && j < n_ctrls)
+        {
+            ctrl = container_of(element, struct ctrl, list);
+            gd->pdevs[j] = pci_dev_get(ctrl->pdev);
+            j++;
+            element = list_next(element);
+        }
+    }
+    spin_unlock(&list->lock);
+
+    /* If list shrank between count and collect, abort. */
+    if (j < n_ctrls)
+    {
+        uint32_t k;
+        for (k = 0; k < j; k++)
+            pci_dev_put(gd->pdevs[k]);
+        kfree(gd->pdevs);
+        kfree(gd->mappings);
+        kfree(gd);
+        return -ENODEV;
+    }
 
     map->page_size = GPU_PAGE_SIZE;
-    map->data = gd;
     map->release = release_gpu_memory;
+    /* map->data stays NULL until setup completes (deferred publish).
+     *
+     * If the NVIDIA invalidation callback fires during setup, it
+     * gets NULL from xchg and returns without touching gd. The
+     * setup thread detects invalid and calls gpu_region_free_normal,
+     * which uses dma_unmap_pages + put_pages.
+     *
+     * This is correct per the NVIDIA P2P API contract: when the
+     * callback gets NULL (setup still in progress), the page table
+     * has NOT been revoked. The setup thread still owns gd and can
+     * safely call put_pages to unregister. put_pages blocks until
+     * the callback has completed, ensuring no UAF.
+     *
+     * The callback-safe APIs (free_dma_mapping, free_page_table) are
+     * ONLY used from within the callback itself (gpu_region_free_callback),
+     * for the case where the callback wins xchg and takes ownership. */
 
     err = nvidia_p2p_get_pages(0, 0, map->vaddr, GPU_PAGE_SIZE * map->n_addrs, &gd->pages,
             (void (*)(void*)) force_release_gpu_memory, map);
     if (err != 0)
     {
         printk(KERN_ERR "nvidia_p2p_get_pages() failed: %d\n", err);
+        gpu_region_free_normal(gd);
         return err;
     }
 
-    /* Debug: print raw physical_address from nvidia_p2p_page_table_t */
-#if 0
+    /* Validate entries. */
+    if (gd->pages->entries != map->n_addrs)
     {
-        int dbg_max = (gd->pages->entries < 4) ? gd->pages->entries : 4;
-        int d;
-        printk(KERN_INFO "BAM P2P: entries=%u page_size=%u\n",
-               gd->pages->entries, gd->pages->page_size);
-        for (d = 0; d < dbg_max; d++) {
-            printk(KERN_INFO "BAM P2P: physical_address[%d] = 0x%llx\n",
-                   d, (unsigned long long)gd->pages->pages[d]->physical_address);
-        }
-        if (gd->pages->entries > 4) {
-            printk(KERN_INFO "BAM P2P: physical_address[%u] = 0x%llx (last)\n",
-                   gd->pages->entries - 1,
-                   (unsigned long long)gd->pages->pages[gd->pages->entries - 1]->physical_address);
-        }
+        printk(KERN_ERR "nvidia_p2p_get_pages returned %u entries, expected %lu\n",
+               gd->pages->entries, map->n_addrs);
+        gpu_region_free_normal(gd);
+        return -EIO;
     }
-#endif
 
-    element = list_next(&list->head);
-
-
-    j = 0;
-    while (element != NULL)
+    /* If callback already fired, put_pages (inside free_normal) syncs. */
+    if (atomic_read(&map->invalid))
     {
-        ctrl = container_of(element, struct ctrl, list);
+        gpu_region_free_normal(gd);
+        return -EIO;
+    }
 
-        err = nvidia_p2p_dma_map_pages(ctrl->pdev, gd->pages, gd->mappings + (j++));
-        if (err != 0)
+    /* DMA-map pages using the snapshotted pdevs. */
+    {
+        bool found_request_pdev = false;
+        j = 0;
+        while (j < n_ctrls)
         {
-            //printk(KERN_ERR "nvidia_p2p_dma_map_pages() failed for nvme%u: %d\n", j-1, err);
-            return err;
-        }
-        //for (i = 0; i < map->n_addrs; ++i)
-        //{
-
-        //   printk("device: %u\ti: %lu\tpaddr: %llx\n", (j-1), i, (uint64_t)  gd->mappings[j-1]->dma_addresses[i]);
-        //}
-        if (j == 1) {
-            for (i = 0; i < map->n_addrs; ++i)
+            /* Check for force_release between iterations. If the
+             * callback fired, the page table is revoked. Abort and
+             * clean up via put_pages (syncs with callback). */
+            if (atomic_read(&map->invalid))
             {
-                map->addrs[i] = gd->mappings[0]->dma_addresses[i];
-                //printk("++paddr: %llx\n", (uint64_t) map->addrs[i]);
+                gpu_region_free_normal(gd);
+                return -EIO;
             }
+
+            err = nvidia_p2p_dma_map_pages(gd->pdevs[j], gd->pages, gd->mappings + j);
+            if (err != 0)
+            {
+                /* gpu_region_free_normal unmaps all non-NULL mappings
+                 * and calls put_pages (syncs with callback). */
+                gpu_region_free_normal(gd);
+                return err;
+            }
+            /* Copy DMA addresses from the mapping for the caller's pdev. */
+            if (gd->pdevs[j] == map->pdev)
+            {
+                found_request_pdev = true;
+                for (i = 0; i < map->n_addrs; ++i)
+                    map->addrs[i] = gd->mappings[j]->dma_addresses[i];
+            }
+            j++;
         }
-        element = list_next(element);
-    }
 
-
-
-
-    if (map->n_addrs != gd->pages->entries)
-    {
-        printk(KERN_WARNING "Requested %lu GPU pages, but only got %u\n", map->n_addrs, gd->pages->entries);
-    }
-
-    map->n_addrs = gd->pages->entries;
-
-    /* Debug: side-by-side comparison of p2p physical vs DMA addresses */
-#if 0
-    {
-        int cmp_max = (map->n_addrs < 4) ? map->n_addrs : 4;
-        int c;
-        printk(KERN_INFO "BAM P2P: === physical_address vs dma_address comparison ===\n");
-        for (c = 0; c < cmp_max; c++) {
-            printk(KERN_INFO "BAM P2P: [%d] p2p_phys=0x%llx  dma=0x%llx  diff=0x%llx\n",
-                   c,
-                   (unsigned long long)gd->pages->pages[c]->physical_address,
-                   (unsigned long long)map->addrs[c],
-                   (unsigned long long)(map->addrs[c] - gd->pages->pages[c]->physical_address));
+        if (!found_request_pdev)
+        {
+            gpu_region_free_normal(gd);
+            return -ENODEV;
         }
     }
-#endif
-    
+
+    /* Publish gd AFTER all setup completes. */
+    map->data = gd;
+
+    /* If callback fired during setup, it took gd via xchg and freed
+     * it via gpu_region_free_callback. The callback saves n_addrs
+     * as a local before xchg, so it never dereferences map after
+     * xchg. It is safe for the caller to unmap_and_release (kvfree)
+     * map even if the callback hasn't fully returned. */
+    if (atomic_read(&map->invalid))
+        return -EIO;
+
     return 0;
 }
 #endif
@@ -581,6 +983,16 @@ int sg_flatten_to_addrs(struct sg_table* sgt, u64* addrs,
 
         while (len >= ctrl_page_size && page_idx < expected_pages)
         {
+            /* Reject unaligned DMA addresses. amdgpu P2P should
+             * always return page-aligned addresses, but a defensive
+             * check prevents a corrupted PRP list. */
+            if (addr & (ctrl_page_size - 1))
+            {
+                printk(KERN_ERR "uGDS: SG entry %u address %llx is not "
+                       "%lu-byte aligned\n",
+                       i, addr, ctrl_page_size);
+                return -EINVAL;
+            }
             addrs[page_idx++] = addr;
             addr += ctrl_page_size;
             len -= ctrl_page_size;
@@ -622,6 +1034,7 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
     struct dmabuf_region* dr;
     unsigned long ctrl_page_size = PAGE_SIZE;
     int err;
+    long fence_ret;
 
     if (expected_pages > ioaddrs_capacity)
     {
@@ -704,8 +1117,25 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
         return err;
     }
 
-    /* Map for DMA -- dynamic importer must hold reservation lock */
+    /* Map for DMA -- dynamic importer must hold reservation lock.
+     * Wait for any outstanding write fences before capturing DMA
+     * addresses, so that GPU writes preceding the import are visible
+     * at the DMA-buf backing storage when NVMe accesses it. */
     dma_resv_lock(dr->dmabuf->resv, NULL);
+    fence_ret = dma_resv_wait_timeout(dr->dmabuf->resv, DMA_RESV_USAGE_WRITE,
+                                 false, MAX_SCHEDULE_TIMEOUT);
+    if (fence_ret < 0 && fence_ret != -ERESTARTSYS)
+    {
+        dma_resv_unlock(dr->dmabuf->resv);
+        printk(KERN_ERR "uGDS: dma_resv_wait_timeout failed: %ld\n", fence_ret);
+        dma_resv_lock(dr->dmabuf->resv, NULL);
+        dma_buf_unpin(dr->attachment);
+        dma_resv_unlock(dr->dmabuf->resv);
+        dma_buf_detach(dr->dmabuf, dr->attachment);
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return fence_ret;
+    }
     dr->sgt = dma_buf_map_attachment(dr->attachment, DMA_BIDIRECTIONAL);
     dma_resv_unlock(dr->dmabuf->resv);
     if (IS_ERR(dr->sgt))

--- a/drv/map.c
+++ b/drv/map.c
@@ -123,9 +123,6 @@ static struct map* create_descriptor(const struct ctrl* ctrl, u64 vaddr, unsigne
         return ERR_PTR(-ENOMEM);
     }
 
-    list_node_init(&map->list);
-
-    map->owner_pid = get_task_pid(current, PIDTYPE_TGID);
     map->vaddr = vaddr;
     map->pdev = ctrl->pdev;
     map->page_size = 0;
@@ -134,7 +131,6 @@ static struct map* create_descriptor(const struct ctrl* ctrl, u64 vaddr, unsigne
     map->n_addrs = n_pages;
     map->n_dma_mapped = 0;
     atomic_set(&map->invalid, 0);
-    atomic_set(&map->refcount, 1);
 
 
     for (i = 0; i < map->n_addrs; ++i)
@@ -149,319 +145,14 @@ static struct map* create_descriptor(const struct ctrl* ctrl, u64 vaddr, unsigne
 
 void unmap_and_release(struct map* map)
 {
-    list_remove(&map->list);
-
     if (map->release != NULL && map->data != NULL)
     {
         map->release(map);
     }
 
-    if (map->owner_pid != NULL)
-        put_pid(map->owner_pid);
-
     kvfree(map);
 }
 
-
-
-struct map* map_find(const struct list* list, u64 vaddr)
-{
-    const struct list_node* element = list_next(&list->head);
-    struct map* map = NULL;
-    struct map* exact = NULL;
-    struct map* masked = NULL;
-
-    /* Acquire refcounted pid once. get_task_pid returns a referenced
-     * pointer (via get_pid), so we must put_pid before returning. */
-    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
-
-    /* Two-pass lookup: prefer exact vaddr match, fall back to
-     * page-mask match. This prevents a 64 KiB CUDA mapping from
-     * shadowing a 4 KiB dma-buf mapping in the same region. */
-    while (element != NULL)
-    {
-        map = container_of(element, struct map, list);
-
-        if (map->owner_pid == current_pid)
-        {
-            if (map->vaddr == vaddr)
-            {
-                exact = map;
-                break;
-            }
-            if (masked == NULL &&
-                map->page_size > 0 &&
-                map->vaddr == (vaddr & ~((u64)map->page_size - 1)))
-            {
-                masked = map;
-            }
-        }
-
-        element = list_next(element);
-    }
-
-    if (current_pid != NULL)
-        put_pid(current_pid);
-
-    return exact ? exact : masked;
-}
-
-
-
-/*
- * Helper: unlink a list_node from the doubly-linked list.
- * Must be called with the list spinlock held.
- */
-static void list_unlink(struct list_node* element)
-{
-    element->prev->next = element->next;
-    element->next->prev = element->prev;
-    element->list = NULL;
-    element->next = NULL;
-    element->prev = NULL;
-}
-
-/*
- * Helper: find a mapping by exact vaddr or page-masked vaddr
- * for the current task and matching PCI device. Returns the map or NULL.
- * Must be called with the list spinlock held.
- *
- * The pdev match prevents cross-device reuse: two NVMe controllers
- * in the same process must not share DMA addresses.
- */
-static struct map* map_lookup_locked(const struct list* list,
-                                      u64 vaddr,
-                                      const struct pci_dev* pdev,
-                                      unsigned long n_pages,
-                                      unsigned long page_size,
-                                      struct list_node** out_element)
-{
-    struct list_node* element = list_next(&list->head);
-    struct map* exact = NULL;
-    struct map* masked = NULL;
-    struct list_node* masked_element = NULL;
-    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
-
-    while (element != NULL)
-    {
-        struct map* map = container_of(element, struct map, list);
-
-        if (map->owner_pid == current_pid &&
-            (pdev == NULL || map->pdev == pdev) &&
-            (n_pages == 0 || map->n_addrs == n_pages) &&
-            (page_size == 0 || map->page_size == page_size))
-        {
-            if (map->vaddr == vaddr)
-            {
-                exact = map;
-                if (out_element)
-                    *out_element = element;
-                break;
-            }
-            if (masked == NULL &&
-                map->page_size > 0 &&
-                map->vaddr == (vaddr & ~((u64)map->page_size - 1)))
-            {
-                masked = map;
-                masked_element = element;
-            }
-        }
-        element = list_next(element);
-    }
-
-    if (current_pid != NULL)
-        put_pid(current_pid);
-
-    if (exact)
-        return exact;
-
-    if (masked)
-    {
-        if (out_element)
-            *out_element = masked_element;
-        return masked;
-    }
-
-    if (out_element)
-        *out_element = NULL;
-    return NULL;
-}
-
-/*
- * Atomically find an existing mapping and increment its refcount.
- * Matches by (owner_pid, vaddr, pdev). Returns the existing map,
- * or NULL if not found.
- */
-struct map* map_find_and_ref(struct list* list, u64 vaddr,
-                             const struct pci_dev* pdev,
-                             unsigned long n_pages,
-                             unsigned long page_size)
-{
-    struct map* result = NULL;
-
-    spin_lock(&list->lock);
-    {
-        result = map_lookup_locked(list, vaddr, pdev, n_pages, page_size, NULL);
-        if (result != NULL)
-        {
-            int old = atomic_read(&result->refcount);
-            if (old >= 0x7FFFFFFF)
-            {
-                spin_unlock(&list->lock);
-                return ERR_PTR(-EMFILE);
-            }
-            atomic_inc(&result->refcount);
-        }
-    }
-    spin_unlock(&list->lock);
-
-    return result;
-}
-
-/*
- * Decrement a mapping's refcount. If it reaches 0 the mapping is
- * removed from the list and freed.
- *
- * The caller must hold map_create_mutex (or otherwise guarantee no
- * concurrent force_release) to prevent a race with the NVIDIA P2P
- * callback path.
- */
-void map_put_ref(struct map* map)
-{
-    struct list* lst;
-
-    if (map == NULL)
-        return;
-
-    lst = map->list.list;
-    spin_lock(&lst->lock);
-    {
-        if (atomic_dec_and_test(&map->refcount))
-        {
-            list_unlink(&map->list);
-        }
-        else
-        {
-            map = NULL; /* still referenced, don't free */
-        }
-    }
-    spin_unlock(&lst->lock);
-
-    if (map != NULL)
-        unmap_and_release(map);
-}
-
-/*
- * Atomically find and remove (or decrement) a mapping from the list.
- *
- * n_pages=0 and page_size=0 act as wildcards. This is correct for
- * UNMAP because userspace should never create two maps with the same
- * VA on the same controller with different backends; if it does, the
- * exact-match path returns the first matching map deterministically.
- *
- * Returns:
- *   - pointer to the removed map if refcount drops to 0 (caller must
- *     unmap_and_release)
- *   - ERR_PTR(-EAGAIN) if the mapping was found but still referenced
- *     (refcount decremented, not removed)
- *   - NULL if not found
- */
-struct map* map_find_and_remove(struct list* list, u64 vaddr,
-                                const struct pci_dev* pdev)
-{
-    struct map* result = NULL;
-    struct list_node* target_element = NULL;
-
-    spin_lock(&list->lock);
-    {
-        result = map_lookup_locked(list, vaddr, pdev, 0, 0, &target_element);
-        if (result != NULL && target_element != NULL)
-        {
-            if (atomic_dec_and_test(&result->refcount))
-            {
-                /* refcount reached 0: safe to remove */
-                list_unlink(target_element);
-            }
-            else
-            {
-                /* Still in use by another on-the-fly user */
-                result = ERR_PTR(-EAGAIN);
-            }
-        }
-        else
-        {
-            result = NULL;
-        }
-    }
-    spin_unlock(&list->lock);
-
-    return result;
-}
-
-
-
-/*
- * Check if any mapping owned by the current task overlaps the
- * byte range [vaddr, vaddr + n_bytes) on the given list and pdev.
- * Uses proper range-overlap detection so mappings at different
- * page granularities (e.g. 4 KiB dmabuf vs 64 KiB CUDA) are
- * correctly detected even when their base addresses differ.
- *
- * Must be called with map_create_mutex held (serializes against
- * concurrent MAP/UNMAP that could add/remove entries).
- */
-bool map_range_exists(struct list* list, u64 vaddr, u64 n_bytes,
-                      const struct pci_dev* pdev)
-{
-    struct list_node* element;
-    struct pid* current_pid;
-    bool found = false;
-    u64 new_end;
-
-    /* Reject wrapping ranges from user-controlled addresses.
-     * Return true so the caller rejects with -EEXIST rather than
-     * allowing a nonsensical wrapped range to be created. */
-    if (vaddr > U64_MAX - n_bytes)
-        return true;
-
-    new_end = vaddr + n_bytes;
-
-    current_pid = get_task_pid(current, PIDTYPE_TGID);
-
-    spin_lock(&list->lock);
-    {
-        element = list_next(&list->head);
-        while (element != NULL)
-        {
-            struct map* map = container_of(element, struct map, list);
-            u64 existing_end;
-
-            if (map->owner_pid != current_pid ||
-                map->pdev != pdev)
-            {
-                element = list_next(element);
-                continue;
-            }
-
-            existing_end = map->vaddr + (u64)map->n_addrs * (u64)map->page_size;
-
-            /* Standard interval overlap: [a, b) vs [c, d) */
-            if (vaddr < existing_end && new_end > map->vaddr)
-            {
-                found = true;
-                break;
-            }
-
-            element = list_next(element);
-        }
-    }
-    spin_unlock(&list->lock);
-
-    if (current_pid != NULL)
-        put_pid(current_pid);
-
-    return found;
-}
 
 
 static void release_user_pages(struct map* map)
@@ -572,7 +263,7 @@ static long map_user_pages(struct map* map)
 
 
 
-struct map* map_userspace(struct list* list, const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages)
+struct map* map_userspace(const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages)
 {
     long err;
     struct map* md;
@@ -597,9 +288,7 @@ struct map* map_userspace(struct list* list, const struct ctrl* ctrl, u64 vaddr,
         return ERR_PTR(err);
     }
 
-    list_insert(list, &md->list);
-
-    //printk(KERN_DEBUG "Mapped %lu host pages starting at address %llx\n", 
+    //printk(KERN_DEBUG "Mapped %lu host pages starting at address %llx\n",
     //        md->n_addrs, md->vaddr);
     return md;
 }
@@ -845,7 +534,7 @@ int map_gpu_memory(struct map* map, struct list* list)
 
 
 #ifdef _CUDA
-struct map* map_device_memory(struct list* list, const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages, struct list* ctrl_list)
+struct map* map_device_memory(const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages, struct list* ctrl_list)
 {
     int err;
     struct map* md = NULL;
@@ -870,9 +559,7 @@ struct map* map_device_memory(struct list* list, const struct ctrl* ctrl, u64 va
         return ERR_PTR(err);
     }
 
-    list_insert(list, &md->list);
-
-    //printk(KERN_DEBUG "Mapped %lu GPU pages starting at address %llx\n", 
+    //printk(KERN_DEBUG "Mapped %lu GPU pages starting at address %llx\n",
     //        md->n_addrs, md->vaddr);
     return md;
 }
@@ -1175,7 +862,7 @@ fail:
 }
 
 
-struct map* map_dmabuf(struct list* list, const struct ctrl* ctrl,
+struct map* map_dmabuf(const struct ctrl* ctrl,
                         u64 gpu_ptr, int dmabuf_fd,
                         u64 dmabuf_offset, unsigned long n_pages,
                         size_t ioaddrs_capacity)
@@ -1188,7 +875,7 @@ struct map* map_dmabuf(struct list* list, const struct ctrl* ctrl,
         return ERR_PTR(-EINVAL);
     }
 
-    /* Use GPU pointer as vaddr for map_find() lookup on unmap */
+    /* Use GPU pointer as the map's vaddr */
     md = create_descriptor(ctrl, gpu_ptr, n_pages);
     if (IS_ERR(md))
     {
@@ -1203,8 +890,6 @@ struct map* map_dmabuf(struct list* list, const struct ctrl* ctrl,
         unmap_and_release(md);
         return ERR_PTR(err);
     }
-
-    list_insert(list, &md->list);
 
     printk(KERN_DEBUG "uGDS: mapped %lu dmabuf pages starting at gpu_ptr %llx\n",
            md->n_addrs, md->vaddr);

--- a/drv/map.h
+++ b/drv/map.h
@@ -12,14 +12,6 @@
 #include <linux/types.h>
 #include <linux/mm_types.h>
 #include <linux/atomic.h>
-#include <linux/pid.h>
-#include <linux/mutex.h>
-
-/* Serialize map creation, removal, and force_release to prevent
- * concurrent MAP/UNMAP/force_release from racing on the same map.
- * Declared in pci.c, used by force_release_gpu_memory() in map.c.
- */
-extern struct mutex map_create_mutex;
 
 
 /* Forward declaration */
@@ -33,21 +25,22 @@ typedef void (*release)(struct map*);
 
 /*
  * Describes a range of mapped memory.
+ *
+ * Ownership: a map is owned by exactly one map_handle in one file's
+ * ledger (see pci.c). There is no global map list; all lookup and
+ * refcounting happens in the per-file ledger under the file ctx lock.
  */
 struct map
 {
-    struct list_node    list;           /* Linked list header */
-    struct pid*         owner_pid;      /* Refcounted owner process (prevents PID reuse collision) */
-    u64                 vaddr;          /* Starting virtual address */
+    u64                 vaddr;          /* Starting virtual address (aligned) */
     struct list*        ctrl_list;
     struct pci_dev*     pdev;           /* Reference to physical PCI device */
     unsigned long       page_size;      /* Logical page size */
-    void*               data;           /* Custom data (protected by data_lock) */
-    release             release;        /* Custom callback (protected by data_lock) */
+    void*               data;           /* Backend data, handed off via xchg */
+    release             release;        /* Backend release callback */
     unsigned long       n_addrs;        /* Number of mapped pages */
-    unsigned long       n_dma_mapped;   /* Number of successfully DMA-mapped pages (host backend) */
+    unsigned long       n_dma_mapped;   /* Successfully DMA-mapped pages (host backend) */
     atomic_t            invalid;        /* Set by dmabuf move_notify or NVIDIA force_release */
-    atomic_t            refcount;       /* On-the-fly mapping refcount (prevents premature unmap) */
     uint64_t            addrs[1];       /* Bus addresses */
 };
 
@@ -56,7 +49,7 @@ struct map
 /*
  * Lock and map userspace pages for DMA.
  */
-struct map* map_userspace(struct list* list, const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages);
+struct map* map_userspace(const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages);
 
 
 
@@ -71,7 +64,7 @@ void unmap_and_release(struct map* map);
 /*
  * Lock and map GPU device memory.
  */
-struct map* map_device_memory(struct list* list, const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages, struct list* ctrl_list);
+struct map* map_device_memory(const struct ctrl* ctrl, u64 vaddr, unsigned long n_pages, struct list* ctrl_list);
 #endif
 
 
@@ -81,64 +74,12 @@ struct map* map_device_memory(struct list* list, const struct ctrl* ctrl, u64 va
  * Map GPU memory via standard Linux DMA-buf framework.
  * Used by AMD HIP/ROCm backend.
  */
-struct map* map_dmabuf(struct list* list, const struct ctrl* ctrl,
+struct map* map_dmabuf(const struct ctrl* ctrl,
                         u64 gpu_ptr, int dmabuf_fd,
                         u64 dmabuf_offset, unsigned long n_pages,
                         size_t ioaddrs_capacity);
 #endif
 
-
-
-/*
- * Find memory mapping from vaddr and current task
- */
-struct map* map_find(const struct list* list, u64 vaddr);
-
-/*
- * Atomically find an existing mapping and increment its refcount.
- * Returns the existing map, or NULL if not found.
- * The list spinlock is held to prevent concurrent races.
- * Used by on-the-fly map creation to deduplicate concurrent
- * maps of the same (pid, vaddr).
- */
-struct map* map_find_and_ref(struct list* list, u64 vaddr,
-                             const struct pci_dev* pdev,
-                             unsigned long n_pages,
-                             unsigned long page_size);
-
-/*
- * Decrement a mapping's refcount. If it reaches 0 the mapping is
- * removed from the list and freed.
- *
- * The caller must hold map_create_mutex (or otherwise guarantee no
- * concurrent force_release) to prevent a race with the NVIDIA P2P
- * callback path.
- */
-void map_put_ref(struct map* map);
-
-/*
- * Atomically find and remove a mapping from the list.
- * Returns the removed map (caller must unmap_and_release it),
- * NULL if not found, or ERR_PTR(-EAGAIN) if the mapping was
- * found but still referenced by another on-the-fly user
- * (refcount was decremented, not removed). The list spinlock
- * is held during traversal and removal to prevent concurrent
- * races.
- *
- * If pdev is non-NULL, only matches mappings for that PCI device.
- */
-struct map* map_find_and_remove(struct list* list, u64 vaddr,
-                                const struct pci_dev* pdev);
-
-
-/*
- * Check if any mapping owned by the current task on the given
- * list overlaps the byte range [vaddr, vaddr + n_bytes).
- * Returns true if an overlap exists (caller should reject
- * the new mapping with -EEXIST).
- */
-bool map_range_exists(struct list* list, u64 vaddr, u64 n_bytes,
-                      const struct pci_dev* pdev);
 
 
 #ifdef _HIP

--- a/drv/map.h
+++ b/drv/map.h
@@ -12,11 +12,20 @@
 #include <linux/types.h>
 #include <linux/mm_types.h>
 #include <linux/atomic.h>
+#include <linux/pid.h>
+#include <linux/mutex.h>
+
+/* Serialize map creation, removal, and force_release to prevent
+ * concurrent MAP/UNMAP/force_release from racing on the same map.
+ * Declared in pci.c, used by force_release_gpu_memory() in map.c.
+ */
+extern struct mutex map_create_mutex;
 
 
 /* Forward declaration */
 struct ctrl;
 struct map;
+struct pci_dev;
 
 
 typedef void (*release)(struct map*);
@@ -28,15 +37,17 @@ typedef void (*release)(struct map*);
 struct map
 {
     struct list_node    list;           /* Linked list header */
-    struct task_struct* owner;          /* Owner of mapping */
+    struct pid*         owner_pid;      /* Refcounted owner process (prevents PID reuse collision) */
     u64                 vaddr;          /* Starting virtual address */
     struct list*        ctrl_list;
     struct pci_dev*     pdev;           /* Reference to physical PCI device */
     unsigned long       page_size;      /* Logical page size */
-    void*               data;           /* Custom data */
-    release             release;        /* Custom callback for unmapping and releasing memory */
+    void*               data;           /* Custom data (protected by data_lock) */
+    release             release;        /* Custom callback (protected by data_lock) */
     unsigned long       n_addrs;        /* Number of mapped pages */
-    atomic_t            invalid;        /* Set by dmabuf move_notify */
+    unsigned long       n_dma_mapped;   /* Number of successfully DMA-mapped pages (host backend) */
+    atomic_t            invalid;        /* Set by dmabuf move_notify or NVIDIA force_release */
+    atomic_t            refcount;       /* On-the-fly mapping refcount (prevents premature unmap) */
     uint64_t            addrs[1];       /* Bus addresses */
 };
 
@@ -82,6 +93,52 @@ struct map* map_dmabuf(struct list* list, const struct ctrl* ctrl,
  * Find memory mapping from vaddr and current task
  */
 struct map* map_find(const struct list* list, u64 vaddr);
+
+/*
+ * Atomically find an existing mapping and increment its refcount.
+ * Returns the existing map, or NULL if not found.
+ * The list spinlock is held to prevent concurrent races.
+ * Used by on-the-fly map creation to deduplicate concurrent
+ * maps of the same (pid, vaddr).
+ */
+struct map* map_find_and_ref(struct list* list, u64 vaddr,
+                             const struct pci_dev* pdev,
+                             unsigned long n_pages,
+                             unsigned long page_size);
+
+/*
+ * Decrement a mapping's refcount. If it reaches 0 the mapping is
+ * removed from the list and freed.
+ *
+ * The caller must hold map_create_mutex (or otherwise guarantee no
+ * concurrent force_release) to prevent a race with the NVIDIA P2P
+ * callback path.
+ */
+void map_put_ref(struct map* map);
+
+/*
+ * Atomically find and remove a mapping from the list.
+ * Returns the removed map (caller must unmap_and_release it),
+ * NULL if not found, or ERR_PTR(-EAGAIN) if the mapping was
+ * found but still referenced by another on-the-fly user
+ * (refcount was decremented, not removed). The list spinlock
+ * is held during traversal and removal to prevent concurrent
+ * races.
+ *
+ * If pdev is non-NULL, only matches mappings for that PCI device.
+ */
+struct map* map_find_and_remove(struct list* list, u64 vaddr,
+                                const struct pci_dev* pdev);
+
+
+/*
+ * Check if any mapping owned by the current task on the given
+ * list overlaps the byte range [vaddr, vaddr + n_bytes).
+ * Returns true if an overlap exists (caller should reject
+ * the new mapping with -EEXIST).
+ */
+bool map_range_exists(struct list* list, u64 vaddr, u64 n_bytes,
+                      const struct pci_dev* pdev);
 
 
 #ifdef _HIP

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -17,6 +17,7 @@
 #include <linux/pci.h>
 #include <linux/fs.h>
 #include <linux/err.h>
+#include <linux/list.h>
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/version.h>
@@ -39,7 +40,7 @@ MODULE_VERSION("1.0");
 
 
 /* Define a filter for selecting devices we are interested in */
-static const struct pci_device_id id_table[] = 
+static const struct pci_device_id id_table[] =
 {
     { PCI_DEVICE_CLASS(PCI_CLASS_NVME, PCI_CLASS_NVME_MASK) },
     { 0 }
@@ -58,12 +59,18 @@ static struct class* dev_class;
 static struct list ctrl_list;
 
 
-/* List of mapped host memory */
-static struct list host_list;
-
-
-/* List of mapped device memory */
-static struct list device_list;
+/*
+ * Index of open file contexts. This is NOT an ownership ledger --
+ * every registration is owned by exactly one ugds_file_ctx. The
+ * index exists solely so remove_pci_dev can find the files whose
+ * registrations must be torn down when a controller goes away.
+ *
+ * Protected by ctx_list_mutex (a mutex, not a spinlock: the remove
+ * path takes each ctx->lock, which sleeps, while iterating).
+ * Lock order: ctx_list_mutex -> ctx->lock.
+ */
+static LIST_HEAD(ctx_list);
+static DEFINE_MUTEX(ctx_list_mutex);
 
 
 /* Number of devices */
@@ -74,249 +81,406 @@ MODULE_PARM_DESC(max_num_ctrls, "Number of controller devices");
 static int curr_ctrls = 0;
 
 
-static int mmap_registers(struct file* file, struct vm_area_struct* vma)
+enum handle_type
 {
-    struct ctrl* ctrl = NULL;
-    int ret;
+    HANDLE_HOST   = 1,
+    HANDLE_CUDA   = 2,
+    HANDLE_DMABUF = 3,
+};
 
-    /* Serialize against PCI remove which also holds map_create_mutex
-     * before calling ctrl_put/kfree. This protects ctrl lifetime. */
-    mutex_lock(&map_create_mutex);
 
-    ctrl = ctrl_find_by_inode(&ctrl_list, file->f_inode);
-    if (ctrl == NULL)
+/*
+ * Per-open-file registration ledger. One instance per struct file
+ * (dup()/fork/fd-passing share the struct file and thus the ledger;
+ * .release fires exactly once when the last reference closes).
+ */
+struct ugds_file_ctx
+{
+    struct list_head    global_node;    /* ctx_list membership */
+    struct ctrl*        ctrl;           /* Resolved at open, kref held */
+    struct list_head    handles;        /* map_handle ledger */
+    struct mutex        lock;           /* Protects handles and dead */
+    bool                dead;           /* Controller removed */
+};
+
+
+/*
+ * One registration in a file's ledger. Identity is the full parameter
+ * tuple: reuse requires all fields equal; a vaddr match with any other
+ * field differing is -EEXIST (the UNMAP ABI only carries the address,
+ * so two distinct handles at the same vaddr cannot coexist).
+ */
+struct map_handle
+{
+    struct list_head    node;
+    struct map*         map;
+    int                 type;           /* enum handle_type */
+    u64                 vaddr;          /* Raw user address (MAP == UNMAP key) */
+    unsigned long       n_pages;
+    int                 dmabuf_fd;      /* -1 unless HANDLE_DMABUF */
+    u64                 dmabuf_offset;
+    unsigned int        count;          /* Registrations from this file */
+};
+
+
+static struct map_handle* handle_find(struct ugds_file_ctx* ctx, u64 vaddr)
+{
+    struct map_handle* handle;
+
+    list_for_each_entry(handle, &ctx->handles, node)
     {
-        mutex_unlock(&map_create_mutex);
-        printk(KERN_CRIT "Unknown controller reference\n");
-        return -EBADF;
+        if (handle->vaddr == vaddr)
+        {
+            return handle;
+        }
     }
 
-    if (vma->vm_end - vma->vm_start > pci_resource_len(ctrl->pdev, 0))
+    return NULL;
+}
+
+
+static bool map_is_dead(int type, const struct map* map)
+{
+    if (atomic_read(&((struct map*) map)->invalid))
     {
-        mutex_unlock(&map_create_mutex);
+        return true;
+    }
+#ifdef _CUDA
+    /* NVIDIA force_release takes map->data via xchg */
+    if (type == HANDLE_CUDA && map->data == NULL)
+    {
+        return true;
+    }
+#endif
+    return false;
+}
+
+
+static int dev_open(struct inode* inode, struct file* file)
+{
+    struct ugds_file_ctx* ctx;
+    struct ctrl* ctrl;
+
+    ctrl = ctrl_find_and_get_by_inode(&ctrl_list, inode);
+    if (ctrl == NULL)
+    {
+        printk(KERN_NOTICE "Open on unknown or removed controller\n");
+        return -ENODEV;
+    }
+
+    ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
+    if (ctx == NULL)
+    {
+        ctrl_put(ctrl);
+        return -ENOMEM;
+    }
+
+    ctx->ctrl = ctrl;
+    INIT_LIST_HEAD(&ctx->handles);
+    mutex_init(&ctx->lock);
+    ctx->dead = false;
+    file->private_data = ctx;
+
+    mutex_lock(&ctx_list_mutex);
+    list_add(&ctx->global_node, &ctx_list);
+    mutex_unlock(&ctx_list_mutex);
+
+    return 0;
+}
+
+
+static int dev_release(struct inode* inode, struct file* file)
+{
+    struct ugds_file_ctx* ctx = file->private_data;
+    struct map_handle* handle;
+    struct map_handle* next;
+
+    mutex_lock(&ctx_list_mutex);
+    list_del(&ctx->global_node);
+    mutex_unlock(&ctx_list_mutex);
+
+    /* Each handle owns exactly one map regardless of count (count is
+     * the number of registrations, not the number of maps). If the
+     * controller was removed, the ledger is already empty. */
+    mutex_lock(&ctx->lock);
+    list_for_each_entry_safe(handle, next, &ctx->handles, node)
+    {
+        list_del(&handle->node);
+        unmap_and_release(handle->map);
+        kfree(handle);
+    }
+    mutex_unlock(&ctx->lock);
+
+    ctrl_put(ctx->ctrl);
+    kfree(ctx);
+
+    return 0;
+}
+
+
+static int mmap_registers(struct file* file, struct vm_area_struct* vma)
+{
+    struct ugds_file_ctx* ctx = file->private_data;
+    int ret;
+
+    if (mutex_lock_killable(&ctx->lock))
+    {
+        return -EINTR;
+    }
+
+    if (ctx->dead)
+    {
+        mutex_unlock(&ctx->lock);
+        return -ENODEV;
+    }
+
+    if (vma->vm_end - vma->vm_start > pci_resource_len(ctx->ctrl->pdev, 0))
+    {
+        mutex_unlock(&ctx->lock);
         printk(KERN_WARNING "Invalid range size\n");
         return -EINVAL;
     }
 
     vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
-    ret = vm_iomap_memory(vma, pci_resource_start(ctrl->pdev, 0), vma->vm_end - vma->vm_start);
+    ret = vm_iomap_memory(vma, pci_resource_start(ctx->ctrl->pdev, 0),
+                          vma->vm_end - vma->vm_start);
 
-    mutex_unlock(&map_create_mutex);
+    mutex_unlock(&ctx->lock);
     return ret;
 }
 
 
+static long do_map(struct ugds_file_ctx* ctx, enum handle_type type,
+                   u64 vaddr, unsigned long n_pages,
+                   int dmabuf_fd, u64 dmabuf_offset,
+                   void __user* ioaddrs, size_t ioaddrs_capacity)
+{
+    struct map_handle* handle = NULL;
+    struct map* map = NULL;
+    long retval = 0;
 
-/*
- * Serialize on-the-fly map creation for the same (pid, vaddr).
- * Without this, two threads in the same process can race to create
- * duplicate kernel maps, and the second map_find_and_ref would miss
- * the first because it hasn't been list_insert-ed yet.
- */
-DEFINE_MUTEX(map_create_mutex);
+    /* Per-file lock held across pinning and (bounded) fence waits:
+     * only threads sharing this fd wait on each other. */
+    if (mutex_lock_killable(&ctx->lock))
+    {
+        return -EINTR;
+    }
+
+    if (ctx->dead)
+    {
+        retval = -ENODEV;
+        goto out;
+    }
+
+    handle = handle_find(ctx, vaddr);
+    if (handle != NULL)
+    {
+        /* Reuse requires the full identity tuple to match. dmabuf
+         * reuse is disabled entirely: the same gpu_ptr can be
+         * re-exported as a different dmabuf with different DMA
+         * addresses, so fd equality is not a robust identity. */
+        if (type == HANDLE_DMABUF ||
+            handle->type != (int) type ||
+            handle->n_pages != n_pages ||
+            handle->dmabuf_fd != dmabuf_fd ||
+            handle->dmabuf_offset != dmabuf_offset)
+        {
+            retval = -EEXIST;
+            goto out;
+        }
+
+        if (handle->count == UINT_MAX)
+        {
+            retval = -EBUSY;
+            goto out;
+        }
+
+        if (map_is_dead(type, handle->map))
+        {
+            retval = -EIO;
+            goto out;
+        }
+
+        handle->count++;
+        if (copy_to_user(ioaddrs, handle->map->addrs,
+                         handle->map->n_addrs * sizeof(uint64_t)))
+        {
+            handle->count--;
+            retval = -EFAULT;
+            goto out;
+        }
+
+        /* Recheck after copy_to_user: force_release may have fired
+         * during the copy, making the copied addresses stale. */
+        if (map_is_dead(type, handle->map))
+        {
+            handle->count--;
+            retval = -EIO;
+        }
+        goto out;
+    }
+
+    switch (type)
+    {
+        case HANDLE_HOST:
+            map = map_userspace(ctx->ctrl, vaddr, n_pages);
+            break;
+
+#ifdef _CUDA
+        case HANDLE_CUDA:
+            map = map_device_memory(ctx->ctrl, vaddr, n_pages, &ctrl_list);
+            break;
+#endif
+
+#ifdef _HIP
+        case HANDLE_DMABUF:
+            map = map_dmabuf(ctx->ctrl, vaddr, dmabuf_fd, dmabuf_offset,
+                             n_pages, ioaddrs_capacity);
+            break;
+#endif
+
+        default:
+            map = ERR_PTR(-EINVAL);
+            break;
+    }
+
+    if (IS_ERR_OR_NULL(map))
+    {
+        retval = (map == NULL) ? -EIO : PTR_ERR(map);
+        goto out;
+    }
+
+    if (map_is_dead(type, map))
+    {
+        if (type == HANDLE_DMABUF)
+        {
+            printk(KERN_ERR "uGDS: mapping %llx invalidated during setup, "
+                            "pinned VRAM migration detected\n", vaddr);
+        }
+        unmap_and_release(map);
+        retval = -EIO;
+        goto out;
+    }
+
+    if (type == HANDLE_DMABUF && map->n_addrs > ioaddrs_capacity)
+    {
+        unmap_and_release(map);
+        retval = -EOVERFLOW;
+        goto out;
+    }
+
+    handle = kmalloc(sizeof(*handle), GFP_KERNEL);
+    if (handle == NULL)
+    {
+        unmap_and_release(map);
+        retval = -ENOMEM;
+        goto out;
+    }
+
+    if (copy_to_user(ioaddrs, map->addrs, map->n_addrs * sizeof(uint64_t)))
+    {
+        kfree(handle);
+        unmap_and_release(map);
+        retval = -EFAULT;
+        goto out;
+    }
+
+    /* Recheck after copy_to_user (see reuse path comment). Failure
+     * here fully unwinds -- no ledger entry is left behind. */
+    if (map_is_dead(type, map))
+    {
+        kfree(handle);
+        unmap_and_release(map);
+        retval = -EIO;
+        goto out;
+    }
+
+    handle->map = map;
+    handle->type = (int) type;
+    handle->vaddr = vaddr;
+    handle->n_pages = n_pages;
+    handle->dmabuf_fd = dmabuf_fd;
+    handle->dmabuf_offset = dmabuf_offset;
+    handle->count = 1;
+    list_add(&handle->node, &ctx->handles);
+
+out:
+    mutex_unlock(&ctx->lock);
+    return retval;
+}
+
+
+static long do_unmap(struct ugds_file_ctx* ctx, u64 vaddr)
+{
+    struct map_handle* handle;
+    long retval = 0;
+
+    if (mutex_lock_killable(&ctx->lock))
+    {
+        return -EINTR;
+    }
+
+    if (ctx->dead)
+    {
+        retval = -ENODEV;
+        goto out;
+    }
+
+    handle = handle_find(ctx, vaddr);
+    if (handle == NULL)
+    {
+        printk(KERN_WARNING "Mapping for address %llx not found\n", vaddr);
+        retval = -EINVAL;
+        goto out;
+    }
+
+    if (--handle->count == 0)
+    {
+        list_del(&handle->node);
+        unmap_and_release(handle->map);
+        kfree(handle);
+    }
+
+out:
+    mutex_unlock(&ctx->lock);
+    return retval;
+}
+
 
 static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 {
-    long retval = 0;
-    struct ctrl* ctrl = NULL;
+    struct ugds_file_ctx* ctx = file->private_data;
     struct nvm_ioctl_map request;
-    struct map* map = NULL;
     u64 addr;
-
-    /* Hold map_create_mutex for the entire ioctl to protect the
-     * controller lifetime. remove_pci_dev also takes this mutex
-     * before calling ctrl_put/kfree, so holding it guarantees
-     * ctrl stays valid for the duration of this call. */
-    mutex_lock(&map_create_mutex);
-
-    ctrl = ctrl_find_by_inode(&ctrl_list, file->f_inode);
-    if (ctrl == NULL)
-    {
-        mutex_unlock(&map_create_mutex);
-        printk(KERN_CRIT "Unknown controller reference\n");
-        return -EBADF;
-    }
 
     switch (cmd)
     {
         case NVM_MAP_HOST_MEMORY:
             if (copy_from_user(&request, (void __user*) arg, sizeof(request)))
             {
-                retval = -EFAULT;
-                break;
+                return -EFAULT;
             }
-
-            /* Reject n_pages==0 before it reaches map_find_and_ref
-             * where it acts as a wildcard matcher. */
             if (request.n_pages == 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
-
-            map = map_find_and_ref(&host_list, request.vaddr_start, ctrl->pdev, request.n_pages, PAGE_SIZE);
-            if (IS_ERR(map))
-            {
-                retval = PTR_ERR(map);
-                break;
-            }
-            if (map != NULL)
-            {
-                /* Reuse existing mapping */
-                if (copy_to_user((void __user*) request.ioaddrs, map->addrs,
-                                  map->n_addrs * sizeof(uint64_t)))
-                {
-                    map_put_ref(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                /* Recheck after copy_to_user: force_release may have
-                 * fired during the copy. */
-                if (atomic_read(&map->invalid))
-                {
-                    map_put_ref(map);
-                    retval = -EIO;
-                    break;
-                }
-                /* Success: keep the ref. It represents the second
-                 * userspace handle's claim on this shared mapping.
-                 * UNMAP will decrement via map_find_and_remove. */
-                retval = 0;
-                break;
-            }
-
-            /* Reject if an overlapping host mapping already exists
-             * for this (pid, pdev). UNMAP uses wildcard matching
-             * that ignores n_pages, so two host mappings at the
-             * same vaddr with different sizes would be ambiguous. */
-            if (map_range_exists(&host_list, request.vaddr_start,
-                                 (u64)request.n_pages * PAGE_SIZE, ctrl->pdev))
-            {
-                retval = -EEXIST;
-                break;
-            }
-
-            map = map_userspace(&host_list, ctrl, request.vaddr_start, request.n_pages);
-
-            if (!IS_ERR_OR_NULL(map))
-            {
-                if (copy_to_user((void __user*) request.ioaddrs, map->addrs, map->n_addrs * sizeof(uint64_t)))
-                {
-                    unmap_and_release(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                retval = 0;
-            }
-            else
-            {
-                retval = PTR_ERR(map);
-            }
-            break;
+            return do_map(ctx, HANDLE_HOST, request.vaddr_start,
+                          request.n_pages, -1, 0,
+                          (void __user*) request.ioaddrs, SIZE_MAX);
 
 #ifdef _CUDA
         case NVM_MAP_DEVICE_MEMORY:
             if (copy_from_user(&request, (void __user*) arg, sizeof(request)))
             {
-                retval = -EFAULT;
-                break;
+                return -EFAULT;
             }
-
-            /* Reject n_pages==0 before it reaches map_find_and_ref. */
             if (request.n_pages == 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
-
-            /* CUDA P2P maps use 64 KiB GPU pages */
-            map = map_find_and_ref(&device_list, request.vaddr_start, ctrl->pdev, request.n_pages, 0x10000);
-            if (IS_ERR(map))
-            {
-                retval = PTR_ERR(map);
-                break;
-            }
-            if (map != NULL)
-            {
-                /* Reject if NVIDIA force-reclaimed the pages */
-                if (atomic_read(&map->invalid) || map->data == NULL)
-                {
-                    map_put_ref(map);
-                    retval = -EIO;
-                    break;
-                }
-                if (copy_to_user((void __user*) request.ioaddrs, map->addrs,
-                                  map->n_addrs * sizeof(uint64_t)))
-                {
-                    map_put_ref(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                /* Recheck after copy_to_user: force_release may have
-                 * fired during the copy (map_create_mutex does not
-                 * serialize the NVIDIA callback). If so, the DMA
-                 * addresses we just copied out are stale. */
-                if (atomic_read(&map->invalid) || map->data == NULL)
-                {
-                    map_put_ref(map);
-                    retval = -EIO;
-                    break;
-                }
-                /* Success: keep the ref. It represents the second
-                 * userspace handle's claim on this shared mapping.
-                 * UNMAP will decrement via map_find_and_remove. */
-                retval = 0;
-                break;
-            }
-
-            /* Reject if a different backend (dmabuf) already mapped
-             * an overlapping address range on this (pid, pdev).
-             * UNMAP uses wildcard matching and cannot distinguish
-             * backends, so allowing overlapping maps would let
-             * UNMAP remove the wrong one. Uses range-overlap to
-             * catch mappings at different page granularities.
-             *
-             * Use GPU-page-aligned base (same as map_device_memory
-             * stores) so a request at B+0x1000 correctly detects
-             * overlap with an existing map at B. */
-            if (map_range_exists(&device_list, request.vaddr_start & ~(0x10000ULL - 1),
-                                 (u64)request.n_pages * 0x10000ULL, ctrl->pdev))
-            {
-                retval = -EEXIST;
-                break;
-            }
-
-            map = map_device_memory(&device_list, ctrl, request.vaddr_start, request.n_pages, &ctrl_list);
-
-            if (!IS_ERR_OR_NULL(map))
-            {
-                /* Reject if force_release invalidated during setup */
-                if (atomic_read(&map->invalid) || map->data == NULL)
-                {
-                    unmap_and_release(map);
-                    retval = -EIO;
-                    break;
-                }
-                if (copy_to_user((void __user*) request.ioaddrs, map->addrs, map->n_addrs * sizeof(uint64_t)))
-                {
-                    unmap_and_release(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                /* Recheck after copy_to_user (see reuse path comment). */
-                if (atomic_read(&map->invalid) || map->data == NULL)
-                {
-                    unmap_and_release(map);
-                    retval = -EIO;
-                    break;
-                }
-                retval = 0;
-            }
-            else
-            {
-                retval = PTR_ERR(map);
-            }
-            break;
+            return do_map(ctx, HANDLE_CUDA, request.vaddr_start,
+                          request.n_pages, -1, 0,
+                          (void __user*) request.ioaddrs, SIZE_MAX);
 #endif
 
 #ifdef _HIP
@@ -327,280 +491,58 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 
             if (copy_from_user(&dreq, (void __user*) arg, sizeof(dreq)))
             {
-                retval = -EFAULT;
-                break;
+                return -EFAULT;
             }
 
             /* Validate ioctl inputs */
             if (dreq.size == 0 || dreq.size % PAGE_SIZE != 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
             if (dreq.gpu_ptr == 0 || dreq.gpu_ptr % PAGE_SIZE != 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
             if (dreq.ioaddrs == 0 || dreq.ioaddrs_capacity == 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
             /* Validate dmabuf_offset: must be page-aligned (or zero) */
             if (dreq.dmabuf_offset != 0 && dreq.dmabuf_offset % PAGE_SIZE != 0)
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
+            }
+            if (dreq.dmabuf_fd < 0)
+            {
+                return -EINVAL;
             }
 
             n_pages = dreq.size / PAGE_SIZE;
-            if (dreq.dmabuf_fd < 0)
-            {
-                retval = -EINVAL;
-                break;
-            }
             /* Sanity limit: reject absurdly large mappings */
             if (n_pages > 1024*1024) /* 4 GB max for 4 KiB pages */
             {
-                retval = -EINVAL;
-                break;
+                return -EINVAL;
             }
 
-            /* dmabuf reuse is disabled: the same gpu_ptr can be backed
-             * by a different dmabuf_fd with different DMA addresses.
-             * Each dmabuf map creates a new descriptor. */
-            map = NULL;
-            if (map != NULL)
-            {
-                /* Reuse existing mapping */
-                if (atomic_read(&map->invalid))
-                {
-                    map_put_ref(map);
-                    retval = -EIO;
-                    break;
-                }
-                if (map->n_addrs > dreq.ioaddrs_capacity)
-                {
-                    map_put_ref(map);
-                    retval = -EOVERFLOW;
-                    break;
-                }
-                if (copy_to_user((void __user*)(uintptr_t)dreq.ioaddrs, map->addrs,
-                                 map->n_addrs * sizeof(uint64_t)))
-                {
-                    map_put_ref(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                /* Recheck after copy_to_user (dmabuf move_notify race). */
-                if (atomic_read(&map->invalid))
-                {
-                    map_put_ref(map);
-                    retval = -EIO;
-                    break;
-                }
-                /* Success: keep the ref. It represents the second
-                 * userspace handle's claim on this shared mapping.
-                 * UNMAP will decrement via map_find_and_remove. */
-                retval = 0;
-                break;
-            }
-
-            /* Reject if a different backend (CUDA P2P) already mapped
-             * an overlapping address range on this (pid, pdev).
-             * UNMAP uses wildcard matching and cannot distinguish
-             * backends, so allowing overlapping maps would let
-             * UNMAP remove the wrong one. Uses range-overlap to
-             * catch mappings at different page granularities. */
-            if (map_range_exists(&device_list, dreq.gpu_ptr,
-                                 (u64)n_pages * PAGE_SIZE, ctrl->pdev))
-            {
-                retval = -EEXIST;
-                break;
-            }
-
-            map = map_dmabuf(&device_list, ctrl,
-                             dreq.gpu_ptr,
-                             dreq.dmabuf_fd,
-                             dreq.dmabuf_offset,
-                             n_pages,
-                             dreq.ioaddrs_capacity);
-
-            if (!IS_ERR_OR_NULL(map))
-            {
-                /* Fail-stop: reject if VRAM was invalidated during setup */
-                if (atomic_read(&map->invalid))
-                {
-                    printk(KERN_ERR "uGDS: dmabuf mapping %llx invalidated "
-                                    "during setup, pinned VRAM migration detected\n",
-                           dreq.gpu_ptr);
-                    unmap_and_release(map);
-                    retval = -EIO;
-                    break;
-                }
-
-                if (map->n_addrs > dreq.ioaddrs_capacity)
-                {
-                    unmap_and_release(map);
-                    retval = -EOVERFLOW;
-                    break;
-                }
-                if (copy_to_user((void __user*)(uintptr_t)dreq.ioaddrs, map->addrs,
-                                 map->n_addrs * sizeof(uint64_t)))
-                {
-                    unmap_and_release(map);
-                    retval = -EFAULT;
-                    break;
-                }
-                /* Recheck after copy_to_user (dmabuf move_notify race). */
-                if (atomic_read(&map->invalid))
-                {
-                    unmap_and_release(map);
-                    retval = -EIO;
-                    break;
-                }
-                retval = 0;
-            }
-            else
-            {
-                retval = PTR_ERR(map);
-            }
-            break;
+            return do_map(ctx, HANDLE_DMABUF, dreq.gpu_ptr, n_pages,
+                          dreq.dmabuf_fd, dreq.dmabuf_offset,
+                          (void __user*)(uintptr_t) dreq.ioaddrs,
+                          dreq.ioaddrs_capacity);
         }
 #endif
 
         case NVM_UNMAP_MEMORY:
             if (copy_from_user(&addr, (void __user*) arg, sizeof(u64)))
             {
-                retval = -EFAULT;
-                break;
+                return -EFAULT;
             }
-
-            {
-                map = map_find_and_remove(&host_list, addr, ctrl->pdev);
-                if (map == ERR_PTR(-EAGAIN))
-                {
-                    retval = 0;
-                }
-                else if (map != NULL)
-                {
-                    unmap_and_release(map);
-                    retval = 0;
-                }
-                else
-                {
-#ifdef _CUDA
-                    map = map_find_and_remove(&device_list, addr, ctrl->pdev);
-                    if (map == ERR_PTR(-EAGAIN))
-                    {
-                        retval = 0;
-                    }
-                    else if (map != NULL)
-                    {
-                        unmap_and_release(map);
-                        retval = 0;
-                    }
-                    else
-#endif
-                    {
-#ifdef _HIP
-                        map = map_find_and_remove(&device_list, addr, ctrl->pdev);
-                        if (map == ERR_PTR(-EAGAIN))
-                        {
-                            retval = 0;
-                        }
-                        else if (map != NULL)
-                        {
-                            unmap_and_release(map);
-                            retval = 0;
-                        }
-                        else
-#endif
-                        {
-                            retval = -EINVAL;
-                            printk(KERN_WARNING "Mapping for address %llx not found\n", addr);
-                        }
-                    }
-                }
-            }
-            break;
+            return do_unmap(ctx, addr);
 
         default:
             printk(KERN_NOTICE "Unknown ioctl command from process %d: %u\n",
                     current->pid, cmd);
-            retval = -EINVAL;
-            break;
+            return -EINVAL;
     }
-
-    mutex_unlock(&map_create_mutex);
-    return retval;
-}
-
-
-
-/* Clean up all mappings owned by the closing file descriptor's process.
- * Called when userspace closes the device fd without explicit unmap. */
-static int dev_release(struct inode* inode, struct file* file)
-{
-    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
-
-    mutex_lock(&map_create_mutex);
-    {
-        struct list* lists[] = { &host_list, &device_list };
-        int li;
-
-        for (li = 0; li < 2; li++)
-        {
-            struct list_node* element;
-            spin_lock(&lists[li]->lock);
-            element = list_next(&lists[li]->head);
-            while (element != NULL)
-            {
-                struct map* map = container_of(element, struct map, list);
-                struct list_node* next = list_next(element);
-
-                if (map->owner_pid == current_pid)
-                {
-                    /* Decrement refcount. If it reaches 0, unlink and
-                     * free. If still referenced, leave in list for
-                     * NVM_UNMAP_MEMORY to find later.
-                     *
-                     * After unlink (or simple decrement without removal)
-                     * advance via 'next' -- NOT from the list head.
-                     * Restarting from head would re-encounter the same
-                     * entry whose refcount we just decremented, draining
-                     * it to 0 and freeing shared mappings that are still
-                     * in use. */
-                    if (atomic_dec_and_test(&map->refcount))
-                    {
-                        element->prev->next = element->next;
-                        element->next->prev = element->prev;
-                        element->list = NULL;
-                        element->next = NULL;
-                        element->prev = NULL;
-
-                        spin_unlock(&lists[li]->lock);
-                        unmap_and_release(map);
-                        spin_lock(&lists[li]->lock);
-                    }
-
-                    element = next;
-                }
-                else
-                {
-                    element = next;
-                }
-            }
-            spin_unlock(&lists[li]->lock);
-        }
-    }
-    mutex_unlock(&map_create_mutex);
-
-    if (current_pid != NULL)
-        put_pid(current_pid);
-
-    return 0;
 }
 
 
@@ -608,8 +550,9 @@ static int dev_release(struct inode* inode, struct file* file)
 static const struct file_operations dev_fops =
 {
     .owner = THIS_MODULE,
-    .unlocked_ioctl = map_ioctl,
+    .open = dev_open,
     .release = dev_release,
+    .unlocked_ioctl = map_ioctl,
     .mmap = mmap_registers,
 };
 
@@ -629,7 +572,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
             dev->bus->number, PCI_SLOT(dev->devfn), PCI_FUNC(dev->devfn));
 
     // Create controller reference
-    ctrl = ctrl_get(&ctrl_list, dev_class, dev, curr_ctrls);
+    ctrl = ctrl_get(dev_class, dev, curr_ctrls);
     if (IS_ERR(ctrl))
     {
         return PTR_ERR(ctrl);
@@ -675,6 +618,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     {
         printk(KERN_ERR DRIVER_NAME " HIP backend requires 64-bit DMA mask\n");
         pci_clear_master(dev);
+        ctrl_chrdev_remove(ctrl);
         pci_disable_device(dev);
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
@@ -688,6 +632,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         {
             printk(KERN_ERR DRIVER_NAME " failed to set DMA mask\n");
             pci_clear_master(dev);
+            ctrl_chrdev_remove(ctrl);
             pci_disable_device(dev);
             pci_release_region(dev, 0);
             ctrl_put(ctrl);
@@ -698,7 +643,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
 #endif
 
     /* Publish controller to the list only after probe is fully
-     * complete. This prevents ioctls from using a partially
+     * complete. This prevents opens from seeing a partially
      * initialized controller. */
     ctrl_publish(&ctrl_list, ctrl);
 
@@ -710,6 +655,8 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
 static void remove_pci_dev(struct pci_dev* dev)
 {
     struct ctrl* ctrl = NULL;
+    struct ugds_file_ctx* ctx;
+
     printk(KERN_DEBUG DRIVER_NAME " Starting remove_pci_dev\n");
     if (dev == NULL)
     {
@@ -717,96 +664,67 @@ static void remove_pci_dev(struct pci_dev* dev)
         return;
     }
 
-    /* Tear down all maps and the controller under map_create_mutex.
-     * Holding the mutex through ctrl_put prevents new ioctls from
-     * using the controller while it is being removed. */
-    mutex_lock(&map_create_mutex);
+    ctrl = ctrl_find_by_pci_dev(&ctrl_list, dev);
+    if (ctrl == NULL)
     {
-        struct list* lists[] = { &host_list, &device_list };
-        int li;
+        /* Device was never adopted (probe capped by max_num_ctrls). */
+        return;
+    }
 
-        for (li = 0; li < 2; li++)
+    /* 1. Unpublish: new opens can no longer find this controller.
+     *    (list_remove takes the list spinlock -- same lock domain as
+     *    ctrl_find_and_get_by_inode.) */
+    list_remove(&ctrl->list);
+
+    /* 2. Device node disappears. */
+    ctrl_chrdev_remove(ctrl);
+
+    /* 3. Settle accounts: for every open file on this controller,
+     *    tear down its registrations and mark it dead. Acquiring
+     *    ctx->lock means no MAP/UNMAP is in flight on that file;
+     *    in-flight operations finish first (bounded: fence waits
+     *    are capped at 10s). */
+    mutex_lock(&ctx_list_mutex);
+    list_for_each_entry(ctx, &ctx_list, global_node)
+    {
+        struct map_handle* handle;
+        struct map_handle* next;
+
+        if (ctx->ctrl != ctrl)
         {
-            struct list_node* element;
-            spin_lock(&lists[li]->lock);
-            element = list_next(&lists[li]->head);
-            while (element != NULL)
-            {
-                struct map* map = container_of(element, struct map, list);
-                struct list_node* next = list_next(element);
-
-                if (map->pdev == dev)
-                {
-                    element->prev->next = element->next;
-                    element->next->prev = element->prev;
-                    element->list = NULL;
-                    element->next = NULL;
-                    element->prev = NULL;
-
-                    spin_unlock(&lists[li]->lock);
-                    unmap_and_release(map);
-                    spin_lock(&lists[li]->lock);
-
-                    element = list_next(&lists[li]->head);
-                }
-                else
-                {
-                    element = next;
-                }
-            }
-            spin_unlock(&lists[li]->lock);
+            continue;
         }
 
-        /* Remove controller from list and destroy char device
-         * while holding map_create_mutex so no new MAP ioctls
-         * can start on this controller. */
-        ctrl = ctrl_find_by_pci_dev(&ctrl_list, dev);
-        if (ctrl != NULL)
-            ctrl_put(ctrl);
+        mutex_lock(&ctx->lock);
+        list_for_each_entry_safe(handle, next, &ctx->handles, node)
+        {
+            list_del(&handle->node);
+            unmap_and_release(handle->map);
+            kfree(handle);
+        }
+        ctx->dead = true;
+        mutex_unlock(&ctx->lock);
     }
-    mutex_unlock(&map_create_mutex);
+    mutex_unlock(&ctx_list_mutex);
 
+    /* 4. All DMA on this controller is now unmapped, satisfying the
+     *    DMA API contract before the device goes away. */
     --curr_ctrls;
-
-    // Release device memory
     pci_release_region(dev, 0);
-
-    // Disable PCI device
     pci_clear_master(dev);
     pci_disable_device(dev);
+
+    /* 5. Drop the probe reference. Open files still hold theirs;
+     *    the ctrl is freed when the last one closes. */
+    ctrl_put(ctrl);
 
     printk(KERN_DEBUG "Controller device removed: %02x:%02x.%1x\n",
             dev->bus->number, PCI_SLOT(dev->devfn), PCI_FUNC(dev->devfn));
 }
 
 
-static unsigned long clear_map_list(struct list* list)
-{
-    unsigned long i = 0;
-    struct list_node* ptr;
-    struct map* map;
-
-    mutex_lock(&map_create_mutex);
-    {
-        ptr = list_next(&list->head);
-        while (ptr != NULL)
-        {
-            map = container_of(ptr, struct map, list);
-            unmap_and_release(map);
-            ++i;
-
-            ptr = list_next(&list->head);
-        }
-    }
-    mutex_unlock(&map_create_mutex);
-
-    return i;
-}
-
-
-
 /* Define driver operations we support */
-static struct pci_driver driver = 
+static struct pci_driver driver =
 {
     .name = DRIVER_NAME,
     .id_table = id_table,
@@ -820,8 +738,6 @@ static int __init ugds_drv_entry(void)
     int err;
 
     list_init(&ctrl_list);
-    list_init(&host_list);
-    list_init(&device_list);
 
     // Set up character device creation
     err = alloc_chrdev_region(&dev_first, 0, max_num_ctrls, DRIVER_NAME);
@@ -862,19 +778,10 @@ module_init(ugds_drv_entry);
 
 static void __exit ugds_drv_exit(void)
 {
-    unsigned long remaining = 0;
-
-    remaining = clear_map_list(&device_list);
-    if (remaining != 0)
-    {
-        printk(KERN_NOTICE "%lu GPU memory mappings were still in use on unload\n", remaining);
-    }
-
-    remaining = clear_map_list(&host_list);
-    if (remaining != 0)
-    {
-        printk(KERN_NOTICE "%lu host memory mappings were still in use on unload\n", remaining);
-    }
+    /* fops.owner pins the module while any file is open, so at this
+     * point there are no live ctxs or maps from normal operation;
+     * hot-remove/unbind teardown is handled by remove_pci_dev.
+     * pci_unregister_driver invokes remove for every bound device. */
     printk(KERN_DEBUG DRIVER_NAME " Before pci_unregister_driver\n");
     pci_unregister_driver(&driver);
     printk(KERN_DEBUG DRIVER_NAME " After pci_unregister_driver\n");

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -17,6 +17,7 @@
 #include <linux/pci.h>
 #include <linux/fs.h>
 #include <linux/err.h>
+#include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/version.h>
 #include <linux/uaccess.h>
@@ -76,25 +77,43 @@ static int curr_ctrls = 0;
 static int mmap_registers(struct file* file, struct vm_area_struct* vma)
 {
     struct ctrl* ctrl = NULL;
+    int ret;
+
+    /* Serialize against PCI remove which also holds map_create_mutex
+     * before calling ctrl_put/kfree. This protects ctrl lifetime. */
+    mutex_lock(&map_create_mutex);
 
     ctrl = ctrl_find_by_inode(&ctrl_list, file->f_inode);
     if (ctrl == NULL)
     {
+        mutex_unlock(&map_create_mutex);
         printk(KERN_CRIT "Unknown controller reference\n");
         return -EBADF;
     }
 
     if (vma->vm_end - vma->vm_start > pci_resource_len(ctrl->pdev, 0))
     {
+        mutex_unlock(&map_create_mutex);
         printk(KERN_WARNING "Invalid range size\n");
         return -EINVAL;
     }
 
     vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
-    return vm_iomap_memory(vma, pci_resource_start(ctrl->pdev, 0), vma->vm_end - vma->vm_start);
+    ret = vm_iomap_memory(vma, pci_resource_start(ctrl->pdev, 0), vma->vm_end - vma->vm_start);
+
+    mutex_unlock(&map_create_mutex);
+    return ret;
 }
 
 
+
+/*
+ * Serialize on-the-fly map creation for the same (pid, vaddr).
+ * Without this, two threads in the same process can race to create
+ * duplicate kernel maps, and the second map_find_and_ref would miss
+ * the first because it hasn't been list_insert-ed yet.
+ */
+DEFINE_MUTEX(map_create_mutex);
 
 static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 {
@@ -104,9 +123,16 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
     struct map* map = NULL;
     u64 addr;
 
+    /* Hold map_create_mutex for the entire ioctl to protect the
+     * controller lifetime. remove_pci_dev also takes this mutex
+     * before calling ctrl_put/kfree, so holding it guarantees
+     * ctrl stays valid for the duration of this call. */
+    mutex_lock(&map_create_mutex);
+
     ctrl = ctrl_find_by_inode(&ctrl_list, file->f_inode);
     if (ctrl == NULL)
     {
+        mutex_unlock(&map_create_mutex);
         printk(KERN_CRIT "Unknown controller reference\n");
         return -EBADF;
     }
@@ -116,7 +142,58 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
         case NVM_MAP_HOST_MEMORY:
             if (copy_from_user(&request, (void __user*) arg, sizeof(request)))
             {
-                return -EFAULT;
+                retval = -EFAULT;
+                break;
+            }
+
+            /* Reject n_pages==0 before it reaches map_find_and_ref
+             * where it acts as a wildcard matcher. */
+            if (request.n_pages == 0)
+            {
+                retval = -EINVAL;
+                break;
+            }
+
+            map = map_find_and_ref(&host_list, request.vaddr_start, ctrl->pdev, request.n_pages, PAGE_SIZE);
+            if (IS_ERR(map))
+            {
+                retval = PTR_ERR(map);
+                break;
+            }
+            if (map != NULL)
+            {
+                /* Reuse existing mapping */
+                if (copy_to_user((void __user*) request.ioaddrs, map->addrs,
+                                  map->n_addrs * sizeof(uint64_t)))
+                {
+                    map_put_ref(map);
+                    retval = -EFAULT;
+                    break;
+                }
+                /* Recheck after copy_to_user: force_release may have
+                 * fired during the copy. */
+                if (atomic_read(&map->invalid))
+                {
+                    map_put_ref(map);
+                    retval = -EIO;
+                    break;
+                }
+                /* Success: keep the ref. It represents the second
+                 * userspace handle's claim on this shared mapping.
+                 * UNMAP will decrement via map_find_and_remove. */
+                retval = 0;
+                break;
+            }
+
+            /* Reject if an overlapping host mapping already exists
+             * for this (pid, pdev). UNMAP uses wildcard matching
+             * that ignores n_pages, so two host mappings at the
+             * same vaddr with different sizes would be ambiguous. */
+            if (map_range_exists(&host_list, request.vaddr_start,
+                                 (u64)request.n_pages * PAGE_SIZE, ctrl->pdev))
+            {
+                retval = -EEXIST;
+                break;
             }
 
             map = map_userspace(&host_list, ctrl, request.vaddr_start, request.n_pages);
@@ -125,11 +202,13 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             {
                 if (copy_to_user((void __user*) request.ioaddrs, map->addrs, map->n_addrs * sizeof(uint64_t)))
                 {
-                    return -EFAULT;
+                    unmap_and_release(map);
+                    retval = -EFAULT;
+                    break;
                 }
                 retval = 0;
             }
-            else 
+            else
             {
                 retval = PTR_ERR(map);
             }
@@ -139,20 +218,101 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
         case NVM_MAP_DEVICE_MEMORY:
             if (copy_from_user(&request, (void __user*) arg, sizeof(request)))
             {
-                return -EFAULT;
+                retval = -EFAULT;
+                break;
+            }
+
+            /* Reject n_pages==0 before it reaches map_find_and_ref. */
+            if (request.n_pages == 0)
+            {
+                retval = -EINVAL;
+                break;
+            }
+
+            /* CUDA P2P maps use 64 KiB GPU pages */
+            map = map_find_and_ref(&device_list, request.vaddr_start, ctrl->pdev, request.n_pages, 0x10000);
+            if (IS_ERR(map))
+            {
+                retval = PTR_ERR(map);
+                break;
+            }
+            if (map != NULL)
+            {
+                /* Reject if NVIDIA force-reclaimed the pages */
+                if (atomic_read(&map->invalid) || map->data == NULL)
+                {
+                    map_put_ref(map);
+                    retval = -EIO;
+                    break;
+                }
+                if (copy_to_user((void __user*) request.ioaddrs, map->addrs,
+                                  map->n_addrs * sizeof(uint64_t)))
+                {
+                    map_put_ref(map);
+                    retval = -EFAULT;
+                    break;
+                }
+                /* Recheck after copy_to_user: force_release may have
+                 * fired during the copy (map_create_mutex does not
+                 * serialize the NVIDIA callback). If so, the DMA
+                 * addresses we just copied out are stale. */
+                if (atomic_read(&map->invalid) || map->data == NULL)
+                {
+                    map_put_ref(map);
+                    retval = -EIO;
+                    break;
+                }
+                /* Success: keep the ref. It represents the second
+                 * userspace handle's claim on this shared mapping.
+                 * UNMAP will decrement via map_find_and_remove. */
+                retval = 0;
+                break;
+            }
+
+            /* Reject if a different backend (dmabuf) already mapped
+             * an overlapping address range on this (pid, pdev).
+             * UNMAP uses wildcard matching and cannot distinguish
+             * backends, so allowing overlapping maps would let
+             * UNMAP remove the wrong one. Uses range-overlap to
+             * catch mappings at different page granularities.
+             *
+             * Use GPU-page-aligned base (same as map_device_memory
+             * stores) so a request at B+0x1000 correctly detects
+             * overlap with an existing map at B. */
+            if (map_range_exists(&device_list, request.vaddr_start & ~(0x10000ULL - 1),
+                                 (u64)request.n_pages * 0x10000ULL, ctrl->pdev))
+            {
+                retval = -EEXIST;
+                break;
             }
 
             map = map_device_memory(&device_list, ctrl, request.vaddr_start, request.n_pages, &ctrl_list);
 
             if (!IS_ERR_OR_NULL(map))
             {
+                /* Reject if force_release invalidated during setup */
+                if (atomic_read(&map->invalid) || map->data == NULL)
+                {
+                    unmap_and_release(map);
+                    retval = -EIO;
+                    break;
+                }
                 if (copy_to_user((void __user*) request.ioaddrs, map->addrs, map->n_addrs * sizeof(uint64_t)))
                 {
-                    return -EFAULT;
+                    unmap_and_release(map);
+                    retval = -EFAULT;
+                    break;
+                }
+                /* Recheck after copy_to_user (see reuse path comment). */
+                if (atomic_read(&map->invalid) || map->data == NULL)
+                {
+                    unmap_and_release(map);
+                    retval = -EIO;
+                    break;
                 }
                 retval = 0;
             }
-            else 
+            else
             {
                 retval = PTR_ERR(map);
             }
@@ -167,7 +327,8 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 
             if (copy_from_user(&dreq, (void __user*) arg, sizeof(dreq)))
             {
-                return -EFAULT;
+                retval = -EFAULT;
+                break;
             }
 
             /* Validate ioctl inputs */
@@ -206,6 +367,59 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                 break;
             }
 
+            /* dmabuf reuse is disabled: the same gpu_ptr can be backed
+             * by a different dmabuf_fd with different DMA addresses.
+             * Each dmabuf map creates a new descriptor. */
+            map = NULL;
+            if (map != NULL)
+            {
+                /* Reuse existing mapping */
+                if (atomic_read(&map->invalid))
+                {
+                    map_put_ref(map);
+                    retval = -EIO;
+                    break;
+                }
+                if (map->n_addrs > dreq.ioaddrs_capacity)
+                {
+                    map_put_ref(map);
+                    retval = -EOVERFLOW;
+                    break;
+                }
+                if (copy_to_user((void __user*)(uintptr_t)dreq.ioaddrs, map->addrs,
+                                 map->n_addrs * sizeof(uint64_t)))
+                {
+                    map_put_ref(map);
+                    retval = -EFAULT;
+                    break;
+                }
+                /* Recheck after copy_to_user (dmabuf move_notify race). */
+                if (atomic_read(&map->invalid))
+                {
+                    map_put_ref(map);
+                    retval = -EIO;
+                    break;
+                }
+                /* Success: keep the ref. It represents the second
+                 * userspace handle's claim on this shared mapping.
+                 * UNMAP will decrement via map_find_and_remove. */
+                retval = 0;
+                break;
+            }
+
+            /* Reject if a different backend (CUDA P2P) already mapped
+             * an overlapping address range on this (pid, pdev).
+             * UNMAP uses wildcard matching and cannot distinguish
+             * backends, so allowing overlapping maps would let
+             * UNMAP remove the wrong one. Uses range-overlap to
+             * catch mappings at different page granularities. */
+            if (map_range_exists(&device_list, dreq.gpu_ptr,
+                                 (u64)n_pages * PAGE_SIZE, ctrl->pdev))
+            {
+                retval = -EEXIST;
+                break;
+            }
+
             map = map_dmabuf(&device_list, ctrl,
                              dreq.gpu_ptr,
                              dreq.dmabuf_fd,
@@ -236,7 +450,15 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                                  map->n_addrs * sizeof(uint64_t)))
                 {
                     unmap_and_release(map);
-                    return -EFAULT;
+                    retval = -EFAULT;
+                    break;
+                }
+                /* Recheck after copy_to_user (dmabuf move_notify race). */
+                if (atomic_read(&map->invalid))
+                {
+                    unmap_and_release(map);
+                    retval = -EIO;
+                    break;
                 }
                 retval = 0;
             }
@@ -251,35 +473,57 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
         case NVM_UNMAP_MEMORY:
             if (copy_from_user(&addr, (void __user*) arg, sizeof(u64)))
             {
-                return -EFAULT;
-            }
-
-            map = map_find(&host_list, addr);
-            if (map != NULL)
-            {
-                unmap_and_release(map);
+                retval = -EFAULT;
                 break;
             }
 
+            {
+                map = map_find_and_remove(&host_list, addr, ctrl->pdev);
+                if (map == ERR_PTR(-EAGAIN))
+                {
+                    retval = 0;
+                }
+                else if (map != NULL)
+                {
+                    unmap_and_release(map);
+                    retval = 0;
+                }
+                else
+                {
 #ifdef _CUDA
-            map = map_find(&device_list, addr);
-            if (map != NULL)
-            {
-                unmap_and_release(map);
-                break;
-            }
+                    map = map_find_and_remove(&device_list, addr, ctrl->pdev);
+                    if (map == ERR_PTR(-EAGAIN))
+                    {
+                        retval = 0;
+                    }
+                    else if (map != NULL)
+                    {
+                        unmap_and_release(map);
+                        retval = 0;
+                    }
+                    else
 #endif
-
+                    {
 #ifdef _HIP
-            map = map_find(&device_list, addr);
-            if (map != NULL)
-            {
-                unmap_and_release(map);
-                break;
-            }
+                        map = map_find_and_remove(&device_list, addr, ctrl->pdev);
+                        if (map == ERR_PTR(-EAGAIN))
+                        {
+                            retval = 0;
+                        }
+                        else if (map != NULL)
+                        {
+                            unmap_and_release(map);
+                            retval = 0;
+                        }
+                        else
 #endif
-            retval = -EINVAL;
-            printk(KERN_WARNING "Mapping for address %llx not found\n", addr);
+                        {
+                            retval = -EINVAL;
+                            printk(KERN_WARNING "Mapping for address %llx not found\n", addr);
+                        }
+                    }
+                }
+            }
             break;
 
         default:
@@ -289,16 +533,83 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             break;
     }
 
+    mutex_unlock(&map_create_mutex);
     return retval;
 }
 
 
 
+/* Clean up all mappings owned by the closing file descriptor's process.
+ * Called when userspace closes the device fd without explicit unmap. */
+static int dev_release(struct inode* inode, struct file* file)
+{
+    struct pid* current_pid = get_task_pid(current, PIDTYPE_TGID);
+
+    mutex_lock(&map_create_mutex);
+    {
+        struct list* lists[] = { &host_list, &device_list };
+        int li;
+
+        for (li = 0; li < 2; li++)
+        {
+            struct list_node* element;
+            spin_lock(&lists[li]->lock);
+            element = list_next(&lists[li]->head);
+            while (element != NULL)
+            {
+                struct map* map = container_of(element, struct map, list);
+                struct list_node* next = list_next(element);
+
+                if (map->owner_pid == current_pid)
+                {
+                    /* Decrement refcount. If it reaches 0, unlink and
+                     * free. If still referenced, leave in list for
+                     * NVM_UNMAP_MEMORY to find later.
+                     *
+                     * After unlink (or simple decrement without removal)
+                     * advance via 'next' -- NOT from the list head.
+                     * Restarting from head would re-encounter the same
+                     * entry whose refcount we just decremented, draining
+                     * it to 0 and freeing shared mappings that are still
+                     * in use. */
+                    if (atomic_dec_and_test(&map->refcount))
+                    {
+                        element->prev->next = element->next;
+                        element->next->prev = element->prev;
+                        element->list = NULL;
+                        element->next = NULL;
+                        element->prev = NULL;
+
+                        spin_unlock(&lists[li]->lock);
+                        unmap_and_release(map);
+                        spin_lock(&lists[li]->lock);
+                    }
+
+                    element = next;
+                }
+                else
+                {
+                    element = next;
+                }
+            }
+            spin_unlock(&lists[li]->lock);
+        }
+    }
+    mutex_unlock(&map_create_mutex);
+
+    if (current_pid != NULL)
+        put_pid(current_pid);
+
+    return 0;
+}
+
+
 /* Define file operations for device file */
-static const struct file_operations dev_fops = 
+static const struct file_operations dev_fops =
 {
     .owner = THIS_MODULE,
     .unlocked_ioctl = map_ioctl,
+    .release = dev_release,
     .mmap = mmap_registers,
 };
 
@@ -356,7 +667,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     // Enable DMA
     pci_set_master(dev);
 
-#ifdef _HIP
+#if defined(_HIP)
     /* HIP backend requires 64-bit DMA for P2P VRAM addresses (large BAR).
      * 32-bit fallback is intentionally a hard failure -- AMD GPU P2P
      * DMA requires 64-bit addressing. */
@@ -369,7 +680,27 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         ctrl_put(ctrl);
         return -EIO;
     }
+#else
+    /* Default CUDA: try 64-bit, fall back to 32-bit. */
+    if (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(64)))
+    {
+        if (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(32)))
+        {
+            printk(KERN_ERR DRIVER_NAME " failed to set DMA mask\n");
+            pci_clear_master(dev);
+            pci_disable_device(dev);
+            pci_release_region(dev, 0);
+            ctrl_put(ctrl);
+            return -EIO;
+        }
+        printk(KERN_WARNING DRIVER_NAME " using 32-bit DMA mask\n");
+    }
 #endif
+
+    /* Publish controller to the list only after probe is fully
+     * complete. This prevents ioctls from using a partially
+     * initialized controller. */
+    ctrl_publish(&ctrl_list, ctrl);
 
     ++curr_ctrls;
     return 0;
@@ -386,11 +717,56 @@ static void remove_pci_dev(struct pci_dev* dev)
         return;
     }
 
-    --curr_ctrls;
+    /* Tear down all maps and the controller under map_create_mutex.
+     * Holding the mutex through ctrl_put prevents new ioctls from
+     * using the controller while it is being removed. */
+    mutex_lock(&map_create_mutex);
+    {
+        struct list* lists[] = { &host_list, &device_list };
+        int li;
 
-    // Find controller reference
-    ctrl = ctrl_find_by_pci_dev(&ctrl_list, dev);
-    ctrl_put(ctrl);
+        for (li = 0; li < 2; li++)
+        {
+            struct list_node* element;
+            spin_lock(&lists[li]->lock);
+            element = list_next(&lists[li]->head);
+            while (element != NULL)
+            {
+                struct map* map = container_of(element, struct map, list);
+                struct list_node* next = list_next(element);
+
+                if (map->pdev == dev)
+                {
+                    element->prev->next = element->next;
+                    element->next->prev = element->prev;
+                    element->list = NULL;
+                    element->next = NULL;
+                    element->prev = NULL;
+
+                    spin_unlock(&lists[li]->lock);
+                    unmap_and_release(map);
+                    spin_lock(&lists[li]->lock);
+
+                    element = list_next(&lists[li]->head);
+                }
+                else
+                {
+                    element = next;
+                }
+            }
+            spin_unlock(&lists[li]->lock);
+        }
+
+        /* Remove controller from list and destroy char device
+         * while holding map_create_mutex so no new MAP ioctls
+         * can start on this controller. */
+        ctrl = ctrl_find_by_pci_dev(&ctrl_list, dev);
+        if (ctrl != NULL)
+            ctrl_put(ctrl);
+    }
+    mutex_unlock(&map_create_mutex);
+
+    --curr_ctrls;
 
     // Release device memory
     pci_release_region(dev, 0);
@@ -407,17 +783,22 @@ static void remove_pci_dev(struct pci_dev* dev)
 static unsigned long clear_map_list(struct list* list)
 {
     unsigned long i = 0;
-    struct list_node* ptr = list_next(&list->head);
+    struct list_node* ptr;
     struct map* map;
 
-    while (ptr != NULL)
+    mutex_lock(&map_create_mutex);
     {
-        map = container_of(ptr, struct map, list);
-        unmap_and_release(map);
-        ++i;
-
         ptr = list_next(&list->head);
+        while (ptr != NULL)
+        {
+            map = container_of(ptr, struct map, list);
+            unmap_and_release(map);
+            ++i;
+
+            ptr = list_next(&list->head);
+        }
     }
+    mutex_unlock(&map_create_mutex);
 
     return i;
 }


### PR DESCRIPTION
## Summary

Comprehensive safety hardening for the uGDS kernel driver (`drv/`). All changes are confined to `drv/` and do not touch userspace code.

## Changes

- **Atomic map operations**: `map_find_and_ref` / `map_find_and_remove` with refcounting to prevent use-after-free under concurrent access
- **PID-based owner tracking** (refcounted) to prevent PID reuse collision
- **Range-overlap detection** (`map_range_exists`) for cross-backend collision prevention
- **NVIDIA P2P callback-safe ownership model** with `xchg`-based handoff -- after `xchg(&map->data, NULL)`, the callback only uses local variables, never dereferences `map`
- **Deferred `map->data` publish** until setup completes; `gd` stays private until fully initialized
- **Per-iteration invalid check** in DMA-map loop to abort early if callback fires mid-setup
- **`pin_user_pages(FOLL_LONGTERM)`** for host memory mappings
- **`.release` handler** for fd cleanup on process crash
- **PCI remove cleanup** under `map_create_mutex`
- **`ctrl_publish` deferred** until probe completes
- **`map_create_mutex` held for entire ioctl** to protect ctrl lifetime
- **`dev_release` advances via saved next pointer** (no drain-to-zero)
- **dmabuf safety**: `dma_resv` fence wait, SG alignment check, overflow guard
- **Version-gated** `unpin_user_page` / `put_page` compatibility
- **Refcount cap** to prevent wraparound
- **Dynamic controller snapshot**: GPU mapping counts controllers at runtime instead of using `max_num_ctrls`, takes `pci_dev_get()` references
- **Map lookup precision**: matches by exact VA, `pdev`, `n_pages`, and `page_size` (not just page-mask)
- **Host GUP partial-failure handling**: short pin is treated as failure, pinned pages unwound, `n_dma_mapped` tracks only successful DMA-mapped pages
- **NVIDIA P2P entries validation**: `gd->pages->entries == map->n_addrs`, DMA addresses copied from matching `pdev` mapping
- **Descriptor allocation guard**: rejects `n_pages == 0` to prevent flexible-array overflow

## Build

Kernel module only (no userspace changes). Builds with both CUDA and HIP backends.

| Backend | Status |
|---------|--------|
| CUDA | Pass |
| HIP | Pass |

## Stack

This PR is part of a 3-PR stack. Review/merge in order:

1. **#19** (this PR): kernel hardening
2. **#21**: dual-backend infra -- [incremental diff](https://github.com/potatogim/uGDS/compare/kernel-hardening...dual-backend-infra)
3. **#16**: fd export -- [incremental diff](https://github.com/potatogim/uGDS/compare/dual-backend-infra...fd-export)

Since these are fork-based PRs targeting `main`, the GitHub "Files changed" tab for #21 and #16 includes changes from prerequisite PRs. Use the incremental diff links above to review only the changes specific to each PR.

