### PR TITLE
feat: add dual-backend abstraction and handle lifetime management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ find_package(Threads REQUIRED)
 option(UGDS_BACKEND_CUDA "Use NVIDIA CUDA backend" ON)
 option(UGDS_BACKEND_HIP  "Use AMD HIP backend"     OFF)
 
-# Both backends can be enabled simultaneously for dual-GPU systems.
+# Both backends can be enabled simultaneously. The async API uses void*
+# for stream parameters to avoid cudaStream_t/hipStream_t type conflicts.
 
 # HIP language support requires CMake >= 3.21
 if(UGDS_BACKEND_HIP AND CMAKE_VERSION VERSION_LESS "3.21")
@@ -26,6 +27,7 @@ set(UGDS_CUDA_ARCHITECTURES "80;90")
 if(UGDS_BACKEND_CUDA)
     find_package(CUDAToolkit REQUIRED)
     set(UGDS_CUDA_INCLUDES ${CUDAToolkit_INCLUDE_DIRS})
+    list(APPEND UGDS_CUDA_LIBS CUDA::cudart)
 endif()
 
 # - HIP backend setup (independent) ------------
@@ -85,6 +87,7 @@ if(NOT UGDS_BACKEND_CUDA AND NOT UGDS_BACKEND_HIP)
     message(WARNING "No GPU backend selected, building library only")
 endif()
 
+
 # Library sources
 set(UGDS_SOURCES
     src/libnvm/admin.cpp
@@ -114,23 +117,22 @@ target_include_directories(ugds
 )
 
 # Backend includes and compile definitions (independent)
-target_link_libraries(ugds PRIVATE Threads::Threads)
-
 if(UGDS_BACKEND_CUDA)
     target_include_directories(ugds PRIVATE ${UGDS_CUDA_INCLUDES})
     target_compile_definitions(ugds PRIVATE _CUDA)
-    target_link_libraries(ugds PRIVATE CUDA::cudart)
+    target_link_libraries(ugds PRIVATE ${UGDS_CUDA_LIBS})
 endif()
 
 if(UGDS_BACKEND_HIP)
     target_include_directories(ugds PRIVATE ${UGDS_HIP_INCLUDES})
     target_link_libraries(ugds PRIVATE ${UGDS_HIP_LIBS})
-    target_compile_definitions(ugds PRIVATE _HIP)
+    target_compile_definitions(ugds PRIVATE _HIP __HIP_PLATFORM_AMD__)
     if(HAVE_HSA_DMABUF_V2)
         target_compile_definitions(ugds PRIVATE HAVE_HSA_DMABUF_V2)
     endif()
 endif()
 
+target_link_libraries(ugds PRIVATE Threads::Threads)
 target_compile_options(ugds PRIVATE -Wall -O2)
 
 # - Tests and benchmarks -----------------------

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,8 @@ Buffers registered with `uGDSBufRegister()` must not be modified by the GPU (HIP
 
 **Important:** Each backend used at runtime must be enabled in both the kernel module and the userspace library. For example, a CUDA-only kernel module will reject HIP `uGDSBufRegister()` calls. In dual-backend builds, use `uGDSBufRegister(ptr, size, UGDS_REGISTER_DMABUF)` for AMD buffers and `uGDSBufRegister(ptr, size, 0)` for NVIDIA buffers (default).
 
+**Note:** In dual-backend builds, unregistered AMD buffers (on-the-fly I/O without prior `uGDSBufRegister`) are not supported. AMD buffers must be explicitly registered before I/O. NVIDIA buffers support both registered and unregistered paths.
+
 ## Step 1: Build the Kernel Module
 
 The kernel module (`ugds_drv.ko`) provides PCI BAR mapping and GPU page pinning for user-space NVMe access.

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -3,14 +3,24 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <time.h>
-#if defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
-#include <hip/hip_runtime.h>
-typedef hipStream_t cudaStream_t;
-#else
-#include <cuda_runtime.h>
-#endif
+
+/* Buffer registration flags (defined locally to avoid pulling in
+ * libnvm/nvm_dma.h, which transitively includes C++ <atomic>) */
+#define NVM_MAP_DMABUF      0x1
+/* GPU runtime headers are NOT included in the public header.
+ * cuda_runtime.h and hip_runtime_api.h define conflicting types
+ * (vector types, stream types) that cannot coexist in a single TU.
+ *
+ * The async API uses void* for streams. Callers pass cudaStream_t
+ * (CUDA) or hipStream_t (HIP), which implicitly convert to void*.
+ * Backend-specific runtime headers are included only in internal
+ * source files that need them.
+ *
+ * Migration note: applications that previously relied on ugds.h to
+ * transitively include cuda_runtime.h must now include it directly. */
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,6 +65,8 @@ typedef enum uGDSOpError {
     UGDS_GPU_MEMORY_PINNING_FAILED   = UGDS_BASE_ERR + 36,
 
     UGDS_BATCH_CAPACITY_EXCEEDED     = UGDS_BASE_ERR + 40,
+    UGDS_BUSY                        = UGDS_BASE_ERR + 42,
+    UGDS_OUT_OF_MEMORY               = UGDS_BASE_ERR + 43,
 } uGDSOpError;
 
 static inline const char* uGDS_status_error(uGDSOpError status) {
@@ -66,6 +78,8 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_DRIVER_VERSION_MISMATCH:     return "driver version mismatch";
     case UGDS_DRIVER_CLOSING:              return "driver closing";
     case UGDS_IO_NOT_SUPPORTED:            return "IO not supported";
+    case UGDS_PLATFORM_NOT_SUPPORTED:      return "platform not supported";
+    case UGDS_DEVICE_NOT_SUPPORTED:        return "device not supported";
     case UGDS_INVALID_FILE_TYPE:           return "unsupported file type";
     case UGDS_INVALID_VALUE:               return "invalid arguments";
     case UGDS_MEMORY_ALREADY_REGISTERED:   return "memory already registered";
@@ -73,6 +87,9 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_INTERNAL_ERROR:              return "internal error";
     case UGDS_GPU_MEMORY_PINNING_FAILED:   return "GPU memory pinning failed";
     case UGDS_BATCH_CAPACITY_EXCEEDED:     return "batch capacity exceeded";
+
+    case UGDS_BUSY:                        return "resource busy, retry";
+    case UGDS_OUT_OF_MEMORY:               return "out of memory";
     default:                                  return "unknown uGDS error";
     }
 }
@@ -109,12 +126,29 @@ uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
 
 void uGDSHandleDeregister(uGDSHandle_t fh);
 
+/* Deregister a handle with a drain timeout.
+ * Returns UGDS_OK on success, or UGDS_BUSY if the timeout expires
+ * before all in-flight operations (including batch handles) complete.
+ * timeout_sec == 0 means non-blocking check only.
+ * timeout_sec < 0 means infinite wait (equivalent to uGDSHandleDeregister).
+ * timeout_sec < -1 means force teardown: skip wedged/in-flight checks
+ * and free all resources unconditionally.  The caller must guarantee
+ * that no NVMe command is still executing (e.g. after a controller reset). */
+uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
+
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 
 /* Flag for uGDSBufRegister: use AMD HIP/dma-buf path */
-#define UGDS_REGISTER_DMABUF  0x1   /* Use AMD HIP/dma-buf path */
+#define UGDS_REGISTER_DMABUF  NVM_MAP_DMABUF
 
 uGDSError_t uGDSBufDeregister(const void* bufPtr_base);
+
+/* Backend identifier for dual-backend dispatch. */
+typedef enum uGDSBackend {
+    UGDS_BACKEND_DEFAULT = 0,
+    UGDS_BACKEND_CUDA    = 1,
+    UGDS_BACKEND_HIP     = 2,
+} uGDSBackend_t;
 
 ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                    off_t file_offset, off_t bufPtr_offset);
@@ -122,7 +156,7 @@ ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                     off_t file_offset, off_t bufPtr_offset);
 
-/* ── Batch IO ── */
+/* -- Batch IO -- */
 
 typedef void* uGDSBatchHandle_t;
 
@@ -167,24 +201,48 @@ uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
 
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
-/* ── Async Stream IO ──
+/* -- Async Stream IO --
  * Pointer params (size_p, file_offset_p, etc.) must be host-accessible.
- * Use cudaHostAlloc for GPU-writable pinned memory (late binding).
- */
+ * Use cudaHostAlloc/hipHostMalloc for GPU-writable pinned memory (late binding).
+ *
+ * Stream parameter is void* to support both CUDA and HIP backends.
+ * Pass cudaStream_t (CUDA) or hipStream_t (HIP) -- both implicitly
+ * convert to void*.
+ *
+ * Backend dispatch:
+ *   - CUDA-only build: uses cudaLaunchHostFunc
+ *   - HIP-only build: uses hipLaunchHostFunc
+ *   - Dual-backend build: dispatches based on the buffer's registered
+ *     backend (UGDS_BACKEND_CUDA -> cudaLaunchHostFunc,
+ *     UGDS_BACKEND_HIP -> hipLaunchHostFunc). */
 
 uGDSError_t uGDSReadAsync(uGDSHandle_t fh, void *bufPtr_base,
                            size_t *size_p, off_t *file_offset_p,
                            off_t *bufPtr_offset_p, ssize_t *bytes_read_p,
-                           cudaStream_t stream);
+                           void* stream);
 
 uGDSError_t uGDSWriteAsync(uGDSHandle_t fh, void *bufPtr_base,
                             size_t *size_p, off_t *file_offset_p,
                             off_t *bufPtr_offset_p, ssize_t *bytes_written_p,
-                            cudaStream_t stream);
+                            void* stream);
 
-uGDSError_t uGDSStreamRegister(cudaStream_t stream);
+/* Register a stream without a backend hint (treated as default).
+ * In dual-backend builds, streams registered via this function are
+ * not validated against the buffer's backend. Use uGDSStreamRegisterEx
+ * to enable cross-backend mismatch detection. */
+uGDSError_t uGDSStreamRegister(void* stream);
 
-uGDSError_t uGDSStreamDeregister(cudaStream_t stream);
+/* Register a stream with an explicit backend for dual-backend validation.
+ * In dual-backend builds, uGDSReadAsync/uGDSWriteAsync will reject
+ * stream/buffer backend mismatches when the stream has been registered
+ * with an explicit backend. Streams registered via uGDSStreamRegister
+ * or not registered at all bypass the check.
+ *
+ * In single-backend builds, this validates that the requested backend
+ * matches the compiled-in backend (e.g. CUDA-only rejects HIP). */
+uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend);
+
+uGDSError_t uGDSStreamDeregister(void* stream);
 
 #ifdef __cplusplus
 }

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -131,9 +131,10 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * before all in-flight operations (including batch handles) complete.
  * timeout_sec == 0 means non-blocking check only.
  * timeout_sec < 0 means infinite wait (equivalent to uGDSHandleDeregister).
- * timeout_sec < -1 means force teardown: skip wedged/in-flight checks
- * and free all resources unconditionally.  The caller must guarantee
- * that no NVMe command is still executing (e.g. after a controller reset). */
+ * timeout_sec < -1 means after-reset teardown: release resources retained
+ * by timed-out I/O, skip wedged/in-flight checks, and free all resources.
+ * The caller must guarantee that no NVMe command is still executing (e.g.
+ * after a controller reset). */
 uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
 
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -130,7 +130,7 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * Returns UGDS_OK on success, or UGDS_BUSY if the timeout expires
  * before all in-flight operations (including batch handles) complete.
  * timeout_sec == 0 means non-blocking check only.
- * timeout_sec < 0 means infinite wait (equivalent to uGDSHandleDeregister).
+ * timeout_sec == -1 means infinite wait (equivalent to uGDSHandleDeregister).
  * timeout_sec < -1 means after-reset teardown: release resources retained
  * by timed-out I/O, skip wedged/in-flight checks, and free all resources.
  * The caller must guarantee that no NVMe command is still executing (e.g.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -124,9 +124,16 @@ run_test() {
         printf "${G}PASS${N}\n"
         PASSED=$((PASSED + 1))
     else
-        printf "${R}FAIL${N}\n"
-        echo "$output" | tail -5 | sed 's/^/    /'
-        FAILED=$((FAILED + 1))
+        local rc=$?
+        if [ $rc -eq 77 ]; then
+            printf "${Y}SKIP${N}\n"
+            echo "$output" | tail -3 | sed 's/^/    /'
+            SKIPPED=$((SKIPPED + 1))
+        else
+            printf "${R}FAIL${N}\n"
+            echo "$output" | tail -5 | sed 's/^/    /'
+            FAILED=$((FAILED + 1))
+        fi
     fi
 }
 
@@ -168,7 +175,28 @@ run_functional() {
     )
 
     for t in "${tests[@]}"; do
-        run_test "$t" "$BUILD_DIR/$t" "$ugds_dev" "$GPU_ID"
+        # In dual-backend builds, targets may be suffixed (_cuda/_hip)
+        local found=0
+        for suffix in "" "_cuda" "_hip"; do
+            if [ -x "$BUILD_DIR/${t}${suffix}" ]; then
+                # Skip on-the-fly unregistered test for HIP in dual builds:
+                # nvm_dma_map_device() defaults to CUDA (flags=0), so HIP
+                # unregistered I/O would route to the wrong backend.
+                # AMD buffers must be explicitly registered via uGDSBufRegister.
+                if [ "$t" = "test_read_write_unregistered" ] && [ "$suffix" = "_hip" ]; then
+                    printf "  %-40s ${Y}SKIP${N} (unregistered HIP I/O unsupported in dual mode)\n" "${t}${suffix}"
+                    SKIPPED=$((SKIPPED + 1))
+                    found=1
+                    continue
+                fi
+                run_test "$t${suffix}" "$BUILD_DIR/${t}${suffix}" "$ugds_dev" "$GPU_ID"
+                found=1
+            fi
+        done
+        if [ $found -eq 0 ]; then
+            printf "  %-40s ${Y}SKIP${N} (not built)\n" "$t"
+            SKIPPED=$((SKIPPED + 1))
+        fi
     done
     echo ""
 }
@@ -182,7 +210,16 @@ run_perf_ugds() {
     local ugds_dev
     ugds_dev=$(ensure_ugds "$slot")
 
-    if [ ! -x "$BUILD_DIR/bench_ugds" ]; then
+    # Find bench_ugds (may be suffixed in dual-backend builds)
+    local bench_bin=""
+    for suffix in "" "_cuda" "_hip"; do
+        if [ -x "$BUILD_DIR/bench_ugds${suffix}" ]; then
+            bench_bin="$BUILD_DIR/bench_ugds${suffix}"
+            break
+        fi
+    done
+
+    if [ -z "$bench_bin" ]; then
         echo "  SKIP (bench_ugds not built)"
         echo ""
         return
@@ -193,7 +230,7 @@ run_perf_ugds() {
 
     for sz in 4K 128K 1M; do
         echo "[UGDS - ${sz} seq read]"
-        "$BUILD_DIR/bench_ugds" -f "$ugds_dev" -l 128M -s "$sz" -t 1 -d "$GPU_ID" -m read
+        "$bench_bin" -f "$ugds_dev" -l 128M -s "$sz" -t 1 -d "$GPU_ID" -m read
     done
     echo ""
 }

--- a/src/libnvm/internal/map.h
+++ b/src/libnvm/internal/map.h
@@ -11,10 +11,10 @@
  */
 enum mapping_type
 {
-    MAP_TYPE_CUDA   =   0x1,   // CUDA device memory (NVIDIA)
-    MAP_TYPE_HOST   =   0x2,   // Host memory (RAM)
-    MAP_TYPE_API    =   0x4,   // Allocated by the API (RAM)
-    MAP_TYPE_DMABUF =   0x8    // DMA-buf (AMD HIP / standard Linux)
+    MAP_TYPE_CUDA        =   0x1,
+    MAP_TYPE_HOST        =   0x2,
+    MAP_TYPE_API         =   0x4,
+    MAP_TYPE_DMABUF      =   0x8,
 };
 
 
@@ -24,13 +24,12 @@ enum mapping_type
  */
 struct ioctl_mapping
 {
-    enum mapping_type   type;   // What kind of memory
-    void*               buffer; // GPU pointer (unmap identity) or host buffer
-    struct va_range     range;  // Memory range descriptor
+    enum mapping_type   type;
+    void*               buffer;
+    struct va_range     range;
 
-    /* DMABUF-specific fields */
-    int       dmabuf_fd;        // HSA-exported dma-buf file descriptor
-    uint64_t  dmabuf_offset;    // Offset within dmabuf allocation
+    int       dmabuf_fd;
+    uint64_t  dmabuf_offset;
 };
 
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -1,5 +1,9 @@
 #include "ugds_internal.h"
-#if defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend: avoid both cuda_runtime.h and hip_runtime.h in this TU
+ * to prevent type conflicts. Functions are declared extern "C" below. */
+#define CUDART_CB
+#elif defined(__HIP_PLATFORM_AMD__) && !defined(__NVCC__)
 #include <hip/hip_runtime.h>
 #define CUDART_CB
 #define cudaLaunchHostFunc hipLaunchHostFunc
@@ -11,7 +15,17 @@ typedef hipStream_t cudaStream_t;
 #endif
 #include <mutex>
 
-static void CUDART_CB async_io_callback(void* userData)
+/* Forward declaration for dual-backend stream validation */
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+static uGDSError_t async_check_stream_backend(void* stream, const void* bufPtr_base);
+#endif
+
+/* Backend-neutral async IO.
+ * Public API accepts void* for stream -- callers pass cudaStream_t
+ * or hipStream_t, which implicitly convert. Internal dispatch
+ * selects the correct backend launch function at compile time. */
+
+static void async_io_callback(void* userData)
 {
     AsyncRequest* req = static_cast<AsyncRequest*>(userData);
     size_t size = *req->size_p;
@@ -21,13 +35,27 @@ static void CUDART_CB async_io_callback(void* userData)
     ssize_t ret = do_io_internal(req->fh, req->bufPtr_base, size,
                                   file_offset, bufPtr_offset, req->opcode);
     *req->bytes_done_p = ret;
+
+    /* Release the in-flight reference held by async_validate.
+     * do_io_internal manages its own reference for registered buffers,
+     * so this accounts for the enqueue-time increment only. */
+    {
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        auto it = g_driver.buf_registry.find(req->bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    /* Release handle reference so HandleDeregister can proceed. */
+    handle_release(static_cast<HandleState*>(req->fh));
+
     delete req;
 }
 
-static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
-                             size_t* size_p, off_t* file_offset_p,
-                             off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
-                             cudaStream_t stream, uint8_t opcode)
+static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
+                                   size_t* size_p, off_t* file_offset_p,
+                                   off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
+                                   std::shared_ptr<HandleState>* hs_sp_out)
 {
     if (!g_driver.initialized)
         return make_error(UGDS_DRIVER_NOT_INITIALIZED);
@@ -37,18 +65,115 @@ static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
         bufPtr_offset_p == nullptr || bytes_done_p == nullptr)
         return make_error(UGDS_INVALID_VALUE);
 
-    {
-        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
-        if (g_driver.buf_registry.find(bufPtr_base) == g_driver.buf_registry.end())
-            return make_error(UGDS_INVALID_VALUE);
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(bufPtr_base);
+    if (it == g_driver.buf_registry.end())
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Hold in-flight reference from enqueue until callback completes.
+     * This prevents uGDSBufDeregister from unmapping the buffer
+     * while the async request is queued but not yet executed. */
+    it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+
+    /* Also hold a handle reference so HandleDeregister cannot free
+     * the HandleState (QPs, controller) while the async callback
+     * is pending. Use handle_lookup_locked since we already hold
+     * g_driver.lock from the buffer registry lookup above. */
+    HandleState* hs = handle_lookup_locked(fh, hs_sp_out);
+    if (!hs) {
+        /* Roll back buffer in_flight ref on handle acquire failure */
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        return make_error(UGDS_INVALID_VALUE);
     }
 
-    AsyncRequest* req = new AsyncRequest{
-        fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-        bytes_done_p, opcode
-    };
+    return UGDS_OK;
+}
 
-    cudaError_t err = cudaLaunchHostFunc(stream, async_io_callback, req);
+static AsyncRequest* make_async_request(uGDSHandle_t fh, void* bufPtr_base,
+                                         size_t* size_p, off_t* file_offset_p,
+                                         off_t* bufPtr_offset_p, ssize_t* bytes_done_p,
+                                         uint8_t opcode,
+                                         std::shared_ptr<HandleState> hs_sp)
+{
+    AsyncRequest* req = new (std::nothrow) AsyncRequest{
+        fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
+        bytes_done_p, opcode, std::move(hs_sp)
+    };
+    return req;
+}
+
+/* -- Backend-specific host function launch --
+ * Uses ugsd_stream_t (void*) internally. In dual-backend builds,
+ * dispatches based on the buffer's registered backend. */
+
+#if defined(__HIP_PLATFORM_AMD__) && !defined(_CUDA)
+/* HIP-only build */
+#include <hip/hip_runtime_api.h>
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)opcode;
+    hipError_t err = hipLaunchHostFunc((hipStream_t)stream,
+                                       async_io_callback, req);
+    if (err != hipSuccess) {
+        delete req;
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+}
+
+#elif defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend build: runtime dispatch based on buffer's backend.
+ * Cannot include both cuda_runtime.h and hip_runtime_api.h in the same
+ * TU due to vector type conflicts. Declare the runtime functions as
+ * extern "C" -- both libcudart and libamdhip64 export them.
+ *
+ * NOTE: On ROCm, hipLaunchHostFunc can map to hipLaunchHostFunc_spt
+ * when HIP_API_PER_THREAD_DEFAULT_STREAM is enabled. This declaration
+ * matches the default (non-SPT) ABI. For SPT support, build HIP-only. */
+
+/* Declare the runtime launch functions directly without their headers.
+ * Both accept (stream_ptr, callback, user_data) and return int-like. */
+extern "C" {
+int cudaLaunchHostFunc(void* stream, void (*callback)(void*), void* userData);
+int hipLaunchHostFunc(void* stream, void (*callback)(void*), void* userData);
+}
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode,
+                                           uGDSBackend_t backend)
+{
+    (void)opcode;
+    int err;
+    if (backend == UGDS_BACKEND_HIP) {
+        err = hipLaunchHostFunc(stream, async_io_callback, req);
+    } else {
+        err = cudaLaunchHostFunc(stream, async_io_callback, req);
+    }
+    if (err != 0) {
+        delete req;
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = err;
+        return e;
+    }
+    return UGDS_OK;
+}
+
+#elif defined(_CUDA) || defined(__CUDACC__)
+/* CUDA-only build */
+#include <cuda_runtime.h>
+
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)opcode;
+    cudaError_t err = cudaLaunchHostFunc((cudaStream_t)(uintptr_t)stream,
+                                         async_io_callback, req);
     if (err != cudaSuccess) {
         delete req;
         uGDSError_t e;
@@ -56,36 +181,248 @@ static uGDSError_t do_async(uGDSHandle_t fh, void* bufPtr_base,
         e.cu_err = static_cast<int>(err);
         return e;
     }
-
     return UGDS_OK;
 }
+
+#else
+/* No GPU backend: async IO not available */
+static uGDSError_t async_launch_host_func(ugsd_stream_t stream,
+                                           AsyncRequest* req, uint8_t opcode)
+{
+    (void)stream; (void)opcode;
+    delete req;
+    return make_error(UGDS_IO_NOT_SUPPORTED);
+}
+#endif
+
+static void async_release_inflight(void* bufPtr_base,
+                                    std::shared_ptr<HandleState>* hs_sp)
+{
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(bufPtr_base);
+    if (it != g_driver.buf_registry.end())
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+
+    if (hs_sp && *hs_sp) {
+        handle_release(hs_sp->get());
+        hs_sp->reset();
+    }
+}
+
+/* -- Public async API (void* stream for dual-backend support) -- */
 
 extern "C" uGDSError_t uGDSReadAsync(uGDSHandle_t fh, void* bufPtr_base,
                                        size_t* size_p, off_t* file_offset_p,
                                        off_t* bufPtr_offset_p, ssize_t* bytes_read_p,
-                                       cudaStream_t stream)
+                                       void* stream)
 {
-    return do_async(fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-                    bytes_read_p, stream, NVM_IO_READ);
+    std::shared_ptr<HandleState> hs_sp;
+    uGDSError_t st = async_validate(fh, bufPtr_base, size_p, file_offset_p,
+                                     bufPtr_offset_p, bytes_read_p, &hs_sp);
+    if (st.err != UGDS_SUCCESS) return st;
+
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: check stream/buffer backend compatibility BEFORE
+     * allocating request to avoid leak on mismatch. */
+    {
+        uGDSError_t sbe = async_check_stream_backend(stream, bufPtr_base);
+        if (sbe.err != UGDS_SUCCESS) {
+            async_release_inflight(bufPtr_base, &hs_sp);
+            return sbe;
+        }
+    }
+#endif
+
+    /* Keep a copy of hs_sp so we can release on launch failure.
+     * The request also holds a copy. */
+    AsyncRequest* req = make_async_request(fh, bufPtr_base, size_p, file_offset_p,
+                                            bufPtr_offset_p, bytes_read_p, NVM_IO_READ,
+                                            hs_sp);
+    if (req == nullptr) {
+        async_release_inflight(bufPtr_base, &hs_sp);
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: look up buffer's registered backend */
+    uGDSBackend_t backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            backend = it->second.backend;
+    }
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_READ, backend);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#else
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_READ);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#endif
 }
 
 extern "C" uGDSError_t uGDSWriteAsync(uGDSHandle_t fh, void* bufPtr_base,
                                         size_t* size_p, off_t* file_offset_p,
                                         off_t* bufPtr_offset_p, ssize_t* bytes_written_p,
-                                        cudaStream_t stream)
+                                        void* stream)
 {
-    return do_async(fh, bufPtr_base, size_p, file_offset_p, bufPtr_offset_p,
-                    bytes_written_p, stream, NVM_IO_WRITE);
+    std::shared_ptr<HandleState> hs_sp;
+    uGDSError_t st = async_validate(fh, bufPtr_base, size_p, file_offset_p,
+                                     bufPtr_offset_p, bytes_written_p, &hs_sp);
+    if (st.err != UGDS_SUCCESS) return st;
+
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: check stream/buffer backend compatibility BEFORE
+     * allocating request to avoid leak on mismatch. */
+    {
+        uGDSError_t sbe = async_check_stream_backend(stream, bufPtr_base);
+        if (sbe.err != UGDS_SUCCESS) {
+            async_release_inflight(bufPtr_base, &hs_sp);
+            return sbe;
+        }
+    }
+#endif
+
+    AsyncRequest* req = make_async_request(fh, bufPtr_base, size_p, file_offset_p,
+                                            bufPtr_offset_p, bytes_written_p, NVM_IO_WRITE,
+                                            hs_sp);
+    if (req == nullptr) {
+        async_release_inflight(bufPtr_base, &hs_sp);
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    /* Dual-backend: look up buffer's registered backend */
+    uGDSBackend_t backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            backend = it->second.backend;
+    }
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_WRITE, backend);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#else
+    {
+        uGDSError_t est = async_launch_host_func((ugsd_stream_t)stream, req, NVM_IO_WRITE);
+        if (est.err != UGDS_SUCCESS)
+            async_release_inflight(bufPtr_base, &hs_sp);
+        return est;
+    }
+#endif
 }
 
-extern "C" uGDSError_t uGDSStreamRegister(cudaStream_t stream)
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+/* Dual-backend: track stream->backend mapping for cross-backend detection.
+ * Users register streams via uGDSStreamRegisterEx with an explicit backend.
+ * Unregistered streams are treated as UGDS_BACKEND_DEFAULT (no check). */
+#include <unordered_map>
+
+static std::mutex                                   s_stream_map_lock;
+static std::unordered_map<void*, uGDSBackend_t>     s_stream_backends;
+
+extern "C" uGDSError_t uGDSStreamRegister(void* stream)
+{
+    /* In dual-backend mode, StreamRegister without a backend hint
+     * just records the stream as default. Use uGDSStreamRegisterEx
+     * to associate an explicit backend. */
+    if (stream != nullptr) {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        s_stream_backends[stream] = UGDS_BACKEND_DEFAULT;
+    }
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend)
+{
+    if (stream == nullptr)
+        return UGDS_OK;
+    if (backend != UGDS_BACKEND_CUDA && backend != UGDS_BACKEND_HIP)
+        return make_error(UGDS_INVALID_VALUE);
+    std::lock_guard<std::mutex> g(s_stream_map_lock);
+    s_stream_backends[stream] = backend;
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
+{
+    if (stream != nullptr) {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        s_stream_backends.erase(stream);
+    }
+    return UGDS_OK;
+}
+
+/* Validate that the stream's backend matches the buffer's backend.
+ * Returns UGDS_OK if compatible, error otherwise. */
+static uGDSError_t async_check_stream_backend(void* stream, const void* bufPtr_base)
+{
+    /* NULL stream means default stream -- always allowed */
+    if (stream == nullptr)
+        return UGDS_OK;
+
+    /* Look up buffer backend */
+    uGDSBackend_t buf_backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+        auto it = g_driver.buf_registry.find(const_cast<void*>(bufPtr_base));
+        if (it != g_driver.buf_registry.end())
+            buf_backend = it->second.backend;
+    }
+
+    /* Look up stream backend */
+    uGDSBackend_t stream_backend = UGDS_BACKEND_DEFAULT;
+    {
+        std::lock_guard<std::mutex> g(s_stream_map_lock);
+        auto it = s_stream_backends.find(stream);
+        if (it != s_stream_backends.end())
+            stream_backend = it->second;
+    }
+
+    /* If both are known (non-default), they must match */
+    if (buf_backend != UGDS_BACKEND_DEFAULT &&
+        stream_backend != UGDS_BACKEND_DEFAULT &&
+        buf_backend != stream_backend)
+        return make_error(UGDS_INVALID_VALUE);
+
+    return UGDS_OK;
+}
+#else
+/* Single-backend: stream/backend mismatch cannot occur at runtime,
+ * but validate the backend enum for API consistency. */
+#if defined(__HIP_PLATFORM_AMD__)
+#define UGDS_ACTIVE_BACKEND UGDS_BACKEND_HIP
+#else
+#define UGDS_ACTIVE_BACKEND UGDS_BACKEND_CUDA
+#endif
+
+extern "C" uGDSError_t uGDSStreamRegister(void* stream)
 {
     (void)stream;
     return UGDS_OK;
 }
 
-extern "C" uGDSError_t uGDSStreamDeregister(cudaStream_t stream)
+extern "C" uGDSError_t uGDSStreamRegisterEx(void* stream, uGDSBackend_t backend)
+{
+    (void)stream;
+    if (backend != UGDS_ACTIVE_BACKEND)
+        return make_error(UGDS_INVALID_VALUE);
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
 {
     (void)stream;
     return UGDS_OK;
 }
+#undef UGDS_ACTIVE_BACKEND
+#endif

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -6,6 +6,17 @@
 #include <algorithm>
 #include <atomic>
 #include <time.h>
+#include <cstdio>
+
+/* Release in-flight reference held by batch submit.
+ * Called on validation failure or when batch entry completes. */
+static void async_release_inflight_batch(void* devPtr_base)
+{
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    auto it = g_driver.buf_registry.find(devPtr_base);
+    if (it != g_driver.buf_registry.end())
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
 
 static void cleanup_prp_pool(BatchState* bs)
 {
@@ -64,6 +75,8 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
         }
         entry.error_code = entry.bytes_done;
         bs->n_completed++;
+        /* Release in-flight reference when all sub-commands complete */
+        async_release_inflight_batch(entry.devPtr_base);
     }
 
     return true;
@@ -92,23 +105,34 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
         return make_error(UGDS_INVALID_VALUE);
 
-    HandleState* hs = static_cast<HandleState*>(fh);
+    /* Look up handle via global registry to safely acquire a shared_ptr.
+     * This prevents UAF if HandleDeregister races with us. */
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs)
+        return make_error(UGDS_INVALID_VALUE);
 
-    if (!hs->batch_qp)
+    if (!hs->batch_qp) {
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
+    }
 
     bool expected = false;
-    if (!hs->batch_active.compare_exchange_strong(expected, true))
+    if (!hs->batch_active.compare_exchange_strong(expected, true)) {
+        handle_release(hs);
         return make_error(UGDS_INVALID_VALUE);
+    }
 
     auto bs = new (std::nothrow) BatchState();
     if (!bs) {
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
 
     bs->capacity = nr;
     bs->hs = hs;
+    bs->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
     bs->entries.resize(nr);
     bs->cmd_map.resize(hs->batch_queue_depth);
 
@@ -119,6 +143,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
         delete bs;
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
     std::memset(pool.buf, 0, pool_bytes);
@@ -129,6 +154,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         pool.buf = nullptr;
         delete bs;
         hs->batch_active.store(false);
+        handle_release(hs);
         return make_error(UGDS_INTERNAL_ERROR);
     }
     pool.n_pages = UGDS_PRP_POOL_PAGES;
@@ -136,6 +162,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
     *batch = static_cast<uGDSBatchHandle_t>(bs);
+
     return UGDS_OK;
 }
 
@@ -147,6 +174,10 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
 
     BatchState* bs = static_cast<BatchState*>(batch);
     std::lock_guard<std::mutex> batch_lock(bs->lock);
+
+    if (bs->hs->wedged.load(std::memory_order_acquire) ||
+        bs->hs->closing.load(std::memory_order_acquire))
+        return make_error(UGDS_BUSY);
 
     if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
         bs->n_entries = 0;
@@ -195,8 +226,11 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.n_cmds_done = 0;
         entry.event_returned = false;
 
-        size_t n_cmds = (p.size + max_xfer - 1) / max_xfer;
-        if (n_cmds == 0) n_cmds = 1;
+        /* Overflow-safe ceil division for n_cmds */
+        size_t n_cmds = (p.size - 1) / max_xfer + 1;
+        if (n_cmds > UINT16_MAX) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
         entry.n_cmds = static_cast<uint16_t>(n_cmds);
     }
 
@@ -224,8 +258,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         {
             std::lock_guard<std::mutex> drv_lock(g_driver.lock);
             auto it = g_driver.buf_registry.find(entry.devPtr_base);
-            if (it != g_driver.buf_registry.end())
-                buf_dma = it->second;
+            if (it != g_driver.buf_registry.end()) {
+                buf_dma = it->second.dma;
+                /* Hold in-flight reference until batch completions are drained
+                 * or destroy finishes. Prevents Deregister from unmapping
+                 * while batch commands retain PRPs from this buffer. */
+                it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+            }
         }
 
         if (buf_dma == nullptr) {
@@ -243,18 +282,21 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            async_release_inflight_batch(entry.devPtr_base);
             continue;
         }
         buf_page_start = static_cast<size_t>(entry.devPtr_offset) / page_size;
 
-        size_t total_pages_needed = buf_page_start +
-            (entry.size + page_size - 1) / page_size;
-        if (total_pages_needed > buf_dma->n_ioaddrs) {
+        /* Overflow-safe bounds check */
+        size_t batch_pages_needed = (entry.size - 1) / page_size + 1;
+        if (batch_pages_needed > buf_dma->n_ioaddrs ||
+            buf_page_start > buf_dma->n_ioaddrs - batch_pages_needed) {
             entry.status = UGDS_BATCH_FAILED;
             entry.error_code = -EINVAL;
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            async_release_inflight_batch(entry.devPtr_base);
             continue;
         }
 
@@ -296,6 +338,20 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
                         if (!drain_one_completion(qp, bs)) {
                             if (++spins > max_spins) {
+                                /* Release in_flight refs only for entries
+                                 * that are still WAITING (ref acquired but
+                                 * not yet submitted). PENDING entries have
+                                 * commands in the SQ -- keep ref until drain.
+                                 * COMPLETE entries were already released by
+                                 * drain_one_completion. FAILED already done. */
+                                for (unsigned i = 0; i < nr; ++i) {
+                                    BatchIOEntry& e = bs->entries[base + i];
+                                    if (e.status == UGDS_BATCH_WAITING) {
+                                        async_release_inflight_batch(e.devPtr_base);
+                                        e.status = UGDS_BATCH_FAILED;
+                                        e.n_cmds = 0;
+                                    }
+                                }
                                 bs->n_entries += nr;
                                 return make_error(UGDS_INTERNAL_ERROR);
                             }
@@ -323,6 +379,15 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     } else if (++spins > max_spins) {
                         if (prp_idx != UINT16_MAX)
                             prp_pool_free(&bs->prp_pool, prp_idx);
+                        /* Release in_flight refs only for WAITING entries. */
+                        for (unsigned i = 0; i < nr; ++i) {
+                            BatchIOEntry& e = bs->entries[base + i];
+                            if (e.status == UGDS_BATCH_WAITING) {
+                                async_release_inflight_batch(e.devPtr_base);
+                                e.status = UGDS_BATCH_FAILED;
+                                e.n_cmds = 0;
+                            }
+                        }
                         bs->n_entries += nr;
                         return make_error(UGDS_INTERNAL_ERROR);
                     } else {
@@ -336,6 +401,15 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                 if (cmd == nullptr) {
                     if (prp_idx != UINT16_MAX)
                         prp_pool_free(&bs->prp_pool, prp_idx);
+                    /* Release in_flight refs only for WAITING entries. */
+                    for (unsigned i = 0; i < nr; ++i) {
+                        BatchIOEntry& e = bs->entries[base + i];
+                        if (e.status == UGDS_BATCH_WAITING) {
+                            async_release_inflight_batch(e.devPtr_base);
+                            e.status = UGDS_BATCH_FAILED;
+                            e.n_cmds = 0;
+                        }
+                    }
                     bs->n_entries += nr;
                     return make_error(UGDS_INTERNAL_ERROR);
                 }
@@ -478,7 +552,56 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
         }
     }
 
+    /* Best-effort: release in-flight references for entries that were
+     * submitted but never fully completed (e.g., submit phase-3 early
+     * return). Check n_cmds_done < n_cmds rather than status alone.
+     *
+     * IMPORTANT: do NOT release refs for entries that have commands
+     * still outstanding in the NVMe SQ (bs->in_flight > 0 after drain).
+     * Those commands may still DMA. Leaking the refs (blocking
+     * deregister) is strictly safer than freeing mappings while the
+     * device may still access them. The caller should reset the
+     * controller if truly stuck. */
+    if (bs->in_flight == 0) {
+        for (unsigned i = 0; i < bs->n_entries; ++i) {
+            BatchIOEntry& entry = bs->entries[i];
+            if (entry.n_cmds > 0 && entry.n_cmds_done < entry.n_cmds) {
+                async_release_inflight_batch(entry.devPtr_base);
+                entry.status = UGDS_BATCH_FAILED;
+            }
+        }
+    } else {
+        /* Commands still in flight after drain timeout.
+         * The NVMe device may still DMA through the PRP list and CQ,
+         * so we must NOT: free the PRP pool, release handle ref,
+         * delete the batch state, or clear batch_active.
+         *
+         * Keeping batch_active=true prevents a new BatchIOSetUp from
+         * reusing the same QP while old completions may still arrive.
+         * Keeping the handle ref prevents HandleDeregister from freeing
+         * the QP while DMA is in progress.
+         *
+         * This wedges the handle until the caller resets the controller.
+         * BatchIODestroy is void so the caller cannot detect this --
+         * the warning is the only signal. This is the safest option:
+         * a wedged handle is strictly better than DMA-after-unmap. */
+        fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
+                "flight after drain timeout -- handle is now wedged "
+                "to prevent DMA-after-unmap. Controller reset required.\n",
+                bs->in_flight);
+        hs->wedged.store(true, std::memory_order_release);
+        return;
+    }
+
     cleanup_prp_pool(bs);
+
+    /* Mark batch inactive before releasing handle ref.
+     * HandleDeregister waits on handle_in_flight==0, so we must not
+     * touch hs after release. */
     hs->batch_active.store(false);
+
+    /* Release handle reference acquired in BatchIOSetUp */
+    handle_release(hs);
+
     delete bs;
 }

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -1,4 +1,7 @@
 #include "ugds_internal.h"
+#include "internal/dma.h"
+#include <unistd.h>
+#include <fcntl.h>
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
     if (!g_driver.initialized) {
@@ -24,10 +27,14 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
                                        const_cast<void*>(bufPtr_base), length,
                                        flags);
     if (status != 0 || dma == nullptr) {
+        if (status == ENOTSUP || status == EOPNOTSUPP)
+            return make_error(UGDS_IO_NOT_SUPPORTED);
         return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
     }
 
-    g_driver.buf_registry[bufPtr_base] = dma;
+    g_driver.buf_registry[bufPtr_base].dma = dma;
+    g_driver.buf_registry[bufPtr_base].backend =
+        (flags & NVM_MAP_DMABUF) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
     return UGDS_OK;
 }
 
@@ -43,7 +50,13 @@ extern "C" uGDSError_t uGDSBufDeregister(const void* bufPtr_base) {
         return make_error(UGDS_MEMORY_NOT_REGISTERED);
     }
 
-    nvm_dma_unmap(it->second);
+    /* Reject deregister if IO is in-flight on this buffer.
+     * Caller must wait for outstanding operations to complete. */
+    if (it->second.in_flight.load(std::memory_order_acquire) > 0) {
+        return make_error(UGDS_BUSY);
+    }
+
+    nvm_dma_unmap(it->second.dma);
     g_driver.buf_registry.erase(it);
 
     return UGDS_OK;

--- a/src/ugds_driver.cpp
+++ b/src/ugds_driver.cpp
@@ -16,10 +16,28 @@ extern "C" uGDSError_t uGDSDriverClose(void) {
     if (!g_driver.initialized) {
         return make_error(UGDS_DRIVER_NOT_INITIALIZED);
     }
+
+    /* Reject close if any buffer has outstanding IO.
+     * Caller must ensure all async/batch operations are complete
+     * and all buffers are deregistered before closing the driver. */
     for (auto& entry : g_driver.buf_registry) {
-        nvm_dma_unmap(entry.second);
+        if (entry.second.in_flight.load(std::memory_order_acquire) > 0) {
+            return make_error(UGDS_BUSY);
+        }
+    }
+
+    /* Reject close if any handle is still registered.
+     * Allowing close while handles exist would drop shared_ptrs without
+     * running HandleDeregister cleanup, leaking QPs/admin queues/controller. */
+    if (!g_driver.handle_registry.empty()) {
+        return make_error(UGDS_BUSY);
+    }
+
+    for (auto& entry : g_driver.buf_registry) {
+        nvm_dma_unmap(entry.second.dma);
     }
     g_driver.buf_registry.clear();
+    g_driver.handle_registry.clear();
     g_driver.default_ctrl = nullptr;
     g_driver.initialized = false;
     return UGDS_OK;

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -9,6 +9,7 @@
 #include <sys/ioctl.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <time.h>
 
 static void cleanup_qp(nvm_aq_ref aq_ref, IOQueuePair* qp, int dev_fd) {
     if (qp->sq_dma) {
@@ -55,7 +56,7 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     if (descr->type != UGDS_HANDLE_TYPE_OPAQUE_FD)
         return make_error(UGDS_INVALID_FILE_TYPE);
 
-    auto hs = std::make_unique<HandleState>();
+    auto hs = std::make_shared<HandleState>();
     hs->fd = descr->handle.fd;
     hs->ns_id = 1;
     hs->ctrl = nullptr;
@@ -330,21 +331,159 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     batch_done:;
     }
 
+    /* Register in global handle registry so handle_lookup() can find
+     * the shared_ptr. The raw pointer serves as the key and the public
+     * opaque handle.
+     *
+     * Re-check g_driver.initialized under lock: DriverClose may have
+     * run between the initial check (line 41) and here, after a long
+     * NVMe admin/setup sequence. */
+    HandleState* raw = hs.get();
     {
         std::lock_guard<std::mutex> g(g_driver.lock);
+        if (!g_driver.initialized)
+        {
+            /* Driver was closed during setup. Roll back all resources
+             * that were allocated above, including sync QPs and batch QP
+             * (same sequence as batch_fail). */
+            cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
+            for (auto& done : hs->qps)
+                cleanup_qp(hs->aq_ref, done.get(), hs->fd);
+            hs->qps.clear();
+            nvm_aq_destroy(hs->aq_ref);
+            nvm_dma_unmap(hs->aq_dma);
+            free(hs->aq_buf);
+            nvm_ctrl_free(hs->ctrl);
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+        try {
+            g_driver.handle_registry[raw] = hs;
+        } catch (const std::bad_alloc&) {
+            /* Registry insertion failed (out of memory). Roll back
+             * all NVMe resources allocated above. */
+            cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
+            for (auto& done : hs->qps)
+                cleanup_qp(hs->aq_ref, done.get(), hs->fd);
+            hs->qps.clear();
+            nvm_aq_destroy(hs->aq_ref);
+            nvm_dma_unmap(hs->aq_dma);
+            free(hs->aq_buf);
+            nvm_ctrl_free(hs->ctrl);
+            return make_error(UGDS_OUT_OF_MEMORY);
+        }
         if (g_driver.default_ctrl == nullptr)
             g_driver.default_ctrl = hs->ctrl;
     }
 
-    *fh = reinterpret_cast<uGDSHandle_t>(hs.release());
+    *fh = reinterpret_cast<uGDSHandle_t>(raw);
     return UGDS_OK;
 }
 
 extern "C" void uGDSHandleDeregister(uGDSHandle_t fh)
 {
-    if (fh == nullptr) return;
+    /* Legacy API: infinite wait. This void API cannot return an error
+     * to the caller.  If the handle is wedged (I/O timeout with commands
+     * still in flight), the underlying NVMe resources (QPs, DMA mappings)
+     * remain live and the caller must NOT close the device fd or free GPU
+     * memory until a successful DeregisterEx.  Use uGDSHandleDeregisterEx
+     * for a status-returning variant. */
+    uGDSError_t err = uGDSHandleDeregisterEx(fh, -1);
+    if (err.err != UGDS_SUCCESS) {
+        fprintf(stderr, "uGDS: HandleDeregister returned %d -- resources "
+                "still live, controller reset required\n", (int)err.err);
+    }
+}
 
-    HandleState* hs = reinterpret_cast<HandleState*>(fh);
+extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
+{
+    if (fh == nullptr) return UGDS_OK;
+
+    HandleState* raw = reinterpret_cast<HandleState*>(fh);
+
+    /* timeout_sec semantics:
+     *   > 0  -- wait up to N seconds, then return UGDS_BUSY
+     *   0    -- non-blocking, return UGDS_BUSY immediately if in-flight
+     *  -1    -- infinite wait (legacy behaviour)
+     *  <-1   -- force teardown: skip wedged/in-flight checks and free all
+     *           resources unconditionally (caller guarantees no NVMe
+     *           command is still executing, e.g. after controller reset) */
+    bool force = (timeout_sec < -1);
+
+    /* Set closing=true under g_driver.lock so new IO entrypoints are
+     * blocked via handle_lookup/handle_lookup_locked. Keep the handle
+     * in the registry during drain so DriverClose's UGDS_BUSY guard
+     * still sees it. Remove from registry only after all cleanup. */
+    std::shared_ptr<HandleState> hs_sp;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        auto it = g_driver.handle_registry.find(raw);
+        if (it == g_driver.handle_registry.end())
+            return UGDS_OK;  /* already deregistered or invalid */
+        /* Atomic single-owner claim: if closing was already true,
+         * another thread is draining. Report busy, not success. */
+        if (it->second->closing.exchange(true, std::memory_order_acq_rel))
+            return make_error(UGDS_BUSY);
+        hs_sp = it->second;  /* copy shared_ptr, keep in registry */
+    }
+
+    HandleState* hs = hs_sp.get();
+
+    /* Wait for outstanding operations with optional timeout. */
+    if (!force && hs->wedged.load(std::memory_order_acquire)) {
+        fprintf(stderr, "uGDS: HandleDeregisterEx: handle is wedged "
+                "(batch timeout with commands in flight). "
+                "Controller reset required.\n");
+        hs->closing.store(false, std::memory_order_release);
+        return make_error(UGDS_BUSY);
+    }
+    if (!force) {
+        struct timespec deadline = {};
+        if (timeout_sec > 0) {
+            clock_gettime(CLOCK_MONOTONIC, &deadline);
+            deadline.tv_sec += timeout_sec;
+        }
+        uint64_t warn_counter = 0;
+        while (hs->handle_in_flight.load(std::memory_order_acquire) > 0) {
+            if (hs->wedged.load(std::memory_order_acquire)) {
+                fprintf(stderr, "uGDS: HandleDeregisterEx: handle became "
+                        "wedged during drain (batch/sync timeout with "
+                        "commands in flight). Controller reset required.\n");
+                hs->closing.store(false, std::memory_order_release);
+                return make_error(UGDS_BUSY);
+            }
+            if (timeout_sec == 0) {
+                hs->closing.store(false, std::memory_order_release);
+                return make_error(UGDS_BUSY);
+            }
+            if (timeout_sec > 0) {
+                struct timespec now;
+                clock_gettime(CLOCK_MONOTONIC, &now);
+                if (now.tv_sec > deadline.tv_sec ||
+                    (now.tv_sec == deadline.tv_sec &&
+                     now.tv_nsec >= deadline.tv_nsec)) {
+                    fprintf(stderr, "uGDS: HandleDeregisterEx: timed out "
+                            "waiting for %u in-flight operations\n",
+                            hs->handle_in_flight.load());
+                    hs->closing.store(false, std::memory_order_release);
+                    return make_error(UGDS_BUSY);
+                }
+            }
+            if ((++warn_counter % 100000000ULL) == 0) {
+                fprintf(stderr, "uGDS: HandleDeregister waiting for %u "
+                        "in-flight operations\n",
+                        hs->handle_in_flight.load());
+            }
+            __builtin_ia32_pause();
+        }
+        /* Re-check wedged before cleanup: concurrent timeout may
+         * have set it after the last in-flight reference dropped. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            fprintf(stderr, "uGDS: HandleDeregisterEx: handle became wedged "
+                    "during drain. Controller reset required.\n");
+            hs->closing.store(false, std::memory_order_release);
+            return make_error(UGDS_BUSY);
+        }
+    }
 
     if (hs->batch_qp)
         cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);
@@ -365,5 +504,16 @@ extern "C" void uGDSHandleDeregister(uGDSHandle_t fh)
     free(hs->aq_buf);
     if (hs->ctrl) nvm_ctrl_free(hs->ctrl);
 
-    delete hs;
+    /* Now that all resources are freed, remove from the registry.
+     * This must happen after cleanup so DriverClose's UGDS_BUSY guard
+     * keeps the handle visible during the entire drain+cleanup window. */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        g_driver.handle_registry.erase(raw);
+    }
+
+    /* hs_sp (the last local shared_ptr) drops here. The registry entry
+     * was the other copy; since we just erased it, this drop frees
+     * HandleState. */
+    return UGDS_OK;
 }

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -47,6 +47,33 @@ static void cleanup_batch_qp(nvm_aq_ref aq_ref, IOQueuePairHuge* bqp, int dev_fd
         hugepage_free(bqp->cq_huge, bqp->cq_huge_size);
 }
 
+/* Release resources retained by timed-out synchronous I/O. The caller must
+ * have already reset the controller and proved that old commands cannot DMA. */
+static void cleanup_timeout_resources(HandleState* hs) {
+    for (auto& qp_ptr : hs->qps) {
+        IOQueuePair& qp = *qp_ptr;
+        nvm_dma_t* timeout_dma = nullptr;
+        const void* registered_buf = nullptr;
+        {
+            std::lock_guard<std::mutex> qp_lock(qp.lock);
+            timeout_dma = qp.timeout_dma;
+            registered_buf = qp.timeout_registered_buf;
+            qp.timeout_dma = nullptr;
+            qp.timeout_registered_buf = nullptr;
+        }
+
+        if (timeout_dma != nullptr)
+            nvm_dma_unmap(timeout_dma);
+
+        if (registered_buf != nullptr) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(registered_buf);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+}
+
 extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
 {
     if (fh == nullptr || descr == nullptr)
@@ -484,6 +511,9 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
             return make_error(UGDS_BUSY);
         }
     }
+
+    if (force)
+        cleanup_timeout_resources(hs);
 
     if (hs->batch_qp)
         cleanup_batch_qp(hs->aq_ref, hs->batch_qp.get(), hs->fd);

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -33,7 +33,7 @@
  * reports MDTS = 0 (no limit). Keeps one transfer within a single PRP list. */
 #define UGDS_DEFAULT_MAX_TRANSFER_SIZE (128UL * 1024)
 
-/* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec §4.6.1. */
+/* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec section 4.6.1. */
 #define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 
 struct IOQueuePair {
@@ -77,16 +77,77 @@ struct HandleState {
     uint16_t                    batch_queue_depth;
     std::atomic<bool>           batch_active{false};
     bool                        interrupt_mode = false;  /* UGDS_INTERRUPT_MODE */
+    std::atomic<bool>           wedged{false};          /* batch timeout: handle poisoned, controller reset required */
+    std::atomic<uint32_t>       handle_in_flight{0};  /* IO refcount for safe deregister */
+    std::atomic<bool>           closing{false};        /* set by Deregister to block new ops */
 };
 
 struct DriverState {
-    bool                                          initialized = false;
+    std::atomic<bool>                              initialized{false};
     std::mutex                                    lock;
     nvm_ctrl_t*                                   default_ctrl = nullptr;
-    std::unordered_map<const void*, nvm_dma_t*>   buf_registry;
+
+    /* Handle registry: maps raw pointer -> shared_ptr to keep handles alive.
+     * handle_lookup acquires under g_driver.lock so Deregister cannot
+     * destroy the HandleState while an IO entrypoint is dereferencing it. */
+    std::unordered_map<HandleState*,
+                       std::shared_ptr<HandleState>>  handle_registry;
+
+    /* Buffer registry with backend tracking for dual-backend dispatch.
+     * in_flight counts active IO references to prevent use-after-free
+     * during concurrent Deregister. */
+    struct BufEntry {
+        nvm_dma_t*           dma;
+        uGDSBackend_t        backend;
+        std::atomic<uint32_t> in_flight{0};
+    };
+    std::unordered_map<const void*, BufEntry>     buf_registry;
 };
 
 extern DriverState g_driver;
+
+/* Look up a handle in the global registry and acquire a reference.
+ * Returns the raw HandleState* on success (and stores a shared_ptr copy
+ * in *out_sp to keep the handle alive). Returns nullptr if the handle
+ * is invalid or being deregistered.
+ *
+ * The caller MUST keep *out_sp alive for the duration of the operation
+ * and call handle_release() when done. */
+static inline HandleState* handle_lookup(uGDSHandle_t fh,
+                                          std::shared_ptr<HandleState>* out_sp) {
+    std::lock_guard<std::mutex> g(g_driver.lock);
+    auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+    if (it == g_driver.handle_registry.end())
+        return nullptr;
+    if (it->second->closing.load(std::memory_order_acquire))
+        return nullptr;
+    if (it->second->wedged.load(std::memory_order_acquire))
+        return nullptr;
+    *out_sp = it->second;
+    it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+    return it->second.get();
+}
+
+/* Same as handle_lookup but assumes the caller already holds g_driver.lock.
+ * Use to avoid deadlock when called from a context that already holds
+ * the driver mutex (e.g. async_validate). */
+static inline HandleState* handle_lookup_locked(uGDSHandle_t fh,
+                                                  std::shared_ptr<HandleState>* out_sp) {
+    auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+    if (it == g_driver.handle_registry.end())
+        return nullptr;
+    if (it->second->closing.load(std::memory_order_acquire))
+        return nullptr;
+    if (it->second->wedged.load(std::memory_order_acquire))
+        return nullptr;
+    *out_sp = it->second;
+    it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+    return it->second.get();
+}
+
+static inline void handle_release(HandleState* hs) {
+    hs->handle_in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
 
 struct PRPPool {
     nvm_dma_t*  dma       = nullptr;
@@ -130,6 +191,7 @@ struct BatchState {
     PRPPool                   prp_pool;
 
     HandleState* hs = nullptr;
+    std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive for batch lifetime */
     std::mutex   lock;
 };
 
@@ -153,7 +215,11 @@ struct AsyncRequest {
     off_t*          bufPtr_offset_p;
     ssize_t*        bytes_done_p;
     uint8_t         opcode;
+    std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
 };
+
+/* Internal stream type -- void* for backend neutrality */
+typedef void* ugsd_stream_t;
 
 void* hugepage_alloc(size_t size, size_t* alloc_size_out);
 void  hugepage_free(void* ptr, size_t alloc_size);

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -47,6 +47,10 @@ struct IOQueuePair {
     void*          prp_buf = nullptr;
     int            irq_efd = -1;   /* eventfd for interrupt mode; -1 = poll */
     uint16_t       irq_vec = 0;    /* MSI-X vector bound to this CQ */
+    /* Timeout resources remain owned by the QP until controller recovery.
+     * At most one synchronous operation can hold this QP lock. */
+    nvm_dma_t*     timeout_dma = nullptr;           /* on-the-fly mapping */
+    const void*    timeout_registered_buf = nullptr; /* registered ref */
     std::mutex     lock;
 };
 

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -1,6 +1,7 @@
 #include "ugds_internal.h"
 
 #include <cstring>
+#include <cstdio>
 #include <cerrno>
 #include <atomic>
 #include <algorithm>
@@ -112,17 +113,30 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         std::lock_guard<std::mutex> drv_lock(g_driver.lock);
         auto it = g_driver.buf_registry.find(bufPtr_base);
         if (it != g_driver.buf_registry.end()) {
-            buf_dma = it->second;
+            buf_dma = it->second.dma;
+            it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
         }
     }
 
     if (buf_dma != nullptr) {
         if ((static_cast<size_t>(bufPtr_offset) % page_size) != 0) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(bufPtr_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
             return -EINVAL;
         }
         buf_page_start = static_cast<size_t>(bufPtr_offset) / page_size;
-        size_t total_pages_needed = buf_page_start + (size + page_size - 1) / page_size;
-        if (total_pages_needed > buf_dma->n_ioaddrs) {
+        /* Overflow-safe bounds check: compute pages_needed separately,
+         * then verify buf_page_start + pages_needed <= n_ioaddrs
+         * without risking wrap. */
+        size_t pages_needed = (size - 1) / page_size + 1;
+        if (pages_needed > buf_dma->n_ioaddrs ||
+            buf_page_start > buf_dma->n_ioaddrs - pages_needed) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(bufPtr_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
             return -EINVAL;
         }
     } else {
@@ -161,12 +175,20 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     IOQueuePair& qp = *hs->qps[qp_idx];
 
     ssize_t result = 0;
+    bool timed_out = false;
     size_t bytes_done = 0;
     uint64_t current_lba = start_lba;
     size_t current_page = buf_page_start;
 
     {
         std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        /* Re-check wedged after acquiring QP lock: a previous
+         * operation may have timed out while we waited. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            result = -EBADF;
+            goto out;
+        }
 
         while (bytes_done < size) {
             size_t remaining = size - bytes_done;
@@ -230,6 +252,10 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             nvm_cpl_t* cpl = wait_for_completion(hs, qp);
             if (cpl == nullptr) {
                 result = -EIO;
+                timed_out = true;
+                /* Mark wedged while still holding qp.lock to prevent
+                 * QP reuse before the flag is visible. */
+                hs->wedged.store(true, std::memory_order_release);
                 goto out;
             }
 
@@ -253,8 +279,20 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     out:;
     }
 
-    if (on_the_fly && buf_dma != nullptr) {
+    if (timed_out) {
+        /* NVMe command may still be executing. wedged was set
+         * under qp.lock. Retain all resources. */
+        fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
+                "Controller reset required.\n");
+        /* Do NOT unmap on-the-fly buffer or release in-flight ref. */
+    } else if (on_the_fly && buf_dma != nullptr) {
         nvm_dma_unmap(buf_dma);
+    } else if (buf_dma != nullptr) {
+        /* Registered buffer: release in-flight reference. */
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        auto it = g_driver.buf_registry.find(bufPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     return result;
@@ -263,12 +301,24 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 extern "C" ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                               off_t file_offset, off_t bufPtr_offset)
 {
-    return do_io_internal(fh, bufPtr_base, size, file_offset, bufPtr_offset, NVM_IO_READ);
+    if (fh == nullptr) return -EINVAL;
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs) return -EBADF;
+    ssize_t ret = do_io_internal(fh, bufPtr_base, size, file_offset, bufPtr_offset, NVM_IO_READ);
+    handle_release(hs);
+    return ret;
 }
 
 extern "C" ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                                off_t file_offset, off_t bufPtr_offset)
 {
-    return do_io_internal(fh, const_cast<void*>(bufPtr_base), size, file_offset, bufPtr_offset,
+    if (fh == nullptr) return -EINVAL;
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs) return -EBADF;
+    ssize_t ret = do_io_internal(fh, const_cast<void*>(bufPtr_base), size, file_offset, bufPtr_offset,
                  NVM_IO_WRITE);
+    handle_release(hs);
+    return ret;
 }

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -209,6 +209,10 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 nvm_cpl_t* drain = wait_for_completion(hs, qp);
                 if (drain == nullptr) {
                     result = -EIO;
+                    /* An older submitted command may still DMA. Treat this
+                     * exactly like a post-submit completion timeout. */
+                    timed_out = true;
+                    hs->wedged.store(true, std::memory_order_release);
                     goto out;
                 }
                 uint16_t st = UGDS_CPL_SCT_SC(drain);
@@ -282,6 +286,14 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     if (timed_out) {
         /* NVMe command may still be executing. wedged was set
          * under qp.lock. Retain all resources. */
+        if (on_the_fly) {
+            /* Transfer ownership from this stack frame to the QP. */
+            qp.timeout_dma = buf_dma;
+        } else {
+            /* Keep the registered buffer's in-flight reference. */
+            qp.timeout_registered_buf = bufPtr_base;
+        }
+        buf_dma = nullptr;
         fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
                 "Controller reset required.\n");
         /* Do NOT unmap on-the-fly buffer or release in-flight ref. */

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -299,7 +299,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         /* Do NOT unmap on-the-fly buffer or release in-flight ref. */
     } else if (on_the_fly && buf_dma != nullptr) {
         nvm_dma_unmap(buf_dma);
-    } else if (buf_dma != nullptr) {
+    } else if (!on_the_fly && buf_dma != nullptr) {
         /* Registered buffer: release in-flight reference. */
         std::lock_guard<std::mutex> drv_lock(g_driver.lock);
         auto it = g_driver.buf_registry.find(bufPtr_base);

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -280,23 +280,28 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         }
 
         result = static_cast<ssize_t>(bytes_done);
+
+        /* Transfer timeout resources to the QP while we still hold
+         * qp.lock.  A concurrent force teardown also acquires qp.lock
+         * in cleanup_timeout_resources(), so this prevents the race
+         * where teardown destroys the QP before we store the mapping. */
+        if (timed_out) {
+            if (on_the_fly) {
+                qp.timeout_dma = buf_dma;
+            } else {
+                qp.timeout_registered_buf = bufPtr_base;
+            }
+            buf_dma = nullptr;
+        }
+
     out:;
     }
 
     if (timed_out) {
         /* NVMe command may still be executing. wedged was set
-         * under qp.lock. Retain all resources. */
-        if (on_the_fly) {
-            /* Transfer ownership from this stack frame to the QP. */
-            qp.timeout_dma = buf_dma;
-        } else {
-            /* Keep the registered buffer's in-flight reference. */
-            qp.timeout_registered_buf = bufPtr_base;
-        }
-        buf_dma = nullptr;
+         * under qp.lock. Resources were transferred to the QP above. */
         fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
                 "Controller reset required.\n");
-        /* Do NOT unmap on-the-fly buffer or release in-flight ref. */
     } else if (on_the_fly && buf_dma != nullptr) {
         nvm_dma_unmap(buf_dma);
     } else if (!on_the_fly && buf_dma != nullptr) {

--- a/test/functional/test_async_basic.cu
+++ b/test/functional/test_async_basic.cu
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_async_errors.cu
+++ b/test/functional/test_async_errors.cu
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     {
         void* d_buf;
         cudaMalloc(&d_buf, 65536);
-        ASSERT_OK(uGDSBufRegister(d_buf, 65536, 0), "BufRegister");
+        ASSERT_OK(uGDSBufRegister(d_buf, 65536, TEST_BUF_FLAGS), "BufRegister");
 
         ssize_t bytes = 0;
         uGDSError_t st = uGDSReadAsync(fh, d_buf, &size, &file_off, &buf_off,

--- a/test/functional/test_async_late_binding.cu
+++ b/test/functional/test_async_late_binding.cu
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_async_multi_stream.cu
+++ b/test/functional/test_async_multi_stream.cu
@@ -17,7 +17,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t streams[N_STREAMS];
     for (int i = 0; i < N_STREAMS; i++)

--- a/test/functional/test_async_stream_order.cu
+++ b/test/functional/test_async_stream_order.cu
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
     void* d_buf;
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
-    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, 0), "BufRegister");
+    ASSERT_OK(uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS), "BufRegister");
 
     cudaStream_t stream;
     cudaStreamCreate(&stream);

--- a/test/functional/test_batch_basic.cu
+++ b/test/functional/test_batch_basic.cu
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Step 1: sync-write a known pattern to offset 0

--- a/test/functional/test_batch_deep.cu
+++ b/test/functional/test_batch_deep.cu
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, total);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, total, 0);
+    st = uGDSBufRegister(d_buf, total, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Sync-write 128 distinct patterns

--- a/test/functional/test_batch_mixed_ops.cu
+++ b/test/functional/test_batch_mixed_ops.cu
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     uGDSBatchHandle_t batch = nullptr;

--- a/test/functional/test_batch_mixed_sizes.cu
+++ b/test/functional/test_batch_mixed_sizes.cu
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, total);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, total, 0);
+    st = uGDSBufRegister(d_buf, total, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     // Step 1: sync-write each region with a distinct pattern

--- a/test/functional/test_batch_reuse.cu
+++ b/test/functional/test_batch_reuse.cu
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
     cudaMalloc(&d_buf, alloc_size);
     if (!d_buf) TEST_FAIL("cudaMalloc failed");
 
-    st = uGDSBufRegister(d_buf, alloc_size, 0);
+    st = uGDSBufRegister(d_buf, alloc_size, TEST_BUF_FLAGS);
     ASSERT_OK(st, "BufRegister");
 
     uGDSBatchHandle_t batch = nullptr;

--- a/test/functional/test_utils.h
+++ b/test/functional/test_utils.h
@@ -9,21 +9,21 @@
   #define cudaFree              hipFree
   #define cudaMemcpy           hipMemcpy
   #define cudaMemset            hipMemset
+  #define cudaMemsetAsync       hipMemsetAsync
   #define cudaSetDevice         hipSetDevice
   #define cudaDeviceSynchronize hipDeviceSynchronize
   #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
   #define cudaSuccess           hipSuccess
   #define cudaError_t           hipError_t
   #define cudaGetErrorString    hipGetErrorString
-  #define cudaStreamSynchronize hipStreamSynchronize
+  #define cudaStream_t          hipStream_t
   #define cudaStreamCreate      hipStreamCreate
   #define cudaStreamDestroy     hipStreamDestroy
-  #define cudaMemsetAsync       hipMemsetAsync
+  #define cudaStreamSynchronize hipStreamSynchronize
   #define cudaHostAlloc         hipHostMalloc
   #define cudaHostAllocDefault  hipHostMallocDefault
   #define cudaFreeHost          hipHostFree
   #define cudaLaunchHostFunc    hipLaunchHostFunc
-  #define cudaStream_t          hipStream_t
   /* HIP builds must use dmabuf path */
   #define TEST_BUF_FLAGS  UGDS_REGISTER_DMABUF
 #else

--- a/test/perf/cufile_bench.cu
+++ b/test/perf/cufile_bench.cu
@@ -19,10 +19,10 @@
   #define cudaSuccess           hipSuccess
   #define cudaError_t           hipError_t
   #define cudaGetErrorString    hipGetErrorString
-  #define cudaStreamSynchronize hipStreamSynchronize
+  #define cudaStream_t          hipStream_t
   #define cudaStreamCreate      hipStreamCreate
   #define cudaStreamDestroy     hipStreamDestroy
-  #define cudaStream_t          hipStream_t
+  #define cudaStreamSynchronize hipStreamSynchronize
   /* HIP builds must use dmabuf path */
   #define TEST_BUF_FLAGS  UGDS_REGISTER_DMABUF
 #else


### PR DESCRIPTION
## Summary

Introduce a dual-backend abstraction (CUDA + HIP) and handle lifetime management to support both GPU vendors within a single binary, and to prevent use-after-free under concurrent async IO and handle deregister.

Builds on #19 (kernel hardening).

## Changes

### Dual-backend stream abstraction
- Replace `cudaStream_t` with `void*` in public async API
- Backend dispatch via compile-time macros (CUDA-only, HIP-only, dual)
- `uGDSStreamRegisterEx` with explicit backend for mismatch detection
- Remove `cuda_runtime.h` from public `ugds.h` header

### Handle lifetime management
- Global `handle_registry` maps raw pointer to `shared_ptr<HandleState>`
- `handle_lookup` / `handle_release` for IO entrypoints
- `BatchState` and `AsyncRequest` hold `shared_ptr` copies
- `uGDSHandleDeregisterEx` with drain timeout
  - `timeout_sec < -1` forces teardown: skips wedged/in-flight checks and
    frees all resources unconditionally (for use after controller reset)
- `handle_registry` insertion wrapped in try-catch; returns
  `UGDS_OUT_OF_MEMORY` with full resource rollback on failure
- Legacy `uGDSHandleDeregister` logs errors from `DeregisterEx`
- `UGDS_BUSY` when handles or buffers are still in use at `DriverClose`

### Timeout safety
- `wedged` flag on `HandleState`, set under `qp.lock` on CQ or batch timeout
- Checked at `handle_lookup`, `qp.lock` acquisition, `HandleDeregisterEx`
  (before, inside, and after drain loop), and `BatchIOSubmit`
- `BatchIOSubmit` also checks `closing` to block new commands during drain
- On timeout: retain `in_flight` reference and on-the-fly mapping

### Buffer registry
- `BufEntry` with backend tracking and atomic `in_flight` counter
- `g_driver.initialized` is `std::atomic<bool>`
- `ENOTSUP` / `EOPNOTSUPP` mapped to `UGDS_IO_NOT_SUPPORTED` in `uGDSBufRegister`

### Batch and IO safety
- Overflow-safe page/count validation in batch/sync IO paths
- `UINT16_MAX` batch command count check
- `uGDSBatchIODestroy` drains in-flight commands; reports wedged handles to stderr on timeout

### Test infrastructure
- `run_tests.sh`: exit code 77 treated as SKIP, dual-backend suffix (`_cuda`/`_hip`) discovery
- Unregistered HIP I/O test skipped in dual mode (documented limitation)

## Build

| Backend | Status |
|---------|--------|
| CUDA-only | Pass |
| HIP-only | Pass |
| Dual (CUDA + HIP) | Pass |

## Stack

1. ~~#19: kernel hardening~~ (merged)
2. **#21** (this PR)
3. **#16**: fd export (depends on #21)