### PR TITLE
[codex] Fix libcufile detection in env switch

### DIFF
--- a/scripts/env_switch.sh
+++ b/scripts/env_switch.sh
@@ -7,6 +7,12 @@
 #   ./scripts/env_switch.sh ugds  <pci_slot>          Switch device to UGDS mode
 #   ./scripts/env_switch.sh gds   <pci_slot> [mount]  Switch device to GDS mode
 #
+# Environment:
+#   CUFILE_LIB         Optional explicit path to libcufile.so for status checks
+#   CUDA_HOME          Optional CUDA toolkit root used to find libcufile.so
+#   CUDA_PATH          Optional CUDA toolkit root used to find libcufile.so
+#   CUDAToolkit_ROOT   Optional CUDA toolkit root used to find libcufile.so
+#
 # Examples:
 #   ./scripts/env_switch.sh status
 #   ./scripts/env_switch.sh ugds 0000:b8:00.0
@@ -117,6 +123,44 @@ list_nvme_devices() {
     done
 }
 
+find_libcufile() {
+    local path
+
+    if [ -n "${CUFILE_LIB:-}" ] && [ -f "$CUFILE_LIB" ]; then
+        echo "$CUFILE_LIB"
+        return 0
+    fi
+
+    local cuda_roots=()
+    [ -n "${CUDA_HOME:-}" ] && cuda_roots+=("$CUDA_HOME")
+    [ -n "${CUDA_PATH:-}" ] && cuda_roots+=("$CUDA_PATH")
+    [ -n "${CUDAToolkit_ROOT:-}" ] && cuda_roots+=("$CUDAToolkit_ROOT")
+
+    local root
+    for root in "${cuda_roots[@]}" /usr/local/cuda /usr/local/cuda-*; do
+        [ -d "$root" ] || continue
+        for path in \
+            "$root"/targets/*-linux/lib/libcufile.so \
+            "$root"/lib64/libcufile.so; do
+            [ -f "$path" ] || continue
+            echo "$path"
+            return 0
+        done
+    done
+
+    local ldconfig_bin
+    for ldconfig_bin in ldconfig /sbin/ldconfig; do
+        command -v "$ldconfig_bin" > /dev/null 2>&1 || continue
+        path=$("$ldconfig_bin" -p 2>/dev/null | awk '/libcufile\.so/{print $NF; exit}')
+        if [ -n "$path" ] && [ -e "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 # ── Commands ─────────────────────────────────────────────────────────
 
 cmd_status() {
@@ -132,8 +176,9 @@ cmd_status() {
     ls /dev/ugds_drv* 2>/dev/null | while read -r d; do echo "  $d"; done || echo "  (no devices)"
     echo ""
     echo "=== GDS ==="
-    if [ -f /usr/local/cuda-12.4/targets/x86_64-linux/lib/libcufile.so ]; then
-        echo "  libcufile: available"
+    local cufile_lib
+    if cufile_lib=$(find_libcufile); then
+        echo "  libcufile: available ($cufile_lib)"
     else
         echo "  libcufile: NOT FOUND"
     fi


### PR DESCRIPTION
## Summary

- Fixes #10.
- Replaces the hardcoded `/usr/local/cuda-12.4/.../libcufile.so` status check with dynamic libcufile discovery.
- Honors `CUFILE_LIB`, `CUDA_HOME`, `CUDA_PATH`, and `CUDAToolkit_ROOT`, then falls back to common `/usr/local/cuda*` installs and `ldconfig`.
- Prints the detected libcufile path in `env_switch.sh status` when available.

## Validation

- `bash -n scripts/env_switch.sh`
- `git diff --check`
- `scripts/env_switch.sh --help`
- Simulated `find_libcufile` checks for `CUFILE_LIB`, `CUDA_HOME`, and `CUDA_PATH`.

Note: full hardware integration tests require a Linux CUDA/GDS/NVMe setup and are not runnable on this local macOS environment.
