### PR TITLE
fix: close hot-remove race and replace curr_ctrls with idr

### DIFF
--- a/drv/ctrl.c
+++ b/drv/ctrl.c
@@ -42,6 +42,7 @@ struct ctrl* ctrl_get(struct class* cls, struct pci_dev* pdev, int number)
 
     list_node_init(&ctrl->list);
     kref_init(&ctrl->ref);
+    ctrl->dying = 0;
 
     ctrl->pdev = pci_dev_get(pdev);
     ctrl->number = number;
@@ -117,6 +118,13 @@ struct ctrl* ctrl_find_and_get_by_inode(struct list* list, const struct inode* i
 
         if (ctrl->cdev == inode->i_cdev)
         {
+            /* Refuse opens on controllers being removed. The dying
+             * flag is set under the list spinlock in remove_pci_dev,
+             * so this check is atomic with respect to list removal. */
+            if (ctrl->dying)
+            {
+                break;
+            }
             /* Same lock domain as list removal in remove_pci_dev,
              * so a controller found here cannot have dropped its
              * final reference yet. */

--- a/drv/ctrl.c
+++ b/drv/ctrl.c
@@ -121,7 +121,7 @@ struct ctrl* ctrl_find_and_get_by_inode(struct list* list, const struct inode* i
             /* Refuse opens on controllers being removed. The dying
              * flag is set under the list spinlock in remove_pci_dev,
              * so this check is atomic with respect to list removal. */
-            if (ctrl->dying)
+            if (READ_ONCE(ctrl->dying))
             {
                 break;
             }

--- a/drv/ctrl.h
+++ b/drv/ctrl.h
@@ -42,6 +42,7 @@ struct ctrl
     struct cdev*        cdev;       /* Character device (cdev_alloc'd) */
     struct device*      chrdev;     /* Character device handle */
     bool                dmabuf_supported; /* 64-bit DMA mask established */
+    bool                dying;      /* Set in remove_pci_dev, checked in dev_open */
 
     struct ugds_irq_state* irq;     /* Opaque; managed by irq.c */
 };

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -22,6 +22,7 @@
 #include <linux/device.h>
 #include <linux/version.h>
 #include <linux/overflow.h>
+#include <linux/idr.h>
 #include <linux/uaccess.h>
 #include "irq.h"
 #include <asm/io.h>
@@ -84,7 +85,8 @@ static int max_num_ctrls = 64;
 module_param(max_num_ctrls, int, 0);
 MODULE_PARM_DESC(max_num_ctrls, "Number of controller devices");
 
-static int curr_ctrls = 0;
+static DEFINE_IDR(ctrl_idr);
+static DEFINE_MUTEX(ctrl_idr_mutex);
 
 
 enum handle_type
@@ -227,6 +229,16 @@ static int dev_open(struct inode* inode, struct file* file)
     file->private_data = ctx;
 
     mutex_lock(&ctx_list_mutex);
+    /* Re-check dying under ctx_list_mutex: remove_pci_dev sets dying
+     * and then iterates ctx_list under this same mutex. If we add
+     * our ctx after that iteration completed, dying is already true. */
+    if (ctrl->dying)
+    {
+        mutex_unlock(&ctx_list_mutex);
+        ctrl_put(ctrl);
+        kfree(ctx);
+        return -ENODEV;
+    }
     list_add(&ctx->global_node, &ctx_list);
     mutex_unlock(&ctx_list_mutex);
 
@@ -668,20 +680,28 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     int err;
     struct ctrl* ctrl = NULL;
 
-    if (curr_ctrls >= max_num_ctrls)
-    {
-        printk(KERN_NOTICE "Maximum number of controller devices added\n");
-        return 0;
-    }
-
     printk(KERN_INFO "Adding controller device: %02x:%02x.%1x",
             dev->bus->number, PCI_SLOT(dev->devfn), PCI_FUNC(dev->devfn));
 
+    mutex_lock(&ctrl_idr_mutex);
+    int ctrl_num = idr_alloc(&ctrl_idr, NULL, 0, max_num_ctrls, GFP_KERNEL);
+    mutex_unlock(&ctrl_idr_mutex);
+    if (ctrl_num < 0)
+    {
+        if (ctrl_num == -ENOSPC)
+        {
+            printk(KERN_NOTICE "Maximum number of controller devices added\n");
+            return 0;  /* capacity is not an error */
+        }
+        return ctrl_num;  /* propagate -ENOMEM etc. */
+    }
+
     // Create controller reference
-    ctrl = ctrl_get(dev_class, dev, curr_ctrls);
+    ctrl = ctrl_get(dev_class, dev, ctrl_num);
     if (IS_ERR(ctrl))
     {
-        return PTR_ERR(ctrl);
+        err = PTR_ERR(ctrl);
+        goto fail_idr;
     }
 
     // Get a reference to device memory
@@ -690,7 +710,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     {
         ctrl_put(ctrl);
         printk(KERN_ERR "Failed to get controller register memory\n");
-        return err;
+        goto fail_idr;
     }
 
     // Enable PCI device
@@ -700,7 +720,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
         printk(KERN_ERR "Failed to enable controller\n");
-        return err;
+        goto fail_idr;
     }
 
     // Create character device file
@@ -710,7 +730,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_disable_device(dev);
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
-        return err;
+        goto fail_idr;
     }
 
     // Enable DMA
@@ -728,7 +748,8 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_disable_device(dev);
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
-        return -EIO;
+        err = -EIO;
+        goto fail_idr;
     }
     ctrl->dmabuf_supported = 1;
 #elif defined(UGDS_HAVE_DMABUF)
@@ -766,7 +787,8 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
             pci_disable_device(dev);
             pci_release_region(dev, 0);
             ctrl_put(ctrl);
-            return -EIO;
+            err = -EIO;
+            goto fail_idr;
         }
         printk(KERN_WARNING DRIVER_NAME " using 32-bit DMA mask\n");
     }
@@ -779,8 +801,13 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
      * initialized controller. */
     ctrl_publish(&ctrl_list, ctrl);
 
-    ++curr_ctrls;
     return 0;
+
+fail_idr:
+    mutex_lock(&ctrl_idr_mutex);
+    idr_remove(&ctrl_idr, ctrl_num);
+    mutex_unlock(&ctrl_idr_mutex);
+    return err;
 }
 
 
@@ -803,10 +830,19 @@ static void remove_pci_dev(struct pci_dev* dev)
         return;
     }
 
-    /* 1. Unpublish: new opens can no longer find this controller.
-     *    (list_remove takes the list spinlock -- same lock domain as
-     *    ctrl_find_and_get_by_inode.) */
-    list_remove(&ctrl->list);
+    /* 1. Unpublish: mark dying under list spinlock, then remove from list.
+     *    dev_open checks dying atomically so it cannot miss removal. */
+    spin_lock(&ctrl_list.lock);
+    ctrl->dying = true;
+    if (likely(ctrl->list.list != NULL && &ctrl->list != &ctrl->list.list->head))
+    {
+        ctrl->list.prev->next = ctrl->list.next;
+        ctrl->list.next->prev = ctrl->list.prev;
+        ctrl->list.list = NULL;
+        ctrl->list.next = NULL;
+        ctrl->list.prev = NULL;
+    }
+    spin_unlock(&ctrl_list.lock);
 
     /* 2. Device node disappears. */
     ctrl_chrdev_remove(ctrl);
@@ -843,7 +879,9 @@ static void remove_pci_dev(struct pci_dev* dev)
 
     /* 5. All DMA on this controller is now unmapped, satisfying the
      *    DMA API contract before the device goes away. */
-    --curr_ctrls;
+    mutex_lock(&ctrl_idr_mutex);
+    idr_remove(&ctrl_idr, ctrl->number);
+    mutex_unlock(&ctrl_idr_mutex);
     pci_release_region(dev, 0);
     pci_clear_master(dev);
     pci_disable_device(dev);

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -85,8 +85,8 @@ static int max_num_ctrls = 64;
 module_param(max_num_ctrls, int, 0);
 MODULE_PARM_DESC(max_num_ctrls, "Number of controller devices");
 
-static DEFINE_IDR(ctrl_idr);
-static DEFINE_MUTEX(ctrl_idr_mutex);
+/* Only the minor number is tracked; IDA is the ID-only allocator. */
+static DEFINE_IDA(ctrl_ida);
 
 
 enum handle_type
@@ -232,7 +232,7 @@ static int dev_open(struct inode* inode, struct file* file)
     /* Re-check dying under ctx_list_mutex: remove_pci_dev sets dying
      * and then iterates ctx_list under this same mutex. If we add
      * our ctx after that iteration completed, dying is already true. */
-    if (ctrl->dying)
+    if (READ_ONCE(ctrl->dying))
     {
         mutex_unlock(&ctx_list_mutex);
         ctrl_put(ctrl);
@@ -683,9 +683,14 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     printk(KERN_INFO "Adding controller device: %02x:%02x.%1x",
             dev->bus->number, PCI_SLOT(dev->devfn), PCI_FUNC(dev->devfn));
 
-    mutex_lock(&ctrl_idr_mutex);
-    int ctrl_num = idr_alloc(&ctrl_idr, NULL, 0, max_num_ctrls, GFP_KERNEL);
-    mutex_unlock(&ctrl_idr_mutex);
+    if (max_num_ctrls <= 0)
+    {
+        printk(KERN_NOTICE "Maximum number of controller devices is zero\n");
+        return 0;
+    }
+
+    int ctrl_num = ida_alloc_range(&ctrl_ida, 0, max_num_ctrls - 1,
+                                   GFP_KERNEL);
     if (ctrl_num < 0)
     {
         if (ctrl_num == -ENOSPC)
@@ -701,7 +706,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     if (IS_ERR(ctrl))
     {
         err = PTR_ERR(ctrl);
-        goto fail_idr;
+        goto fail_ida;
     }
 
     // Get a reference to device memory
@@ -710,7 +715,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
     {
         ctrl_put(ctrl);
         printk(KERN_ERR "Failed to get controller register memory\n");
-        goto fail_idr;
+        goto fail_ida;
     }
 
     // Enable PCI device
@@ -720,7 +725,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
         printk(KERN_ERR "Failed to enable controller\n");
-        goto fail_idr;
+        goto fail_ida;
     }
 
     // Create character device file
@@ -730,7 +735,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_disable_device(dev);
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
-        goto fail_idr;
+        goto fail_ida;
     }
 
     // Enable DMA
@@ -749,7 +754,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
         pci_release_region(dev, 0);
         ctrl_put(ctrl);
         err = -EIO;
-        goto fail_idr;
+        goto fail_ida;
     }
     ctrl->dmabuf_supported = 1;
 #elif defined(UGDS_HAVE_DMABUF)
@@ -788,7 +793,7 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
             pci_release_region(dev, 0);
             ctrl_put(ctrl);
             err = -EIO;
-            goto fail_idr;
+            goto fail_ida;
         }
         printk(KERN_WARNING DRIVER_NAME " using 32-bit DMA mask\n");
     }
@@ -803,10 +808,8 @@ static int add_pci_dev(struct pci_dev* dev, const struct pci_device_id* id)
 
     return 0;
 
-fail_idr:
-    mutex_lock(&ctrl_idr_mutex);
-    idr_remove(&ctrl_idr, ctrl_num);
-    mutex_unlock(&ctrl_idr_mutex);
+fail_ida:
+    ida_free(&ctrl_ida, ctrl_num);
     return err;
 }
 
@@ -833,7 +836,7 @@ static void remove_pci_dev(struct pci_dev* dev)
     /* 1. Unpublish: mark dying under list spinlock, then remove from list.
      *    dev_open checks dying atomically so it cannot miss removal. */
     spin_lock(&ctrl_list.lock);
-    ctrl->dying = true;
+    WRITE_ONCE(ctrl->dying, true);
     if (likely(ctrl->list.list != NULL && &ctrl->list != &ctrl->list.list->head))
     {
         ctrl->list.prev->next = ctrl->list.next;
@@ -879,9 +882,7 @@ static void remove_pci_dev(struct pci_dev* dev)
 
     /* 5. All DMA on this controller is now unmapped, satisfying the
      *    DMA API contract before the device goes away. */
-    mutex_lock(&ctrl_idr_mutex);
-    idr_remove(&ctrl_idr, ctrl->number);
-    mutex_unlock(&ctrl_idr_mutex);
+    ida_free(&ctrl_ida, ctrl->number);
     pci_release_region(dev, 0);
     pci_clear_master(dev);
     pci_disable_device(dev);


### PR DESCRIPTION
Found during review of #19.

**Hot-remove race:** dev_open could acquire a kref and add its context to ctx_list after remove_pci_dev had already settled that list. The new context would be missed by cleanup, leaving stale references to a removed PCI device.

Fix: ctrl->dying is set under ctrl_list spinlock before list removal. ctrl_find_and_get_by_inode checks dying under the same spinlock. dev_open re-checks dying under ctx_list_mutex before adding to the list.

**Minor number reuse:** curr_ctrls was both a count and a minor allocator. Removing a non-last controller and probing another would reuse an active minor.

Fix: Replaced with idr_alloc/idr_remove. All probe failure paths go through a fail_idr cleanup label.

Out of scope: VMA revocation after hot-remove (pre-existing), dma_resv_lock interruptible wait (separate concern).