### PR TITLE
[feat] Add scatter-gather vectored I/O support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(UGDS_SOURCES
     src/ugds_handle.cpp
     src/ugds_buf.cpp
     src/ugds_io.cpp
+    src/ugds_iov.cpp
     src/ugds_batch.cpp
     src/ugds_async.cpp
     src/ugds_rdma.cpp

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -121,16 +121,28 @@ typedef struct uGDSDescr_t {
 
 typedef void* uGDSHandle_t;
 
+/* Open the uGDS driver: discover the NVMe controller and initialize
+ * the global driver state.  Must be called once before any other API.
+ * Returns UGDS_OK or an error if the controller cannot be opened. */
 uGDSError_t uGDSDriverOpen(void);
 
+/* Close the driver and release controller resources.  All handles and
+ * buffers should be deregistered first. */
 uGDSError_t uGDSDriverClose(void);
 
+/* Register a file/Windows handle obtained from the user as a uGDS
+ * handle.  'descr' describes the underlying OS handle type (opaque fd
+ * on Linux, opaque handle on Windows, userspace FS).  The returned
+ * *fh is the opaque handle used by all IO entry points. */
 uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
 
 /* Return the usable NVMe namespace capacity in bytes for a registered handle. */
 uGDSError_t uGDSGetDeviceCapacity(uGDSHandle_t fh,
                                   uint64_t* capacity_bytes);
 
+/* Deregister a handle (non-blocking, equivalent to DeregisterEx with
+ * timeout_sec == -1).  Blocks until all in-flight operations on this
+ * handle have drained. */
 void uGDSHandleDeregister(uGDSHandle_t fh);
 
 /* Deregister a handle with a drain timeout.
@@ -151,6 +163,11 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * API may use it. The caller must have already reset the controller. */
 uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
 
+/* Register a device/host buffer for direct IO.  'bufPtr_base' is the
+ * exact base pointer of the allocation; 'length' is in bytes.  'flags'
+ * may include UGDS_REGISTER_DMABUF to use the AMD HIP/dma-buf path.
+ * The registration creates the dma mapping used by subsequent IO calls;
+ * it must be released by uGDSBufDeregister. */
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 
 /* Flag for uGDSBufRegister: use AMD HIP/dma-buf path */
@@ -162,6 +179,9 @@ uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 #define NVM_MAP_RDMA        0x2    /* Retain dmabuf fd for RDMA use */
 #define NVM_MAP_FORCE_CUDA  0x4    /* Force CUDA path (skip auto-probe) */
 
+/* Release a buffer registration previously created by uGDSBufRegister
+ * or uGDSBufRegisterEx.  Blocks until all in-flight IO on this buffer
+ * has drained; returns UGDS_BUSY if the drain cannot complete. */
 uGDSError_t uGDSBufDeregister(const void* bufPtr_base);
 
 /* Backend identifier for dual-backend dispatch. */
@@ -177,6 +197,10 @@ typedef struct uGDSBufConfig {
     bool            enable_export;
 } uGDSBufConfig_t;
 
+/* Register a device/host buffer with an explicit backend selection
+ * (CUDA or HIP) and optional dma-buf export flag.  In dual-backend
+ * builds the backend drives async launch dispatch; in single-backend
+ * builds it is validated against the compiled-in backend. */
 uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,
                                const uGDSBufConfig_t* config);
 
@@ -188,6 +212,11 @@ typedef struct uGDSDmabufExport {
     size_t    length;
 } uGDSDmabufExport_t;
 
+/* Export a dma-buf file descriptor for a registered buffer so it can
+ * be registered with an RDMA NIC via ibv_reg_dmabuf_mr().  'out->fd'
+ * is dup()'d -- the caller owns it and MUST close() it after use.
+ * Requires the buffer to have been registered with NVM_MAP_RDMA at
+ * uGDSBufRegister time. */
 uGDSError_t uGDSExportDmabuf(const void* bufPtr_base,
                               uGDSDmabufExport_t* out);
 
@@ -215,9 +244,17 @@ uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
 uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
                                 uGDSRDMARegion_t* region);
 
+/* Synchronous read from the namespace into a registered device buffer.
+ * 'bufPtr_base' must have been registered via uGDSBufRegister/
+ * uGDSBufRegisterEx (exact value); 'bufPtr_offset' is the byte offset
+ * inside that registration.  'size' must be a multiple of the namespace
+ * block size and bounded by the controller MDTS.  Returns the number of
+ * bytes read, or -errno on failure. */
 ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                    off_t file_offset, off_t bufPtr_offset);
 
+/* Synchronous write to the namespace from a registered device buffer.
+ * Argument and return conventions match uGDSRead. */
 ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                     off_t file_offset, off_t bufPtr_offset);
 
@@ -254,16 +291,36 @@ typedef struct uGDSIOEvents {
     ssize_t             ret;
 } uGDSIOEvents_t;
 
+/* Create a batch IO context bound to 'fh' with capacity for 'nr'
+ * entries.  Allocates the batch's private submission/completion
+ * resources and a dedicated QP (UGDS_BATCH_QUEUE_DEPTH).  The handle
+ * is pinned for the lifetime of the batch via an internal shared_ptr.
+ * Only one batch may be active per handle at a time; a second SetUp
+ * returns UGDS_BUSY. */
 uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch, uGDSHandle_t fh,
                                unsigned nr);
 
+/* Submit up to 'nr' plain (single-buffer) IO entries.  Each iocb[k]
+ * describes a single devPtr_base/file_offset/size transfer.  Entries
+ * are appended to the batch ring; completions are reaped via
+ * uGDSBatchIOGetStatus.  Vectored entries may be mixed on the same
+ * batch via uGDSBatchIOSubmitv. */
 uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                                uGDSIOParams_t* iocb, unsigned flags);
 
+/* Reap completions.  Blocks until at least 'min_nr' entries have
+ * completed or 'timeout' elapses, then copies up to *nr events into
+ * 'events'.  On return *nr holds the number actually reaped (0 on
+ * timeout).  Events may be returned in any order. */
 uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
                                   unsigned* nr, uGDSIOEvents_t* events,
                                   struct timespec* timeout);
 
+/* Destroy the batch context.  Drains in-flight commands under a
+ * bounded timeout.  If the drain fails the handle is wedged and the
+ * batch transitions to WEDGED; the caller must reset the controller
+ * and then call uGDSHandleDeregisterEx with timeout_sec < -1 to force
+ * teardown. */
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
 /* -- Vectored (scatter-gather) IO -- */
@@ -274,34 +331,52 @@ void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
  * multiple of the controller page size (MPS).  'size' must be a
  * multiple of the namespace block size and non-zero.  offset + size
  * must not exceed the length passed at registration (the exact byte
- * length, not a page-rounded value). */
+ * length, not a page-rounded value).
+ *
+ * The registration invariants enforced at acquire time are:
+ *   - registered-range bound on offset + size
+ *   - controller affinity between the buffer and the submitting handle */
 typedef struct uGDSIoSegment {
-    void*   base;
-    off_t   offset;
-    size_t  size;
+    void*   base;     /* registered buffer base (exact registry key) */
+    off_t   offset;   /* byte offset inside base; must be MPS-aligned */
+    size_t  size;     /* transfer size in bytes; must be block-multiple */
 } uGDSIoSegment_t;
 
-#define UGDS_IOV_MAX        1024   /* sync/async: POSIX IOV_MAX parity */
-#define UGDS_BATCH_IOV_MAX  128    /* per batch entry (bounds arena) */
+/* Maximum number of segments per sync/async vectored call.
+ * Mirrors POSIX IOV_MAX so callers can reuse existing iov sizing. */
+#define UGDS_IOV_MAX        1024
 
-/* Vectored read/write.  Segments are consumed in array order:
- * segs[0] maps to [file_offset, file_offset + segs[0].size), etc.
- * Returns total bytes transferred, or -errno (same convention as
- * uGDSRead/uGDSWrite).  The segment array is fully consumed during
- * the call (synchronous); the caller may free/reuse it on return.
- * (Implementation in Phase 1.) */
+/* Maximum number of segments per vectored batch entry.  Bounds the
+ * arena allocation: capacity * UGDS_BATCH_IOV_MAX SegView slots are
+ * reserved once per batch object lifetime. */
+#define UGDS_BATCH_IOV_MAX  128
+
+/* Vectored read.  Segments are consumed in array order: segs[0] maps
+ * to [file_offset, file_offset + segs[0].size), segs[1] continues at
+ * file_offset + segs[0].size, and so on.  Returns total bytes read, or
+ * -errno (same convention as uGDSRead/uGDSWrite).
+ *
+ * The segment array is fully consumed during the call (synchronous);
+ * the caller may free/reuse it on return.
+ *
+ * Validation is performed up-front under g_driver.lock (exact-length
+ * bound, controller affinity check, MPS alignment of offset,
+ * block-multiple of size, overflow-safe total).  On timeout the handle
+ * is marked wedged and -EIO is returned; a controller reset is then
+ * required before the handle can be reused. */
 ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                     unsigned nr_segs, off_t file_offset);
 
+/* Vectored write.  Layout and error conventions match uGDSReadv. */
 ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                      unsigned nr_segs, off_t file_offset);
 
 /* Vectored batch IO.  Because uGDSIOParams_t has no mode/union/reserved
  * field, SGL batch entries use this new params struct and submit function;
  * setup/status/destroy are shared with the existing batch object.
+ *
  * 'segs' is copied at submit, so the caller may free iocb and the arrays
- * on return -- parity with uGDSBatchIOSubmit.
- * (Implementation in Phase 2.) */
+ * on return -- parity with uGDSBatchIOSubmit. */
 typedef struct uGDSIOSegParams {
     const uGDSIoSegment_t* segs;      /* copied at submit */
     unsigned               nr_segs;   /* <= UGDS_BATCH_IOV_MAX */
@@ -310,13 +385,19 @@ typedef struct uGDSIOSegParams {
     void*                  cookie;
 } uGDSIOSegParams_t;
 
-/* Same semantics as uGDSBatchIOSubmit: entries join the batch created
- * by uGDSBatchIOSetUp; completions are reaped via uGDSBatchIOGetStatus.
- * Plain and vectored submits may be mixed on the same batch handle. */
+/* Submit vectored (scatter-gather) batch entries.  Same semantics as
+ * uGDSBatchIOSubmit: entries join the batch created by uGDSBatchIOSetUp;
+ * completions are reaped via uGDSBatchIOGetStatus.  Plain and vectored
+ * submits may be mixed on the same batch handle.
+ *
+ * Per-entry validation follows the value matrix (alignment, sizes,
+ * overflow-safe total) and the analytic window counter.  Preflight
+ * failures become terminal FAILED entries with -EINVAL and contribute
+ * zero commands to the work array. */
 uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
                                  uGDSIOSegParams_t* iocb, unsigned flags);
 
-/* Vectored async IO on a CUDA/HIP stream.
+/* Vectored async read on a CUDA/HIP stream.
  * Binding contract (mirrors uGDSReadAsync late binding):
  *   - segs (the array pointer) and nr_segs are fixed at enqueue.
  *   - segs[i].base is read at enqueue (validation + in-flight refs)
@@ -324,11 +405,17 @@ uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
  *   - segs[i].offset, segs[i].size and *file_offset_p are read in the
  *     stream callback (late binding).  The segs array must remain
  *     valid until the callback runs.
- * (Implementation in Phase 3.) */
+ *
+ * *bytes_read_p is pre-zeroed at enqueue. On validation or launch
+ *     failure the return value remains zero and the error is returned
+ *     via the uGDSError_t return code. On success the callback writes
+ *     the byte count (or -errno on runtime failure) exactly once. */
 uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                              unsigned nr_segs, off_t* file_offset_p,
                              ssize_t* bytes_read_p, void* stream);
 
+/* Vectored async write on a CUDA/HIP stream.  Binding contract and
+ * lifecycle match uGDSReadvAsync. */
 uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                               unsigned nr_segs, off_t* file_offset_p,
                               ssize_t* bytes_written_p, void* stream);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -140,8 +140,15 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * timeout_sec == -1 means infinite wait (equivalent to uGDSHandleDeregister).
  * timeout_sec < -1 means after-reset teardown: release resources retained
  * by timed-out I/O, skip wedged/in-flight checks, and free all resources.
- * The caller must guarantee that no NVMe command is still executing (e.g.
- * after a controller reset). */
+ *
+ * Force contract (timeout_sec < -1): before calling this function the
+ * caller MUST quiesce ALL host API calls and callbacks associated with
+ * this handle -- not only NVMe commands, but every uGDSRead/uGDSWrite,
+ * uGDSReadv/uGDSWritev, batch, and async operation that has passed
+ * handle_lookup, plus every async callback already enqueued on a
+ * stream. No such call may execute or resume concurrently with force
+ * teardown. After force returns, the handle is fully invalid and no
+ * API may use it. The caller must have already reset the controller. */
 uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
 
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -259,6 +259,73 @@ uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
 
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
+/* -- Vectored (scatter-gather) IO -- */
+
+/* One scatter-gather segment. 'base' must be a pointer previously
+ * registered via uGDSBufRegister/uGDSBufRegisterEx (exact value).
+ * 'offset' is a byte offset inside that registration and must be a
+ * multiple of the controller page size (MPS).  'size' must be a
+ * multiple of the namespace block size and non-zero.  offset + size
+ * must not exceed the length passed at registration (the exact byte
+ * length, not a page-rounded value). */
+typedef struct uGDSIoSegment {
+    void*   base;
+    off_t   offset;
+    size_t  size;
+} uGDSIoSegment_t;
+
+#define UGDS_IOV_MAX        1024   /* sync/async: POSIX IOV_MAX parity */
+#define UGDS_BATCH_IOV_MAX  128    /* per batch entry (bounds arena) */
+
+/* Vectored read/write.  Segments are consumed in array order:
+ * segs[0] maps to [file_offset, file_offset + segs[0].size), etc.
+ * Returns total bytes transferred, or -errno (same convention as
+ * uGDSRead/uGDSWrite).  The segment array is fully consumed during
+ * the call (synchronous); the caller may free/reuse it on return.
+ * (Implementation in Phase 1.) */
+ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                    unsigned nr_segs, off_t file_offset);
+
+ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                     unsigned nr_segs, off_t file_offset);
+
+/* Vectored batch IO.  Because uGDSIOParams_t has no mode/union/reserved
+ * field, SGL batch entries use this new params struct and submit function;
+ * setup/status/destroy are shared with the existing batch object.
+ * 'segs' is copied at submit, so the caller may free iocb and the arrays
+ * on return -- parity with uGDSBatchIOSubmit.
+ * (Implementation in Phase 2.) */
+typedef struct uGDSIOSegParams {
+    const uGDSIoSegment_t* segs;      /* copied at submit */
+    unsigned               nr_segs;   /* <= UGDS_BATCH_IOV_MAX */
+    off_t                  file_offset;
+    uGDSOpcode_t           opcode;
+    void*                  cookie;
+} uGDSIOSegParams_t;
+
+/* Same semantics as uGDSBatchIOSubmit: entries join the batch created
+ * by uGDSBatchIOSetUp; completions are reaped via uGDSBatchIOGetStatus.
+ * Plain and vectored submits may be mixed on the same batch handle. */
+uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
+                                 uGDSIOSegParams_t* iocb, unsigned flags);
+
+/* Vectored async IO on a CUDA/HIP stream.
+ * Binding contract (mirrors uGDSReadAsync late binding):
+ *   - segs (the array pointer) and nr_segs are fixed at enqueue.
+ *   - segs[i].base is read at enqueue (validation + in-flight refs)
+ *     and MUST NOT change afterwards.
+ *   - segs[i].offset, segs[i].size and *file_offset_p are read in the
+ *     stream callback (late binding).  The segs array must remain
+ *     valid until the callback runs.
+ * (Implementation in Phase 3.) */
+uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                             unsigned nr_segs, off_t* file_offset_p,
+                             ssize_t* bytes_read_p, void* stream);
+
+uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                              unsigned nr_segs, off_t* file_offset_p,
+                              ssize_t* bytes_written_p, void* stream);
+
 /* -- Async Stream IO --
  * Pointer params (size_p, file_offset_p, etc.) must be host-accessible.
  * Use cudaHostAlloc/hipHostMalloc for GPU-writable pinned memory (late binding).

--- a/src/libnvm/linux_dma.cpp
+++ b/src/libnvm/linux_dma.cpp
@@ -561,7 +561,17 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
         }
         else
         {
-            /* Standard NVIDIA CUDA path via kernel P2P */
+            /* Standard NVIDIA CUDA path via kernel P2P.
+             * Reject non-64KiB-aligned devptr: the kernel maps
+             * vaddr & GPU_PAGE_MASK (drv/map.c), so a misaligned
+             * base silently addresses the containing 64KiB page and
+             * ioaddrs[0] does not correspond to devptr. This is silent
+             * data corruption. */
+            if ((uintptr_t)devptr % ((size_t)1 << 16) != 0)
+            {
+                dprintf("CUDA P2P devptr %p not 64KiB-aligned\n", devptr);
+                return EINVAL;
+            }
             err = create_mapping_descriptor(&md, 1ULL << 16, MAP_TYPE_CUDA, devptr, size);
             if (err != 0)
             {

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -14,6 +14,12 @@ typedef hipStream_t cudaStream_t;
 #include <cuda_runtime.h>
 #endif
 #include <mutex>
+#include <cerrno>
+#include <new>
+
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
 
 /* Forward declaration for dual-backend stream validation */
 #if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
@@ -440,3 +446,446 @@ extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
 }
 #undef UGDS_ACTIVE_BACKEND
 #endif
+
+/* ======================================================================== */
+/* Vectored async (uGDSReadvAsync / uGDSWritevAsync)                       */
+/* Async path + timeout ownership handling.                                */
+/* ======================================================================== */
+
+/* ---- Dual-backend stream-backend lookup helper ----
+ * Reads the registered backend of a stream exactly once under
+ * s_stream_map_lock.  Returns UGDS_BACKEND_DEFAULT for unregistered or
+ * NULL streams.  Single-backend builds collapse to a compile-time active
+ * backend.  This helper is separate from async_check_stream_backend so
+ * that the async-vectored launch decision can read the stream backend
+ * exactly once (atomic snapshot). */
+static uGDSBackend_t iov_stream_backend_lookup(void* stream)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    if (stream == nullptr)
+        return UGDS_BACKEND_DEFAULT;
+    std::lock_guard<std::mutex> g(s_stream_map_lock);
+    auto it = s_stream_backends.find(stream);
+    if (it == s_stream_backends.end())
+        return UGDS_BACKEND_DEFAULT;
+    return it->second;
+#else
+    (void)stream;
+#if defined(__HIP_PLATFORM_AMD__)
+    return UGDS_BACKEND_HIP;
+#else
+    return UGDS_BACKEND_CUDA;
+#endif
+#endif
+}
+
+/* ---- launch_backend decision ----
+ * A is the buffer backend when the list is homogeneous (the single
+ * backend that every segment shares).  Single-backend builds reduce to
+ * A == active backend and the "mixed" branches become unreachable at
+ * compile time (the other backend cannot register buffers). */
+static uGDSError_t iov_compute_launch_backend(uGDSBackend_t list_a,
+                                              bool         mixed,
+                                              uGDSBackend_t stream_backend,
+                                              uGDSBackend_t* out)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    if (!mixed) {
+        /* Homogeneous list: every segment is on backend A. */
+        if (stream_backend == UGDS_BACKEND_DEFAULT) {
+            /* NULL/unregistered/registered-DEFAULT: launch on A. */
+            *out = list_a;
+            return UGDS_OK;
+        }
+        if (stream_backend == list_a) {
+            *out = list_a;
+            return UGDS_OK;
+        }
+        /* Registered on a backend that is not A: scalar-mismatch parity. */
+        return make_error(UGDS_INVALID_VALUE);
+    }
+    /* Mixed list: accepted iff the stream has an explicit registered
+     * backend; launch on that backend. */
+    if (stream_backend == UGDS_BACKEND_DEFAULT)
+        return make_error(UGDS_INVALID_VALUE);
+    *out = stream_backend;
+    return UGDS_OK;
+#else
+    /* Single-backend: mixed is unrepresentable, the active backend is
+     * the only one.  Any non-DEFAULT stream registration was already
+     * validated against the active backend at StreamRegisterEx. */
+    (void)stream_backend;
+    (void)mixed;
+    *out = list_a;
+    return UGDS_OK;
+#endif
+}
+
+/* ---- async_validate_v ----
+ * Under a single g_driver.lock hold:
+ *  - resolve every segment in the registry (identity-only: dma/base/
+ *    registered_length/backend), controller affinity check;
+ *  - acquire in-flight refs all-or-nothing into req->owner via
+ *    acquire_identity_only (registered-only);
+ *  - capture a list_backend snapshot for the launch decision;
+ *  - take a handle-operation reference via handle_lookup_locked.
+ * Geometry (offset/size) is NOT validated here -- late binding.
+ *
+ * On success, fills req->resolved (identity-only SegView[]), req->owner,
+ * req->hs_sp, and *out_list_backend / *out_mixed.  On failure, owner is
+ * untouched (no refs acquired) and the caller frees req->resolved.  The
+ * handle-operation ref is released on any failure path after lookup
+ * succeeds. */
+static uGDSError_t async_validate_v(uGDSHandle_t fh,
+                                    uGDSIoSegment_t* segs,
+                                    unsigned nr_segs,
+                                    SegView* resolved,
+                                    SglRefOwner* owner,
+                                    std::shared_ptr<HandleState>* hs_sp_out,
+                                    uGDSBackend_t* out_list_backend,
+                                    bool* out_mixed)
+{
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (fh == nullptr || segs == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+    if (nr_segs == 0 || nr_segs > UGDS_IOV_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* No per-segment value validation here (late binding).  Only base != NULL
+     * is checked so that registry lookup is well-defined. */
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr)
+            return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Take a single g_driver.lock to do: handle lookup + identity-only
+     * reference acquisition.  The handle ref is needed so that
+     * handle_in_flight prevents Deregister from tearing down the QPs
+     * while the request is queued.  owner->acquire_identity_only takes
+     * the same lock internally; the lock is not held across the acquire
+     * call. */
+    HandleState* hs = nullptr;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        hs = handle_lookup_locked(fh, hs_sp_out);
+    }
+    if (!hs)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Controller affinity check + ref acquisition.  handle_lookup_locked succeeded,
+     * so hs is valid for the lifetime of *hs_sp_out. */
+    int rc = owner->acquire_identity_only(
+        segs, static_cast<uint32_t>(nr_segs),
+        hs->ctrl, resolved);
+    if (rc != 0) {
+        handle_release(hs);
+        hs_sp_out->reset();
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Snapshot segment backends from resolved[] (read under no lock; the
+     * registry entries are pinned by owner for the lifetime of this
+     * request).  mixed == true iff backends span more than one value;
+     * list_a is the first non-DEFAULT backend, or DEFAULT if all are
+     * DEFAULT (homogeneous-DEFAULT). */
+    uGDSBackend_t a = UGDS_BACKEND_DEFAULT;
+    bool mixed = false;
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        uGDSBackend_t b = resolved[i].backend;
+        if (i == 0) {
+            a = b;
+        } else if (b != a) {
+            mixed = true;
+            /* Keep a as the first-segment backend; for a mixed list the
+             * launch decision ignores a and uses the stream backend. */
+        }
+    }
+    /* If a == DEFAULT the list is homogeneous-DEFAULT; treat A as the
+     * build's active backend for the decision (parity with the scalar
+     * buffer-backend dispatch). */
+#if defined(__HIP_PLATFORM_AMD__) && !defined(_CUDA)
+    if (a == UGDS_BACKEND_DEFAULT) a = UGDS_BACKEND_HIP;
+#elif !defined(__HIP_PLATFORM_AMD__)
+    if (a == UGDS_BACKEND_DEFAULT) a = UGDS_BACKEND_CUDA;
+#else
+    /* Dual build: leave DEFAULT; iov_compute_launch_backend treats the
+     * single buffer-backend snapshot path as DEFAULT => launch on A.  In
+     * dual builds, homogeneous-DEFAULT means all segments are DEFAULT --
+     * that means none were registered via uGDSBufRegisterEx with an
+     * explicit backend, so the buffer backend parity is the CUDA (A)
+     * side; iov_compute_launch_backend uses list_a as-is. */
+#endif
+
+    *out_list_backend = a;
+    *out_mixed = mixed;
+    return UGDS_OK;
+}
+
+/* ---- async_iov_execute (section 6.3, callback body) ----
+ * Must be effectively noexcept: the caller (async_iov_callback) is a
+ * full exception boundary.  All work here is infallible except for
+ * do_iov_engine, which is noexcept-by-contract (the engine's only
+ * allocation-free path is the streaming cursor). */
+static void async_iov_execute(AsyncRequest* req) noexcept
+{
+    /* 1. Late-bind offset/size from user_segs and file_offset_p.  These
+     *    reads race with the producer only if the caller violates the
+     *    binding contract (documented in include/ugds.h); under that
+     *    contract the values are stable from enqueue until the callback
+     *    runs.  No registry access is needed: identity is already
+     *    snapshotted in resolved[]. */
+    const off_t file_offset = *req->file_offset_p;
+
+    /* 2. Complete resolved[] geometry and run the same per-segment value
+     *    checks as sync do_readv_writev, but using the snapshotted
+     *    registered_length.  This closes the late-binding window. */
+    HandleState* hs = req->hs_sp.get();
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    ssize_t err_ret = 0;
+    uint64_t total_size = 0;
+
+    for (unsigned i = 0; i < req->nr_segs; ++i) {
+        const uGDSIoSegment_t& us = req->user_segs[i];
+        SegView& sv = req->resolved[i];
+
+        if (us.size == 0) { err_ret = -EINVAL; break; }
+        if (us.offset < 0) { err_ret = -EINVAL; break; }
+        if ((static_cast<size_t>(us.offset) % page_size) != 0) {
+            err_ret = -EINVAL; break;
+        }
+        if ((us.size % block_size) != 0) { err_ret = -EINVAL; break; }
+
+        /* Exact-length bound against the snapshotted registered_length. */
+        const uint64_t off = static_cast<uint64_t>(us.offset);
+        const uint64_t sz  = static_cast<uint64_t>(us.size);
+        if (off > sv.registered_length ||
+            sz > (sv.registered_length - off)) {
+            err_ret = -EINVAL; break;
+        }
+
+        if (sz > static_cast<uint64_t>(SSIZE_MAX) - total_size) {
+            err_ret = -EINVAL; break;
+        }
+        total_size += sz;
+
+        sv.page_start = off / page_size;
+        sv.size       = us.size;
+    }
+
+    if (err_ret == 0) {
+        if (file_offset < 0 ||
+            (static_cast<size_t>(file_offset) % block_size) != 0)
+            err_ret = -EINVAL;
+    }
+
+    if (err_ret != 0) {
+        /* Validation failure: release handle ref, write -errno, and
+         * delete req.  owner destructor releases the in-flight refs
+         * (none parked -- the engine never ran). */
+        *req->bytes_done_p = err_ret;
+        handle_release(hs);
+        delete req;
+        return;
+    }
+
+    /* 3. Engine dispatch.  Pass our owner; on timeout the engine
+     *    move-assigns it into qp.timeout_refs and we must NOT release. */
+    IovEngineResult result = do_iov_engine(hs, req->resolved,
+                                           static_cast<uint32_t>(req->nr_segs),
+                                           file_offset, req->opcode,
+                                           &req->owner, nullptr);
+
+    /* 4. Publish the result. */
+    *req->bytes_done_p = result.ret;
+
+    /* 5. Release the handle-operation reference taken at enqueue. */
+    handle_release(hs);
+
+    /* 6. delete req: the owner destructor releases the in-flight refs
+     *    unless the engine parked them on timeout (in which case
+     *    req->owner was moved-from and is empty). */
+    delete req;
+}
+
+/* ---- async_iov_callback (exception boundary) ----
+ * Declared noexcept-equivalent: any exception is caught and translated
+ * to -EIO so nothing propagates into the CUDA/HIP runtime. */
+static void async_iov_callback(void* userData) noexcept
+{
+    AsyncRequest* req = static_cast<AsyncRequest*>(userData);
+    try {
+        async_iov_execute(req);
+    } catch (...) {
+        /* Last-resort guard: async_iov_execute is noexcept-by-contract
+         * but the language does not enforce it.  Park the failure and
+         * free the request so the caller's bytes_done_p is writable
+         * exactly once. */
+        if (req->bytes_done_p != nullptr)
+            *req->bytes_done_p = -EIO;
+        if (req->hs_sp)
+            handle_release(req->hs_sp.get());
+        delete req;
+    }
+}
+
+/* ---- vectored launch dispatch ----
+ * Selects cudaLaunchHostFunc vs hipLaunchHostFunc in dual builds based
+ * on the enqueue-time launch_backend decision.  Single-backend builds
+ * use the active runtime. */
+static uGDSError_t iov_launch_host_func(void* stream, AsyncRequest* req)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    int err;
+    if (req->launch_backend == UGDS_BACKEND_HIP) {
+        err = hipLaunchHostFunc(stream, async_iov_callback, req);
+    } else {
+        err = cudaLaunchHostFunc(stream, async_iov_callback, req);
+    }
+    if (err != 0) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = err;
+        return e;
+    }
+    return UGDS_OK;
+#elif defined(__HIP_PLATFORM_AMD__)
+    hipError_t err = hipLaunchHostFunc((hipStream_t)stream,
+                                       async_iov_callback, req);
+    if (err != hipSuccess) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+#else
+    cudaError_t err = cudaLaunchHostFunc((cudaStream_t)(uintptr_t)stream,
+                                         async_iov_callback, req);
+    if (err != cudaSuccess) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+#endif
+}
+
+/* ---- common enqueue + launch for uGDSReadvAsync / uGDSWritevAsync ---- */
+static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
+                                         uGDSIoSegment_t* segs,
+                                         unsigned nr_segs,
+                                         off_t* file_offset_p,
+                                         ssize_t* bytes_done_p,
+                                         void* stream,
+                                         uint8_t opcode)
+{
+    /* Malformed-call checks.  These do not need the registry and
+     * cannot race with Deregister. */
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (fh == nullptr || segs == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+    if (nr_segs == 0 || nr_segs > UGDS_IOV_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+    if (file_offset_p == nullptr || bytes_done_p == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Pre-zero bytes_done_p so a late callback-failure still reports a
+     * deterministic value to the caller. */
+    *bytes_done_p = 0;
+
+    /* Allocate the request and its resolved[] storage BEFORE acquiring
+     * any reference, so that allocation failure cannot strand an
+     * in_flight or handle_in_flight counter.  resolved[] uses the
+     * inline slot for nr <= 4. */
+    AsyncRequest* req = new (std::nothrow) AsyncRequest;
+    if (req == nullptr)
+        return make_error(UGDS_OUT_OF_MEMORY);
+    req->fh            = fh;
+    req->file_offset_p = file_offset_p;
+    req->bytes_done_p  = bytes_done_p;
+    req->opcode        = opcode;
+    req->user_segs     = segs;
+    req->nr_segs       = nr_segs;
+    /* bufPtr_base/size_p/bufPtr_offset_p are unused for the vectored path. */
+
+    if (nr_segs <= 4) {
+        req->resolved = req->inline_resolved;
+    } else {
+        SegView* heap = new (std::nothrow) SegView[nr_segs];
+        if (heap == nullptr) {
+            delete req;
+            return make_error(UGDS_OUT_OF_MEMORY);
+        }
+        req->resolved = heap;
+    }
+
+    /* async_validate_v acquires in-flight refs + handle ref, fills
+     * resolved (identity-only), and snapshots list backend + mixed. */
+    uGDSBackend_t list_backend = UGDS_BACKEND_DEFAULT;
+    bool mixed = false;
+    uGDSError_t st = async_validate_v(fh, segs, nr_segs, req->resolved,
+                                      &req->owner, &req->hs_sp,
+                                      &list_backend, &mixed);
+    if (st.err != UGDS_SUCCESS) {
+        /* No refs acquired, no handle ref held.  Free the request and
+         * its heap storage (if any). */
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return st;
+    }
+
+    /* Compute launch_backend ONCE from the snapshot list_backend and
+     * a single read of the stream backend. */
+    uGDSBackend_t stream_backend = iov_stream_backend_lookup(stream);
+    uGDSBackend_t launch_backend = UGDS_BACKEND_DEFAULT;
+    uGDSError_t lberr = iov_compute_launch_backend(list_backend, mixed,
+                                                    stream_backend,
+                                                    &launch_backend);
+    if (lberr.err != UGDS_SUCCESS) {
+        /* Reject at enqueue: release refs + handle ref, then free. */
+        req->owner.release();  /* idempotent: decrements in_flight */
+        handle_release(req->hs_sp.get());
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return lberr;
+    }
+    req->launch_backend = launch_backend;
+
+    /* Launch the callback on the selected backend's stream.  On failure
+     * the caller can retry, so we must roll back every reference we
+     * acquired and free the request. */
+    uGDSError_t lc = iov_launch_host_func(stream, req);
+    if (lc.err != UGDS_SUCCESS) {
+        req->owner.release();
+        handle_release(req->hs_sp.get());
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return lc;
+    }
+
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                                        unsigned nr_segs, off_t* file_offset_p,
+                                        ssize_t* bytes_read_p, void* stream)
+{
+    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                 bytes_read_p, stream, NVM_IO_READ);
+}
+
+extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                                         unsigned nr_segs, off_t* file_offset_p,
+                                         ssize_t* bytes_written_p, void* stream)
+{
+    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                 bytes_written_p, stream, NVM_IO_WRITE);
+}

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -830,17 +830,24 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     }
 
     /* async_validate_v acquires in-flight refs + handle ref, fills
-     * resolved (identity-only), and snapshots list backend + mixed. */
+     * resolved (identity-only), and snapshots list backend + mixed.
+     * The handle ref guard ensures handle_release is called on
+     * exception between validation and successful launch. */
     uGDSBackend_t list_backend = UGDS_BACKEND_DEFAULT;
     bool mixed = false;
     uGDSError_t st = async_validate_v(fh, segs, nr_segs, req->resolved,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held. req_guard frees req +
-         * heap resolved[] via destructor. */
         return st;
     }
+
+    /* RAII: release handle ref if we leave scope without launching. */
+    struct HandleRefGuard {
+        HandleState* hs;
+        bool armed;
+        ~HandleRefGuard() { if (armed && hs) handle_release(hs); }
+    } hguard{req->hs_sp.get(), true};
 
     /* Compute launch_backend ONCE from the snapshot list_backend and
      * a single read of the stream backend. */
@@ -851,7 +858,7 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
         req->owner.release();
-        handle_release(req->hs_sp.get());
+        /* hguard releases handle ref */
         return lberr;
     }
     req->launch_backend = launch_backend;
@@ -862,11 +869,12 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
         req->owner.release();
-        handle_release(req->hs_sp.get());
+        /* hguard releases handle ref */
         return lc;
     }
 
-    /* Launch succeeded: release ownership to the callback. */
+    /* Launch succeeded: disarm guards, release ownership to callback. */
+    hguard.armed = false;
     (void)req_guard.release();
     return UGDS_OK;
 }

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -805,10 +805,11 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     /* Allocate the request and its resolved[] storage BEFORE acquiring
      * any reference, so that allocation failure cannot strand an
      * in_flight or handle_in_flight counter.  resolved[] uses the
-     * inline slot for nr <= 4. */
-    AsyncRequest* req = new (std::nothrow) AsyncRequest;
-    if (req == nullptr)
-        return make_error(UGDS_OUT_OF_MEMORY);
+     * inline slot for nr <= 4.
+     * unique_ptr owns req until successful launch; on any exception or
+     * early return it is automatically freed. */
+    auto req_guard = std::make_unique<AsyncRequest>();
+    AsyncRequest* req = req_guard.get();
     req->fh            = fh;
     req->file_offset_p = file_offset_p;
     req->bytes_done_p  = bytes_done_p;
@@ -822,10 +823,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
         /* resolved_owns_heap stays false (default). */
     } else {
         SegView* heap = new (std::nothrow) SegView[nr_segs];
-        if (heap == nullptr) {
-            delete req;  /* ~AsyncRequest frees heap[] if owned */
+        if (heap == nullptr)
             return make_error(UGDS_OUT_OF_MEMORY);
-        }
         req->resolved = heap;
         req->resolved_owns_heap = true;  /* destructor owns it */
     }
@@ -838,9 +837,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held.  Free the request; the
-         * destructor frees heap resolved[] if any. */
-        delete req;
+        /* No refs acquired, no handle ref held. req_guard frees req +
+         * heap resolved[] via destructor. */
         return st;
     }
 
@@ -852,11 +850,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     stream_backend,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
-        /* Reject at enqueue: release refs + handle ref, then free.
-         * The destructor frees heap resolved[] if owned. */
-        req->owner.release();  /* idempotent: decrements in_flight */
+        req->owner.release();
         handle_release(req->hs_sp.get());
-        delete req;
         return lberr;
     }
     req->launch_backend = launch_backend;
@@ -866,13 +861,13 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * acquired and free the request. */
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
-        /* The destructor frees heap resolved[] if owned. */
         req->owner.release();
         handle_release(req->hs_sp.get());
-        delete req;
         return lc;
     }
 
+    /* Launch succeeded: release ownership to the callback. */
+    (void)req_guard.release();
     return UGDS_OK;
 }
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -70,6 +70,11 @@ static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
     if (it == g_driver.buf_registry.end())
         return make_error(UGDS_INVALID_VALUE);
 
+    /* Controller affinity check: validate against the submitting
+     * handle's controller. */
+    if (it->second.map_ctrl == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+
     /* Hold in-flight reference from enqueue until callback completes.
      * This prevents uGDSBufDeregister from unmapping the buffer
      * while the async request is queued but not yet executed. */
@@ -83,6 +88,15 @@ static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
     if (!hs) {
         /* Roll back buffer in_flight ref on handle acquire failure */
         it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Controller affinity check: controller at registration must match
+     * the submitting handle's controller. */
+    if (it->second.map_ctrl != hs->ctrl) {
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        handle_release(hs);
+        hs_sp_out->reset();
         return make_error(UGDS_INVALID_VALUE);
     }
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -622,12 +622,10 @@ static uGDSError_t async_validate_v(uGDSHandle_t fh,
     return UGDS_OK;
 }
 
-/* ---- async_iov_execute (section 6.3, callback body) ----
- * Must be effectively noexcept: the caller (async_iov_callback) is a
- * full exception boundary.  All work here is infallible except for
- * do_iov_engine, which is noexcept-by-contract (the engine's only
- * allocation-free path is the streaming cursor). */
-static void async_iov_execute(AsyncRequest* req) noexcept
+/* ---- async_iov_execute (callback body) ----
+ * Potentially throwing: do_iov_engine acquires std::mutex and may throw.
+ * The caller (async_iov_callback) is the noexcept exception boundary. */
+static void async_iov_execute(AsyncRequest* req)
 {
     /* 1. Late-bind offset/size from user_segs and file_offset_p.  These
      *    reads race with the producer only if the caller violates the
@@ -719,10 +717,10 @@ static void async_iov_callback(void* userData) noexcept
     try {
         async_iov_execute(req);
     } catch (...) {
-        /* Last-resort guard: async_iov_execute is noexcept-by-contract
-         * but the language does not enforce it.  Park the failure and
-         * free the request so the caller's bytes_done_p is writable
-         * exactly once. */
+        /* Real catch boundary: async_iov_execute is NOT noexcept,
+         * so exceptions from do_iov_engine or mutex acquisition
+         * arrive here. Park the failure and free the request so
+         * the caller's bytes_done_p is writable exactly once. */
         if (req->bytes_done_p != nullptr)
             *req->bytes_done_p = -EIO;
         if (req->hs_sp)
@@ -798,6 +796,12 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * deterministic value to the caller. */
     *bytes_done_p = 0;
 
+    /* Validate base pointers before any allocation. */
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr)
+            return make_error(UGDS_INVALID_VALUE);
+    }
+
     /* Allocate the request and its resolved[] storage BEFORE acquiring
      * any reference, so that allocation failure cannot strand an
      * in_flight or handle_in_flight counter.  resolved[] uses the
@@ -815,13 +819,15 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
 
     if (nr_segs <= 4) {
         req->resolved = req->inline_resolved;
+        /* resolved_owns_heap stays false (default). */
     } else {
         SegView* heap = new (std::nothrow) SegView[nr_segs];
         if (heap == nullptr) {
-            delete req;
+            delete req;  /* ~AsyncRequest frees heap[] if owned */
             return make_error(UGDS_OUT_OF_MEMORY);
         }
         req->resolved = heap;
+        req->resolved_owns_heap = true;  /* destructor owns it */
     }
 
     /* async_validate_v acquires in-flight refs + handle ref, fills
@@ -832,10 +838,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held.  Free the request and
-         * its heap storage (if any). */
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
+        /* No refs acquired, no handle ref held.  Free the request; the
+         * destructor frees heap resolved[] if any. */
         delete req;
         return st;
     }
@@ -848,11 +852,10 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     stream_backend,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
-        /* Reject at enqueue: release refs + handle ref, then free. */
+        /* Reject at enqueue: release refs + handle ref, then free.
+         * The destructor frees heap resolved[] if owned. */
         req->owner.release();  /* idempotent: decrements in_flight */
         handle_release(req->hs_sp.get());
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
         delete req;
         return lberr;
     }
@@ -863,10 +866,9 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * acquired and free the request. */
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
+        /* The destructor frees heap resolved[] if owned. */
         req->owner.release();
         handle_release(req->hs_sp.get());
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
         delete req;
         return lc;
     }
@@ -878,14 +880,26 @@ extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                                         unsigned nr_segs, off_t* file_offset_p,
                                         ssize_t* bytes_read_p, void* stream)
 {
-    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
-                                 bytes_read_p, stream, NVM_IO_READ);
+    try {
+        return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                     bytes_read_p, stream, NVM_IO_READ);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                                          unsigned nr_segs, off_t* file_offset_p,
                                          ssize_t* bytes_written_p, void* stream)
 {
-    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
-                                 bytes_written_p, stream, NVM_IO_WRITE);
+    try {
+        return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                     bytes_written_p, stream, NVM_IO_WRITE);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -573,16 +573,32 @@ static uGDSError_t async_validate_v(uGDSHandle_t fh,
     if (!hs)
         return make_error(UGDS_INVALID_VALUE);
 
-    /* Controller affinity check + ref acquisition.  handle_lookup_locked succeeded,
-     * so hs is valid for the lifetime of *hs_sp_out. */
+    /* RAII: ensure handle_release runs even if acquire_identity_only
+     * throws (e.g., from its internal mutex acquisition). */
+    struct HandleReleaseGuard {
+        HandleState* hs;
+        std::shared_ptr<HandleState>* sp;
+        bool armed;
+        ~HandleReleaseGuard() {
+            if (armed) {
+                handle_release(hs);
+                sp->reset();
+            }
+        }
+    } hguard{hs, hs_sp_out, true};
+
+    /* Controller affinity check + ref acquisition.  handle_lookup_locked
+     * succeeded, so hs is valid for the lifetime of *hs_sp_out. */
     int rc = owner->acquire_identity_only(
         segs, static_cast<uint32_t>(nr_segs),
         hs->ctrl, resolved);
     if (rc != 0) {
-        handle_release(hs);
-        hs_sp_out->reset();
+        /* hguard releases handle ref */
         return make_error(UGDS_INVALID_VALUE);
     }
+
+    /* Success: disarm the guard. Caller owns the handle ref now. */
+    hguard.armed = false;
 
     /* Snapshot segment backends from resolved[] (read under no lock; the
      * registry entries are pinned by owner for the lifetime of this

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -1,3 +1,34 @@
+/* ugds_async.cpp -- Asynchronous vectored IO on CUDA/HIP streams.
+ *
+ * Public APIs implemented here:
+ *   - uGDSReadvAsync  / uGDSWritevAsync   (vectored async IO)
+ *
+ * Internal functions:
+ *   - async_validate_v       (handle lookup + identity-only ref acquisition)
+ *   - do_readv_writev_async   (request allocation, validation, launch)
+ *   - async_iov_execute       (callback body: late binding + engine dispatch)
+ *   - async_iov_callback      (noexcept exception boundary around execute)
+ *
+ * Late binding contract:
+ *   - segs[i].base is read at enqueue (validation + in-flight refs) and
+ *     MUST NOT change afterwards.
+ *   - segs[i].offset, segs[i].size, and *file_offset_p are read in the
+ *     stream callback (late binding).  The segs array must remain valid
+ *     until the callback runs.
+ *
+ * Callback lifecycle:
+ *   1. Enqueue: uGDSReadvAsync/uGDSWritevAsync allocates AsyncRequest,
+ *      acquires identity-only refs + handle ref under g_driver.lock,
+ *      computes launch_backend, and launches async_iov_callback on the
+ *      stream.  unique_ptr owns the request until successful launch;
+ *      HandleRefGuard owns the handle ref from validation through launch.
+ *   2. Callback: async_iov_callback (noexcept) wraps async_iov_execute
+ *      in try/catch(...).  On success, writes bytes_done_p and releases
+ *      refs.  On exception, writes -EIO to bytes_done_p and releases.
+ *   3. Cleanup: ~AsyncRequest frees heap resolved[] (if owned); owner
+ *      releases in-flight buffer refs; handle_release decrements
+ *      handle_in_flight.
+ */
 #include "ugds_internal.h"
 #if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
 /* Dual-backend: avoid both cuda_runtime.h and hip_runtime.h in this TU

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -39,27 +39,51 @@ static inline void queue_entry_release(BatchState* bs, unsigned idx)
     bs->release_scratch[bs->n_release_pending++] = idx;
 }
 
-/* Drain all pending deferred releases in one g_driver.lock hold.
+/* Release the in-flight reference(s) held by a batch entry.
+ * Kind-aware release.
+ * - BATCH_ENTRY_PLAIN: one ref at entry.devPtr_base (legacy path).
+ * - BATCH_ENTRY_VECTORED: one ref per base in
+ *   bs->seg_arena[entry.seg_begin .. seg_begin + seg_count).
+ *   Duplicate bases are released per occurrence, matching acquire().
+ * Must be called WITHOUT holding g_driver.lock. */
+void release_entry_refs(BatchState* bs, BatchIOEntry& entry)
+{
+    if (!entry.refs_held)
+        return;
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    if (entry.kind == BATCH_ENTRY_VECTORED) {
+        for (uint32_t k = 0; k < entry.seg_count; ++k) {
+            uint32_t ai = entry.seg_begin + k;
+            if (ai >= bs->seg_arena.size())
+                break;
+            const void* base = bs->seg_arena[ai].base;
+            auto it = g_driver.buf_registry.find(base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    } else {
+        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    entry.refs_held = false;
+    entry.release_queued = false;
+}
+
+/* Drain all pending deferred releases in one pass.
  * Must be called under bs->lock but NOT under qp.lock and NOT under
- * g_driver.lock (the old version called
- * async_release_inflight_batch which re-locked g_driver.lock, causing
- * a deadlock on a non-recursive mutex). */
+ * g_driver.lock (the old version called async_release_inflight_batch
+ * which re-locked g_driver.lock, causing a deadlock on a non-recursive
+ * mutex). */
 static void drain_release_scratch(BatchState* bs)
 {
     if (bs->n_release_pending == 0) return;
-    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
     for (uint32_t i = 0; i < bs->n_release_pending; ++i) {
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        /* Inline the decrement instead of calling
-         * async_release_inflight_batch to avoid re-locking
-         * g_driver.lock (nested-lock bug fix). */
-        auto it = g_driver.buf_registry.find(entry.devPtr_base);
-        if (it != g_driver.buf_registry.end())
-            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-        entry.refs_held = false;
-        entry.release_queued = false;
+        /* C1: release_entry_refs handles both PLAIN and VECTORED. */
+        release_entry_refs(bs, entry);
     }
     bs->n_release_pending = 0;
 }
@@ -1181,8 +1205,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
             continue;
         }
 
-        /* refs are now held by the arena; mark for deferred release. */
+        /* refs are now held by the batch (the in_flight counter was
+         * incremented by acquire).  Transfer ownership to the batch by
+         * disarming the local owner so its destructor does not release.
+         * drain_release_scratch will decrement each base in entry's
+         * arena range, selected by entry.kind. */
         entry.refs_held = true;
+        owner.disarm();
 
         /* Stream windows into the work array. */
         SglWindowCursor cursor;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -195,7 +195,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
 
     (void)flags;
 
-    // Phase 1: validate and populate entries
+    // Validate and populate entries
     unsigned base = bs->n_entries;
     for (unsigned i = 0; i < nr; ++i) {
         const uGDSIOParams_t& p = iocb[i];
@@ -234,7 +234,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.n_cmds = static_cast<uint16_t>(n_cmds);
     }
 
-    // Phase 2: build sub-command list
+    // Build sub-command list
     struct SubCmd {
         unsigned io_idx;
         uint64_t lba;
@@ -318,7 +318,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         }
     }
 
-    // Phase 3: enqueue all NVMe commands to the single batch QP
+    // Enqueue all NVMe commands to the single batch QP
     {
         std::lock_guard<std::mutex> qp_lock(qp.lock);
 

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,13 +212,15 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that owns ALL five items by value.
-     * Declared before bs_sp so its destructor runs first on unwind.
+    /* BatchSetupTxn - RAII scope guard that owns ALL five items by value.
      * Pool resources are owned by value (not pointer to bs_sp members)
      * so destruction order does not cause dangling dereferences.
      * On commit, pool resources are transferred to bs_sp->prp_pool
      * and txn.armed is cleared.
-     * Destructor uses try_lock to remain noexcept-safe. */
+     * Destructor uses a blocking lock_guard because gate-state transitions
+     * must be atomic under g_driver.lock. If the lock throws (system_error),
+     * std::terminate is the correct outcome: the process state is
+     * unrecoverable. try_to_lock would silently skip the mutex and race. */
     struct BatchSetupTxn {
         HandleState* hs;
         void* pool_buf;
@@ -229,8 +231,8 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
             /* Rollback items 5, 4 (owned by value) */
             if (pool_dma) { nvm_dma_unmap(pool_dma); }
             if (pool_buf) { free(pool_buf); }
-            /* Rollback items 3, 2, 1 (gate state, best-effort lock) */
-            std::unique_lock<std::mutex> lk(g_driver.lock, std::try_to_lock);
+            /* Rollback items 3, 2, 1 (gate state under g_driver.lock) */
+            std::lock_guard<std::mutex> g(g_driver.lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
@@ -306,10 +308,10 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     return UGDS_OK;
 
 setup_rollback:
-    /* Pool resources are owned by txn; txn.armed=false below prevents
-     * the destructor from double-freeing. Gate state is also unwound
-     * explicitly. bs_sp is reset for its own cleanup. */
-    txn.armed = false;  /* prevent double-run: we clean up explicitly */
+    /* Clean up pool resources first, then gate state. txn stays armed
+     * so its destructor handles gate rollback if the lock_guard below
+     * throws (the destructor will block on the same lock, which is fine
+     * since the throwing lock_guard's exception unwinds this frame). */
     {
         if (txn.pool_dma) { nvm_dma_unmap(txn.pool_dma); txn.pool_dma = nullptr; }
         if (txn.pool_buf) { free(txn.pool_buf); txn.pool_buf = nullptr; }
@@ -321,6 +323,7 @@ setup_rollback:
         handle_release(hs);
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
+    txn.armed = false;  /* gate cleanup done; disarm to prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -7,6 +7,9 @@
 #include <atomic>
 #include <time.h>
 #include <cstdio>
+#include <cassert>
+#include <new>
+#include <memory>
 
 /* Release in-flight reference held by batch submit.
  * Called on validation failure or when batch entry completes. */
@@ -16,6 +19,61 @@ static void async_release_inflight_batch(void* devPtr_base)
     auto it = g_driver.buf_registry.find(devPtr_base);
     if (it != g_driver.buf_registry.end())
         it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+/* Append an entry index to the deferred-release scratch.
+ * Must be called under bs->lock; the actual registry decrement is
+ * deferred until after qp.lock is released. */
+static inline void queue_entry_release(BatchState* bs, unsigned idx)
+{
+    BatchIOEntry& entry = bs->entries[idx];
+    if (!entry.refs_held) return;
+    if (entry.release_queued) return;  /* already queued */
+    assert(bs->n_release_pending < bs->release_scratch.size());
+    entry.release_queued = true;
+    bs->release_scratch[bs->n_release_pending++] = idx;
+}
+
+/* Drain all pending deferred releases in one g_driver.lock hold.
+ * Must be called under bs->lock but NOT under qp.lock.
+ * Clears refs_held and release_queued for each drained index, then
+ * resets n_release_pending. */
+static void drain_release_scratch(BatchState* bs)
+{
+    if (bs->n_release_pending == 0) return;
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    for (uint32_t i = 0; i < bs->n_release_pending; ++i) {
+        uint32_t idx = bs->release_scratch[i];
+        BatchIOEntry& entry = bs->entries[idx];
+        if (!entry.refs_held) continue;  /* already released */
+        async_release_inflight_batch(entry.devPtr_base);
+        entry.refs_held = false;
+        entry.release_queued = false;
+    }
+    bs->n_release_pending = 0;
+}
+
+/* Abort a Phase-3 entry that is WAITING or PENDING.
+ * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
+ * -ECANCELED, and queues the entry for deferred release if all its
+ * submitted commands have already completed.  Must be called
+ * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1). */
+static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
+{
+    BatchIOEntry& entry = bs->entries[idx];
+    if (entry.status != UGDS_BATCH_WAITING &&
+        entry.status != UGDS_BATCH_PENDING)
+        return;
+    entry.error_code = -ECANCELED;
+    entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */
+    if (entry.n_cmds_done == entry.n_cmds) {
+        /* All submitted commands already drained: terminalize now. */
+        entry.status = UGDS_BATCH_FAILED;
+        bs->n_completed++;
+        queue_entry_release(bs, idx);
+    }
+    /* else: submitted prefix still draining; drain_one_completion will
+     * terminalize when n_cmds_done == n_cmds. */
 }
 
 static void cleanup_prp_pool(BatchState* bs)
@@ -69,14 +127,25 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
 
     entry.n_cmds_done++;
 
-    if (entry.n_cmds_done == entry.n_cmds) {
+    if (entry.error_code == -ECANCELED) {
+        /* Abort has terminal-result precedence: do not overwrite with
+         * bytes or device status.  Terminalize when the submitted prefix
+         * has fully drained. */
+        if (entry.n_cmds_done == entry.n_cmds) {
+            entry.status = UGDS_BATCH_FAILED;
+            bs->n_completed++;
+            queue_entry_release(bs, slot.io_idx);
+        }
+    } else if (entry.n_cmds_done == entry.n_cmds) {
         if (entry.status != UGDS_BATCH_FAILED) {
             entry.status = UGDS_BATCH_COMPLETE;
         }
         entry.error_code = entry.bytes_done;
         bs->n_completed++;
-        /* Release in-flight reference when all sub-commands complete */
-        async_release_inflight_batch(entry.devPtr_base);
+        /* Queue deferred release of in-flight reference:
+         * the actual registry decrement runs after qp.lock drops via
+         * drain_release_scratch, restoring the stated lock order. */
+        queue_entry_release(bs, slot.io_idx);
     }
 
     return true;
@@ -105,65 +174,117 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
         return make_error(UGDS_INVALID_VALUE);
 
-    /* Look up handle via global registry to safely acquire a shared_ptr.
-     * This prevents UAF if HandleDeregister races with us. */
+    /* --- Setup gate: one g_driver.lock critical section ---
+     * The closing check, batch_active claim, and batch_setting_up
+     * publication are indivisible with respect to force teardown's
+     * closing claim, which runs under the same lock. */
     std::shared_ptr<HandleState> hs_sp;
-    HandleState* hs = handle_lookup(fh, &hs_sp);
-    if (!hs)
-        return make_error(UGDS_INVALID_VALUE);
+    HandleState* hs = nullptr;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+        if (it == g_driver.handle_registry.end())
+            return make_error(UGDS_INVALID_VALUE);
+        if (it->second->closing.load(std::memory_order_acquire))
+            return make_error(UGDS_INVALID_VALUE);
+        if (it->second->wedged.load(std::memory_order_acquire))
+            return make_error(UGDS_INVALID_VALUE);
+        if (!it->second->batch_qp)
+            return make_error(UGDS_INTERNAL_ERROR);
 
-    if (!hs->batch_qp) {
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+        bool expected = false;
+        if (!it->second->batch_active.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel))
+            return make_error(UGDS_INVALID_VALUE);
+
+        /* Gate won: acquire handle reference + set batch_setting_up */
+        hs_sp = it->second;
+        it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+        hs = hs_sp.get();
+        hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    bool expected = false;
-    if (!hs->batch_active.compare_exchange_strong(expected, true)) {
-        handle_release(hs);
-        return make_error(UGDS_INVALID_VALUE);
-    }
-
-    auto bs = new (std::nothrow) BatchState();
-    if (!bs) {
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
-    }
-
-    bs->capacity = nr;
-    bs->hs = hs;
-    bs->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
-    bs->entries.resize(nr);
-    bs->cmd_map.resize(hs->batch_queue_depth);
+    /* --- Private, fallible phase --- */
+    auto bs_sp = std::make_shared<BatchState>();
+    bs_sp->capacity = nr;
+    bs_sp->hs = hs;
+    bs_sp->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
+    bs_sp->entries.resize(nr);
+    bs_sp->cmd_map.resize(hs->batch_queue_depth);
+    /* release_scratch is sized from capacity (the immutable SetUp
+     * bound), NOT n_entries (the current round's consumed count). */
+    bs_sp->release_scratch.resize(nr);
 
     const size_t page_size = hs->ctrl->page_size;
-    PRPPool& pool = bs->prp_pool;
+    PRPPool& pool = bs_sp->prp_pool;
     size_t pool_bytes = UGDS_PRP_POOL_PAGES * page_size;
 
+    uGDSError_t setup_err = UGDS_OK;
     if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
-        delete bs;
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+        setup_err = make_error(UGDS_OUT_OF_MEMORY);
+        goto setup_rollback;
     }
     std::memset(pool.buf, 0, pool_bytes);
 
-    int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
-    if (!nvm_ok(rc)) {
-        free(pool.buf);
-        pool.buf = nullptr;
-        delete bs;
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+    {
+        int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
+        if (!nvm_ok(rc)) {
+            free(pool.buf);
+            pool.buf = nullptr;
+            setup_err = (rc == ENOMEM)
+                ? make_error(UGDS_OUT_OF_MEMORY)
+                : make_error(UGDS_INTERNAL_ERROR);
+            goto setup_rollback;
+        }
     }
     pool.n_pages = UGDS_PRP_POOL_PAGES;
     pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
-    *batch = static_cast<uGDSBatchHandle_t>(bs);
+    /* --- Publication: one g_driver.lock critical section --- */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        if (hs->closing.load(std::memory_order_acquire)) {
+            /* Deregister/force arrived mid-setup; roll back.
+             * batch_setting_up is cleared as the LAST rollback action. */
+            setup_err = make_error(UGDS_INVALID_VALUE);
+            goto setup_rollback;
+        }
+        /* active_batch must be null: the CAS above ensures no other setup
+         * claimed batch_active, and no destroy can have run yet. */
+        if (hs->active_batch != nullptr) {
+            setup_err = make_error(UGDS_INTERNAL_ERROR);
+            goto setup_rollback;
+        }
+        bs_sp->self = bs_sp;            /* public-handle ownership */
+        hs->active_batch = bs_sp;       /* owning recovery link */
+        hs->batch_setting_up.store(false, std::memory_order_release);
+    }
 
+    *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
     return UGDS_OK;
+
+setup_rollback:
+    /* Rollback in reverse acquisition order:
+     * 5 (pool DMA) -> 4 (pool buf) -> 3 (BatchState shared_ptr)
+     * -> 2 (batch_active) -> 1 (handle ref + batch_setting_up LAST).
+     * pool.dma and pool.buf are cleaned up above or here; the shared_ptr
+     * reset handles item 3. */
+    {
+        if (pool.dma) { nvm_dma_unmap(pool.dma); pool.dma = nullptr; }
+        if (pool.buf) { free(pool.buf); pool.buf = nullptr; }
+    }
+    bs_sp.reset();  /* RAII: releases BatchState if last owner */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        hs->batch_active.store(false, std::memory_order_release);
+        handle_release(hs);
+        /* batch_setting_up cleared LAST so a waiting force teardown
+         * proceeds only after every other side effect (including the
+         * DMA unmap, which needs hs->ctrl alive) has been undone. */
+        hs->batch_setting_up.store(false, std::memory_order_release);
+    }
+    return setup_err;
 }
 
 extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
@@ -225,6 +346,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.error_code = 0;
         entry.n_cmds_done = 0;
         entry.event_returned = false;
+        /* SGL/lifecycle fields */
+        entry.kind = BATCH_ENTRY_PLAIN;
+        entry.seg_begin = 0;
+        entry.seg_count = 0;
+        entry.refs_held = false;
+        entry.release_queued = false;
+        entry.n_cmds_submitted = 0;
 
         /* Overflow-safe ceil division for n_cmds */
         size_t n_cmds = (p.size - 1) / max_xfer + 1;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,13 +212,25 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn scope guard. The five named rollback items
-     * are armed in acquisition order. Rollback runs in reverse order.
-     * Item 1: gate refs/flags. Item 2: batch_active claim.
-     * Items 3-5 are handled by the explicit rollback below for the
-     * private phase allocations. The gate (items 1+2) is rolled back
-     * by the explicit cleanup at setup_rollback. */
-    bool txn_gate_armed = true;   /* items 1+2 armed */
+    /* M3: BatchSetupTxn - RAII scope guard that rolls back gate state
+     * if the function exits via exception or early return before commit.
+     * Five items (acquired in order, rolled back in reverse):
+     *   1. handle_in_flight reference
+     *   2. batch_active claim
+     *   3. batch_setting_up flag (cleared LAST, under g_driver.lock)
+     * Items 4-5 (pool DMA, pool buf) are handled by the explicit
+     * setup_rollback label for non-throwing failures. */
+    struct BatchSetupTxn {
+        HandleState* hs;
+        bool armed;
+        ~BatchSetupTxn() {
+            if (!armed) return;
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            hs->batch_active.store(false, std::memory_order_release);
+            handle_release(hs);
+            hs->batch_setting_up.store(false, std::memory_order_release);
+        }
+    } txn{hs, true};
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -275,7 +287,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
-        txn_gate_armed = false;         /* commit: gate items disarmed */
+        txn.armed = false;           /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
@@ -301,6 +313,7 @@ setup_rollback:
          * DMA unmap, which needs hs->ctrl alive) has been undone. */
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
+    txn.armed = false;  /* explicit rollback done; prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,25 +212,31 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that rolls back gate state
+    /* M3: BatchSetupTxn - RAII scope guard that rolls back ALL five items
      * if the function exits via exception or early return before commit.
-     * Five items (acquired in order, rolled back in reverse):
-     *   1. handle_in_flight reference
-     *   2. batch_active claim
-     *   3. batch_setting_up flag (cleared LAST, under g_driver.lock)
-     * Items 4-5 (pool DMA, pool buf) are handled by the explicit
-     * setup_rollback label for non-throwing failures. */
+     * Items (acquired in order, rolled back in reverse):
+     *   5. pool DMA mapping
+     *   4. pool host buffer
+     *   3. batch_active claim
+     *   2. handle_in_flight reference
+     *   1. batch_setting_up flag (cleared LAST, under g_driver.lock) */
     struct BatchSetupTxn {
         HandleState* hs;
+        void** pool_buf;
+        nvm_dma_t** pool_dma;
         bool armed;
         ~BatchSetupTxn() {
             if (!armed) return;
+            /* Rollback items 5, 4 (raw resources) */
+            if (pool_dma && *pool_dma) { nvm_dma_unmap(*pool_dma); *pool_dma = nullptr; }
+            if (pool_buf && *pool_buf) { free(*pool_buf); *pool_buf = nullptr; }
+            /* Rollback items 3, 2, 1 (gate state) */
             std::lock_guard<std::mutex> g(g_driver.lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
         }
-    } txn{hs, true};
+    } txn{hs, nullptr, nullptr, true};
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -253,18 +259,21 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         goto setup_rollback;
     }
     std::memset(pool.buf, 0, pool_bytes);
+    txn.pool_buf = &pool.buf;  /* arm item 4 */
 
     {
         int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
         if (!nvm_ok(rc)) {
             free(pool.buf);
             pool.buf = nullptr;
+            txn.pool_buf = nullptr;  /* already freed */
             setup_err = (rc == ENOMEM)
                 ? make_error(UGDS_OUT_OF_MEMORY)
                 : make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
     }
+    txn.pool_dma = &pool.dma;  /* arm item 5 */
     pool.n_pages = UGDS_PRP_POOL_PAGES;
     pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
@@ -654,6 +663,7 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
                                               uGDSIOEvents_t* events,
                                               struct timespec* timeout)
 {
+    try {
     if (batch == nullptr || nr == nullptr || events == nullptr)
         return make_error(UGDS_INVALID_VALUE);
 
@@ -720,12 +730,15 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
 
         __builtin_ia32_pause();
     }
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 {
     if (batch == nullptr) return;
-
+    try {
     BatchState* bs = static_cast<BatchState*>(batch);
     HandleState* hs = bs->hs;
 
@@ -819,4 +832,9 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 
     /* link_pin then last_pin drop here; whichever is the final reference
      * runs ~BatchState with no guard addressing its members. */
+    } catch (...) {
+        /* Destroy is void; swallow to prevent crossing C ABI.
+         * The BatchState may be partially cleaned up but shared_ptr
+         * ref counts prevent double-free. */
+    }
 }

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -82,28 +82,39 @@ static void drain_release_scratch(BatchState* bs)
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        /* C1: release_entry_refs handles both PLAIN and VECTORED. */
+        /* release_entry_refs handles both PLAIN and VECTORED. */
         release_entry_refs(bs, entry);
     }
     bs->n_release_pending = 0;
 }
 
-/* Abort a Phase-3 entry that is WAITING, PENDING, or FAILED.
+/* Abort an entry that is WAITING or PENDING (not yet terminal).
+ *
  * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
  * -ECANCELED, and queues the entry for deferred release if all its
- * submitted commands have already completed.  Must be called
- * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1).
+ * submitted commands have already completed.  Must be called under
+ * bs->lock + qp.lock; does NOT touch g_driver.lock.
  *
- * C4 (review R1): abort also accepts the FAILED state so a device
- * error latched by drain_one_completion is not stranded: the submitted
- * prefix still drains exactly once and refs are released.  A COMPLETE
- * or TORN_DOWN entry is left untouched. */
+ * Entries already terminalized by drain_one_completion (device error
+ * latched as FAILED while the submitted prefix continues to drain)
+ * are still eligible: their remaining commands will drain, and the
+ * ECANCELED precedence in drain ensures consistent terminalization.
+ *
+ * Entries that were never submitted (preflight/resolve failures with
+ * n_cmds == 0 and n_completed already incremented) must be skipped to
+ * avoid double-counting.  We detect this with n_cmds == 0: such
+ * entries have no command-level lifecycle to abort. */
 static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
 {
     BatchIOEntry& entry = bs->entries[idx];
     if (entry.status != UGDS_BATCH_WAITING &&
         entry.status != UGDS_BATCH_PENDING &&
         entry.status != UGDS_BATCH_FAILED)
+        return;
+    /* Skip entries that were terminalized before any submission
+     * (preflight or resolve failure).  These already incremented
+     * n_completed and have no command lifecycle to abort. */
+    if (entry.n_cmds == 0)
         return;
     entry.error_code = -ECANCELED;
     entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -850,3 +850,470 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
          * ref counts prevent double-free. */
     }
 }
+
+/* ======================================================================== */
+/* uGDSBatchIOSubmitv: vectored batch submit                              */
+/* ======================================================================== */
+
+/* Registry preflight result: a stack record filled under g_driver.lock
+ * without taking refs.  Classifies each entry so the caller can size
+ * the work array before any ref acquisition or allocation. */
+struct PreflightResult {
+    bool        valid;
+};
+
+/* Pure value validation for one vectored entry.
+ * Performs the value-matrix checks and computes the analytic window
+ * count via sgl_count_windows_analytic.  Writes nothing to bs.
+ * Returns true on success (out_n_cmds set), false on value error. */
+static bool submitv_validate_entry(const uGDSIOSegParams_t& p,
+                                   size_t page_size, size_t block_size,
+                                   size_t window_cap, size_t SU,
+                                   uint32_t* out_n_cmds)
+{
+    if (p.segs == nullptr || p.nr_segs == 0)
+        return false;
+    if (p.nr_segs > UGDS_BATCH_IOV_MAX)
+        return false;
+    if (p.file_offset < 0)
+        return false;
+    if ((static_cast<size_t>(p.file_offset) % block_size) != 0)
+        return false;
+
+    /* opcode check */
+    if (p.opcode != UGDS_READ && p.opcode != UGDS_WRITE)
+        return false;
+
+    uint64_t total_size = 0;
+    for (unsigned k = 0; k < p.nr_segs; ++k) {
+        if (p.segs[k].base == nullptr || p.segs[k].size == 0)
+            return false;
+        if (p.segs[k].offset < 0)
+            return false;
+        if ((static_cast<size_t>(p.segs[k].offset) % page_size) != 0)
+            return false;
+        if ((p.segs[k].size % block_size) != 0)
+            return false;
+
+        uint64_t seg_size = static_cast<uint64_t>(p.segs[k].size);
+        if (seg_size > static_cast<uint64_t>(SSIZE_MAX) - total_size)
+            return false;  /* total overflow */
+        total_size += seg_size;
+    }
+
+    /* Analytic window count over the segment array.  O(nr_segs). */
+    uint32_t n_cmds = 0;
+    if (!sgl_count_windows_analytic(p.segs, p.nr_segs,
+                                    window_cap, page_size, block_size,
+                                    &n_cmds))
+        return false;
+
+    if (n_cmds == 0)
+        return false;
+
+    (void)SU;  /* window_cap already incorporates SU rounding */
+    *out_n_cmds = n_cmds;
+    return true;
+}
+
+extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
+                                            uGDSIOSegParams_t* iocb,
+                                            unsigned flags)
+{
+    try {
+    /* ==================================================================
+     * Basic call/batch checks (no state mutation)
+     * ================================================================== */
+    if (batch == nullptr || iocb == nullptr || nr == 0)
+        return make_error(UGDS_INVALID_VALUE);
+
+    BatchState* bs = static_cast<BatchState*>(batch);
+    std::lock_guard<std::mutex> batch_lock(bs->lock);
+
+    if (bs->hs->wedged.load(std::memory_order_acquire) ||
+        bs->hs->closing.load(std::memory_order_acquire))
+        return make_error(UGDS_BUSY);
+
+    if (bs->lifecycle != BATCH_LIFECYCLE_ACTIVE)
+        return make_error(UGDS_INVALID_VALUE);
+
+    if (bs->n_entries + nr > bs->capacity)
+        return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
+
+    (void)flags;
+
+    /* recycle: same path as plain submit, plus arena_used reset. */
+    if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
+        bs->n_entries = 0;
+        bs->n_completed = 0;
+        bs->n_events_read = 0;
+        bs->arena_used = 0;
+    }
+
+    HandleState* hs = bs->hs;
+    IOQueuePair& qp = hs->batch_qp->qp;
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+    const size_t max_xfer   = compute_max_xfer(hs);
+
+    /* Compute SU and window_cap (parity with sync vectored path). */
+    const size_t SU = (page_size > block_size &&
+                       (page_size & (page_size - 1)) == 0 &&
+                       (block_size & (block_size - 1)) == 0)
+                      ? std::max(page_size, block_size)
+                      : [&]() {
+                          size_t a = page_size, b = block_size;
+                          while (b != 0) { size_t t = a % b; a = b; b = t; }
+                          return (page_size / a) * block_size;
+                      }();
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* ==================================================================
+     * Validate -> preflight -> allocate -> commit-copy
+     * ================================================================== */
+
+    /* --- Step 1: Pure value validation (all entries, no state write) --- */
+    unsigned base = bs->n_entries;
+
+    uint32_t per_entry_n_cmds[UGDS_MAX_BATCH_IO_SIZE];
+    uint64_t total_cmds = 0;
+    for (unsigned i = 0; i < nr; ++i) {
+        uint32_t n_cmds_i = 0;
+        if (!submitv_validate_entry(iocb[i], page_size, block_size,
+                                    window_cap, SU, &n_cmds_i))
+            return make_error(UGDS_INVALID_VALUE);
+
+        /* checked addition for total_cmds */
+        if (total_cmds > UINT64_MAX - n_cmds_i)
+            return make_error(UGDS_INVALID_VALUE);
+        total_cmds += n_cmds_i;
+        per_entry_n_cmds[i] = n_cmds_i;
+    }
+
+    if (total_cmds > UINT32_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* --- Step 2: Registry preflight (read-only, no refs) ---
+     * Classifies each entry; failures become terminal FAILED -EINVAL
+     * and contribute zero to alloc_cmds. */
+    PreflightResult preflight[UGDS_MAX_BATCH_IO_SIZE];
+    uint64_t alloc_cmds = 0;
+    {
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        for (unsigned i = 0; i < nr; ++i) {
+            const uGDSIOSegParams_t& p = iocb[i];
+            bool ok = true;
+
+            /* Check every segment: registration, exact-length, affinity. */
+            for (unsigned k = 0; k < p.nr_segs && ok; ++k) {
+                auto it = g_driver.buf_registry.find(p.segs[k].base);
+                if (it == g_driver.buf_registry.end()) {
+                    ok = false;
+                    break;
+                }
+                DriverState::BufEntry& be = it->second;
+                /* Controller affinity check */
+                if (be.map_ctrl != hs->ctrl) { ok = false; break; }
+                /* Exact-length bounds */
+                const uint64_t off = static_cast<uint64_t>(p.segs[k].offset);
+                const uint64_t sz  = static_cast<uint64_t>(p.segs[k].size);
+                if (off > be.length || sz > be.length - off) {
+                    ok = false;
+                    break;
+                }
+            }
+
+            preflight[i].valid = ok;
+            if (ok) {
+                alloc_cmds += per_entry_n_cmds[i];
+            }
+        }
+    }
+
+    /* --- Step 3: Allocate (fallible, still no entry/watermark mutation) ---
+     * First the local work array, then the one-time arena resize.
+     * The arena resize is the final fallible operation before commit. */
+    std::vector<SubCmdV> work;
+    if (alloc_cmds > 0)
+        work.resize(static_cast<size_t>(alloc_cmds));
+
+    if (bs->seg_arena.empty()) {
+        /* One lifetime allocation: capacity * UGDS_BATCH_IOV_MAX.
+         * capacity <= 128, UGDS_BATCH_IOV_MAX = 128, so <= 16384
+         * SegView elements (~48 B each = ~768 KiB). */
+        size_t arena_elems = static_cast<size_t>(bs->capacity) *
+                             static_cast<size_t>(UGDS_BATCH_IOV_MAX);
+        bs->seg_arena.resize(arena_elems);
+    }
+
+    /* --- Step 4: Commit-copy (infallible) ---
+     * From here, no allocation or throw is possible.  Capture the
+     * watermark for rollback safety; populate entries and arena.
+     * The watermark is the 8.4 rollback anchor: it is never restored
+     * in this path because no operation after this point can fail, but
+     * it documents the invariant and serves as the audit point for the
+     * fixed-size arena model. */
+    const uint32_t watermark = bs->arena_used;
+    (void)watermark;  /* documented rollback anchor; no post-commit failure */
+    uint32_t work_used = 0;
+
+    for (unsigned i = 0; i < nr; ++i) {
+        unsigned idx = base + i;
+        BatchIOEntry& entry = bs->entries[idx];
+        const uGDSIOSegParams_t& p = iocb[i];
+
+        /* Clear entry fields for both success and failure paths. */
+        entry.cookie = p.cookie;
+        entry.devPtr_base = nullptr;   /* not used for vectored */
+        entry.file_offset = p.file_offset;
+        entry.devPtr_offset = 0;
+        entry.size = 0;
+        entry.opcode = (p.opcode == UGDS_READ) ? NVM_IO_READ : NVM_IO_WRITE;
+        entry.status = UGDS_BATCH_WAITING;
+        entry.bytes_done = 0;
+        entry.error_code = 0;
+        entry.n_cmds_done = 0;
+        entry.event_returned = false;
+        entry.refs_held = false;
+        entry.release_queued = false;
+        entry.n_cmds_submitted = 0;
+
+        if (!preflight[i].valid) {
+            /* Preflight failure: terminal FAILED -EINVAL, n_cmds = 0. */
+            entry.kind = BATCH_ENTRY_VECTORED;
+            entry.seg_begin = 0;
+            entry.seg_count = 0;
+            entry.n_cmds = 0;
+            entry.status = UGDS_BATCH_FAILED;
+            entry.error_code = -EINVAL;
+            bs->n_completed++;
+            continue;
+        }
+
+        /* Preflight-valid entry: copy segments into the arena. */
+        assert(bs->arena_used + p.nr_segs <= bs->seg_arena.size());
+        entry.kind = BATCH_ENTRY_VECTORED;
+        entry.seg_begin = bs->arena_used;
+        entry.seg_count = static_cast<uint32_t>(p.nr_segs);
+        entry.n_cmds = static_cast<uint16_t>(per_entry_n_cmds[i]);
+
+        for (unsigned k = 0; k < p.nr_segs; ++k) {
+            bs->seg_arena[bs->arena_used + k] = SegView{};
+        }
+        bs->arena_used += static_cast<uint32_t>(p.nr_segs);
+    }
+
+    /* ==================================================================
+     * Acquiring resolve / build
+     * ==================================================================
+     * For each preflight-valid entry, acquire refs (all-or-nothing per
+     * entry via SglRefOwner), resolve SegView geometry into the arena,
+     * and stream windows into the work array via SglWindowCursor. */
+
+    for (unsigned i = 0; i < nr; ++i) {
+        unsigned idx = base + i;
+        BatchIOEntry& entry = bs->entries[idx];
+
+        /* Skip entries already terminalized in commit-copy. */
+        if (entry.status == UGDS_BATCH_FAILED)
+            continue;
+
+        const uGDSIOSegParams_t& p = iocb[i];
+        SegView* seg_views = bs->seg_arena.data() + entry.seg_begin;
+
+        /* Acquire in-flight refs and resolve geometry (all-or-nothing). */
+        SglRefOwner owner;
+        int rc = owner.acquire(p.segs, static_cast<uint32_t>(p.nr_segs),
+                               hs->ctrl, page_size, seg_views);
+        if (rc != 0) {
+            /* Resolve failure: entry-local.  No work items emitted. */
+            entry.status = UGDS_BATCH_FAILED;
+            entry.error_code = -EINVAL;
+            entry.n_cmds = 0;
+            entry.n_cmds_done = 0;
+            entry.n_cmds_submitted = 0;
+            bs->n_completed++;
+            /* owner is empty (all-or-nothing), nothing to release. */
+            continue;
+        }
+
+        /* refs are now held by the arena; mark for deferred release. */
+        entry.refs_held = true;
+
+        /* Stream windows into the work array. */
+        SglWindowCursor cursor;
+        sgl_cursor_init(cursor, seg_views, static_cast<uint32_t>(p.nr_segs),
+                        window_cap, page_size, block_size);
+
+        uint64_t current_lba =
+            static_cast<uint64_t>(p.file_offset) / block_size;
+
+        CmdWindow win;
+        while (sgl_cursor_next(cursor, win)) {
+            assert(work_used < work.size());
+            work[work_used].io_idx = idx;
+            work[work_used].lba    = current_lba;
+            work[work_used].window = win;
+            work_used++;
+
+            current_lba += win.bytes / block_size;
+        }
+    }
+
+    /* ==================================================================
+     * Enqueue (mirrors the plain submit)
+     * ================================================================== */
+    {
+        std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        for (uint32_t wi = 0; wi < work_used; ++wi) {
+            SubCmdV& sc = work[wi];
+            BatchIOEntry& entry = bs->entries[sc.io_idx];
+
+            const size_t n_pages = sc.window.n_pages;
+            SegView* seg_views = bs->seg_arena.data() + entry.seg_begin;
+
+            /* PRP pool page for windows needing a list (> 2 pages). */
+            uint16_t prp_idx = UINT16_MAX;
+            if (n_pages > 2) {
+                int pidx = prp_pool_alloc(&bs->prp_pool);
+                if (pidx < 0) {
+                    /* Pool exhaustion: submit ring, then drain loop. */
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    uint64_t spins = 0;
+                    const uint64_t max_spins =
+                        (uint64_t)hs->ctrl->timeout * 1000000ULL;
+                    while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
+                        if (!drain_one_completion(qp, bs)) {
+                            if (++spins > max_spins) {
+                                nvm_sq_submit(&qp.sq);
+                                std::atomic_thread_fence(
+                                    std::memory_order_seq_cst);
+                                for (unsigned i = sc.io_idx;
+                                     i < base + nr; ++i)
+                                    abort_phase3_entry(bs, i);
+                                bs->n_entries += nr;
+                                goto phase3v_abort_return;
+                            }
+                            __builtin_ia32_pause();
+                        }
+                    }
+                }
+                prp_idx = static_cast<uint16_t>(pidx);
+            }
+
+            uint16_t slot = static_cast<uint16_t>(
+                qp.sq.tail.load(std::memory_order_relaxed) % qp.sq.qs);
+            nvm_cmd_t* cmd = nvm_sq_enqueue(&qp.sq);
+
+            if (cmd == nullptr) {
+                /* SQ full: submit ring, drain, retry. */
+                nvm_sq_submit(&qp.sq);
+                std::atomic_thread_fence(std::memory_order_seq_cst);
+
+                uint64_t spins = 0;
+                const uint64_t max_spins =
+                    (uint64_t)hs->ctrl->timeout * 1000000ULL;
+                bool drained = false;
+                while (!drained) {
+                    if (drain_one_completion(qp, bs)) {
+                        drained = true;
+                    } else if (++spins > max_spins) {
+                        if (prp_idx != UINT16_MAX)
+                            prp_pool_free(&bs->prp_pool, prp_idx);
+                        nvm_sq_submit(&qp.sq);
+                        std::atomic_thread_fence(std::memory_order_seq_cst);
+                        for (unsigned i = sc.io_idx; i < base + nr; ++i)
+                            abort_phase3_entry(bs, i);
+                        bs->n_entries += nr;
+                        goto phase3v_abort_return;
+                    } else {
+                        __builtin_ia32_pause();
+                    }
+                }
+
+                slot = static_cast<uint16_t>(
+                    qp.sq.tail.load(std::memory_order_relaxed) % qp.sq.qs);
+                cmd = nvm_sq_enqueue(&qp.sq);
+                if (cmd == nullptr) {
+                    if (prp_idx != UINT16_MAX)
+                        prp_pool_free(&bs->prp_pool, prp_idx);
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    for (unsigned i = sc.io_idx; i < base + nr; ++i)
+                        abort_phase3_entry(bs, i);
+                    bs->n_entries += nr;
+                    goto phase3v_abort_return;
+                }
+            }
+
+            memset(cmd, 0, sizeof(nvm_cmd_t));
+            nvm_cmd_header(cmd, slot, entry.opcode, hs->ns_id);
+
+            /* Build PRP via SglPageCursor. */
+            SglPageCursor pc;
+            sgl_page_cursor_init(pc, seg_views,
+                                 sc.window.first_seg,
+                                 sc.window.first_seg_page_off,
+                                 sc.window.n_segs, sc.window.n_pages);
+
+            if (n_pages == 1) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, 0);
+            } else if (n_pages == 2) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                uint64_t prp2 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, prp2);
+            } else {
+                volatile uint64_t* prp_list =
+                    reinterpret_cast<volatile uint64_t*>(
+                        static_cast<uint8_t*>(bs->prp_pool.buf) +
+                        prp_idx * page_size);
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                for (size_t p = 1; p < n_pages; ++p)
+                    prp_list[p - 1] = sgl_page_cursor_next(pc);
+                sgl_publish_prp();
+                nvm_cmd_data_ptr(cmd, prp1,
+                                 bs->prp_pool.dma->ioaddrs[prp_idx]);
+            }
+
+            size_t n_blocks = sc.window.bytes / block_size;
+            nvm_cmd_rw_blks(cmd, sc.lba, static_cast<uint16_t>(n_blocks));
+
+            CmdSlot& cs = bs->cmd_map[slot];
+            cs.io_idx = static_cast<uint16_t>(sc.io_idx);
+            cs.chunk_bytes = sc.window.bytes;
+            cs.prp_page_idx = prp_idx;
+            cs.active = true;
+            bs->in_flight++;
+
+            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING. */
+            entry.n_cmds_submitted++;
+            entry.status = UGDS_BATCH_PENDING;
+        }
+
+        /* Single doorbell for all enqueued commands. */
+        sgl_publish_prp();
+        nvm_sq_submit(&qp.sq);
+        sgl_publish_prp();
+    }
+
+    /* Drain deferred releases after qp.lock is released. */
+    drain_release_scratch(bs);
+
+    bs->n_entries += nr;
+    return UGDS_OK;
+
+phase3v_abort_return:
+    /* Abort path: the abort helper queued entries for deferred release. */
+    drain_release_scratch(bs);
+    return make_error(UGDS_INTERNAL_ERROR);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+}

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -911,6 +911,11 @@ static bool submitv_validate_entry(const uGDSIOSegParams_t& p,
     if (n_cmds == 0)
         return false;
 
+    /* BatchIOEntry::n_cmds is uint16_t.  Reject counts that would
+     * truncate before any allocation or commit-copy. */
+    if (n_cmds > UINT16_MAX)
+        return false;
+
     (void)SU;  /* window_cap already incorporates SU rounding */
     *out_n_cmds = n_cmds;
     return true;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -12,7 +12,8 @@
 #include <memory>
 
 /* Release in-flight reference held by batch submit.
- * Called on validation failure or when batch entry completes. */
+ * Called on validation failure or when batch entry completes.
+ * MUST be called WITHOUT holding g_driver.lock. */
 static void async_release_inflight_batch(void* devPtr_base)
 {
     std::lock_guard<std::mutex> drv_lock(g_driver.lock);
@@ -35,9 +36,10 @@ static inline void queue_entry_release(BatchState* bs, unsigned idx)
 }
 
 /* Drain all pending deferred releases in one g_driver.lock hold.
- * Must be called under bs->lock but NOT under qp.lock.
- * Clears refs_held and release_queued for each drained index, then
- * resets n_release_pending. */
+ * Must be called under bs->lock but NOT under qp.lock and NOT under
+ * g_driver.lock (the old version called
+ * async_release_inflight_batch which re-locked g_driver.lock, causing
+ * a deadlock on a non-recursive mutex). */
 static void drain_release_scratch(BatchState* bs)
 {
     if (bs->n_release_pending == 0) return;
@@ -46,7 +48,12 @@ static void drain_release_scratch(BatchState* bs)
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        async_release_inflight_batch(entry.devPtr_base);
+        /* Inline the decrement instead of calling
+         * async_release_inflight_batch to avoid re-locking
+         * g_driver.lock (nested-lock bug fix). */
+        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
         entry.refs_held = false;
         entry.release_queued = false;
     }
@@ -76,7 +83,7 @@ static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
      * terminalize when n_cmds_done == n_cmds. */
 }
 
-static void cleanup_prp_pool(BatchState* bs)
+void cleanup_prp_pool(BatchState* bs)
 {
     PRPPool& pool = bs->prp_pool;
     if (pool.dma) nvm_dma_unmap(pool.dma);
@@ -169,6 +176,7 @@ static size_t compute_max_xfer(HandleState* hs)
 extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
                                           uGDSHandle_t fh, unsigned nr)
 {
+    try {
     if (batch == nullptr || fh == nullptr)
         return make_error(UGDS_INVALID_VALUE);
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
@@ -203,6 +211,14 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs = hs_sp.get();
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
+
+    /* M3: BatchSetupTxn scope guard. The five named rollback items
+     * are armed in acquisition order. Rollback runs in reverse order.
+     * Item 1: gate refs/flags. Item 2: batch_active claim.
+     * Items 3-5 are handled by the explicit rollback below for the
+     * private phase allocations. The gate (items 1+2) is rolled back
+     * by the explicit cleanup at setup_rollback. */
+    bool txn_gate_armed = true;   /* items 1+2 armed */
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -259,6 +275,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
+        txn_gate_armed = false;         /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
@@ -285,11 +302,17 @@ setup_rollback:
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
     return setup_err;
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                                            uGDSIOParams_t* iocb, unsigned flags)
 {
+    try {
     if (batch == nullptr || iocb == nullptr || nr == 0)
         return make_error(UGDS_INVALID_VALUE);
 
@@ -387,11 +410,29 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             std::lock_guard<std::mutex> drv_lock(g_driver.lock);
             auto it = g_driver.buf_registry.find(entry.devPtr_base);
             if (it != g_driver.buf_registry.end()) {
-                buf_dma = it->second.dma;
+                /* Controller affinity check. */
+                if (it->second.map_ctrl != hs->ctrl) {
+                    buf_dma = nullptr;
+                }
+                /* Exact-length bounds. */
+                else {
+                    const uint64_t off =
+                        static_cast<uint64_t>(entry.devPtr_offset);
+                    const uint64_t sz  =
+                        static_cast<uint64_t>(entry.size);
+                    if (off > it->second.length ||
+                        sz > it->second.length - off) {
+                        buf_dma = nullptr;
+                    } else {
+                        buf_dma = it->second.dma;
+                    }
+                }
                 /* Hold in-flight reference until batch completions are drained
                  * or destroy finishes. Prevents Deregister from unmapping
                  * while batch commands retain PRPs from this buffer. */
                 it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+                /* Mark that this entry holds a deferred in-flight ref. */
+                entry.refs_held = true;
             }
         }
 
@@ -401,6 +442,8 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            /* Use deferred release so refs_held is consistent. */
+            queue_entry_release(bs, idx);
             continue;
         }
 
@@ -410,12 +453,12 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
-            async_release_inflight_batch(entry.devPtr_base);
+            queue_entry_release(bs, idx);
             continue;
         }
         buf_page_start = static_cast<size_t>(entry.devPtr_offset) / page_size;
 
-        /* Overflow-safe bounds check */
+        /* Defensive page-count bounds check (subsumed by exact-length check). */
         size_t batch_pages_needed = (entry.size - 1) / page_size + 1;
         if (batch_pages_needed > buf_dma->n_ioaddrs ||
             buf_page_start > buf_dma->n_ioaddrs - batch_pages_needed) {
@@ -424,7 +467,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
-            async_release_inflight_batch(entry.devPtr_base);
+            queue_entry_release(bs, idx);
             continue;
         }
 
@@ -466,22 +509,17 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
                         if (!drain_one_completion(qp, bs)) {
                             if (++spins > max_spins) {
-                                /* Release in_flight refs only for entries
-                                 * that are still WAITING (ref acquired but
-                                 * not yet submitted). PENDING entries have
-                                 * commands in the SQ -- keep ref until drain.
-                                 * COMPLETE entries were already released by
-                                 * drain_one_completion. FAILED already done. */
-                                for (unsigned i = 0; i < nr; ++i) {
-                                    BatchIOEntry& e = bs->entries[base + i];
-                                    if (e.status == UGDS_BATCH_WAITING) {
-                                        async_release_inflight_batch(e.devPtr_base);
-                                        e.status = UGDS_BATCH_FAILED;
-                                        e.n_cmds = 0;
-                                    }
+                                /* Abort current and later entries via
+                                 * the common helper. WAITING + PENDING
+                                 * are both handled. Ring the SQ doorbell
+                                 * for the accepted prefix. */
+                                nvm_sq_submit(&qp.sq);
+                                std::atomic_thread_fence(std::memory_order_seq_cst);
+                                for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                                    abort_phase3_entry(bs, i);
                                 }
                                 bs->n_entries += nr;
-                                return make_error(UGDS_INTERNAL_ERROR);
+                                goto phase3_abort_return;
                             }
                             __builtin_ia32_pause();
                         }
@@ -507,17 +545,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     } else if (++spins > max_spins) {
                         if (prp_idx != UINT16_MAX)
                             prp_pool_free(&bs->prp_pool, prp_idx);
-                        /* Release in_flight refs only for WAITING entries. */
-                        for (unsigned i = 0; i < nr; ++i) {
-                            BatchIOEntry& e = bs->entries[base + i];
-                            if (e.status == UGDS_BATCH_WAITING) {
-                                async_release_inflight_batch(e.devPtr_base);
-                                e.status = UGDS_BATCH_FAILED;
-                                e.n_cmds = 0;
-                            }
+                        /* Abort current and later entries. */
+                        nvm_sq_submit(&qp.sq);
+                        std::atomic_thread_fence(std::memory_order_seq_cst);
+                        for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                            abort_phase3_entry(bs, i);
                         }
                         bs->n_entries += nr;
-                        return make_error(UGDS_INTERNAL_ERROR);
+                        goto phase3_abort_return;
                     } else {
                         __builtin_ia32_pause();
                     }
@@ -529,17 +564,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                 if (cmd == nullptr) {
                     if (prp_idx != UINT16_MAX)
                         prp_pool_free(&bs->prp_pool, prp_idx);
-                    /* Release in_flight refs only for WAITING entries. */
-                    for (unsigned i = 0; i < nr; ++i) {
-                        BatchIOEntry& e = bs->entries[base + i];
-                        if (e.status == UGDS_BATCH_WAITING) {
-                            async_release_inflight_batch(e.devPtr_base);
-                            e.status = UGDS_BATCH_FAILED;
-                            e.n_cmds = 0;
-                        }
+                    /* Abort current and later entries. */
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                        abort_phase3_entry(bs, i);
                     }
                     bs->n_entries += nr;
-                    return make_error(UGDS_INTERNAL_ERROR);
+                    goto phase3_abort_return;
                 }
             }
 
@@ -574,6 +606,9 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
+            /* M2: commit the slot map first, then increment
+             * n_cmds_submitted, then transition WAITING->PENDING. */
+            entry.n_cmds_submitted++;
             entry.status = UGDS_BATCH_PENDING;
         }
 
@@ -583,8 +618,22 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         std::atomic_thread_fence(std::memory_order_seq_cst);
     }
 
+    /* Drain deferred releases after qp.lock is released. */
+    drain_release_scratch(bs);
+
     bs->n_entries += nr;
     return UGDS_OK;
+
+phase3_abort_return:
+    /* Drain deferred releases after qp.lock is released.  The abort
+     * helper queued WAITING/PENDING entries for release. */
+    drain_release_scratch(bs);
+    return make_error(UGDS_INTERNAL_ERROR);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
@@ -623,6 +672,9 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             while (drain_one_completion(qp, bs)) {}
         }
+
+        /* Drain deferred releases after qp.lock is released. */
+        drain_release_scratch(bs);
 
         for (unsigned i = 0; i < bs->n_entries && n_ready < max_events; ++i) {
             BatchIOEntry& entry = bs->entries[i];
@@ -663,73 +715,95 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 
     BatchState* bs = static_cast<BatchState*>(batch);
     HandleState* hs = bs->hs;
-    IOQueuePair& qp = hs->batch_qp->qp;
 
-    // Drain remaining in-flight commands
-    if (bs->in_flight > 0) {
-        std::lock_guard<std::mutex> qp_lock(qp.lock);
-        uint64_t spins = 0;
-        const uint64_t max_spins = (uint64_t)hs->ctrl->timeout * 1000000ULL;
-        while (bs->in_flight > 0) {
-            if (!drain_one_completion(qp, bs)) {
-                if (++spins > max_spins) break;
-                __builtin_ia32_pause();
-            } else {
-                spins = 0;
+    /* Pin rule: declare pins BEFORE the lock guard so they outlive
+     * it. C++ destroys locals in reverse construction order: the
+     * guard unlocks before the pins drop. This prevents ~BatchState
+     * from running while the mutex is still locked. */
+    std::shared_ptr<BatchState> last_pin;
+    std::shared_ptr<BatchState> link_pin;
+
+    {
+        std::lock_guard<std::mutex> bl(bs->lock);
+
+        /* Tombstone check: if a force teardown already set TORN_DOWN,
+         * this is the post-force one-shot Destroy. Transfer self into
+         * a local pin and let the guard unlock before the pin drops. */
+        if (bs->lifecycle == BATCH_LIFECYCLE_TORN_DOWN) {
+            last_pin = std::move(bs->self);
+            return;
+        }
+
+        /* Drain remaining in-flight commands under bs->lock -> qp.lock. */
+        IOQueuePair& qp = hs->batch_qp->qp;
+        if (bs->in_flight > 0) {
+            std::lock_guard<std::mutex> qp_lock(qp.lock);
+            uint64_t spins = 0;
+            const uint64_t max_spins = (uint64_t)hs->ctrl->timeout * 1000000ULL;
+            while (bs->in_flight > 0) {
+                if (!drain_one_completion(qp, bs)) {
+                    if (++spins > max_spins) break;
+                    __builtin_ia32_pause();
+                } else {
+                    spins = 0;
+                }
             }
         }
-    }
 
-    /* Best-effort: release in-flight references for entries that were
-     * submitted but never fully completed (e.g., submit phase-3 early
-     * return). Check n_cmds_done < n_cmds rather than status alone.
-     *
-     * IMPORTANT: do NOT release refs for entries that have commands
-     * still outstanding in the NVMe SQ (bs->in_flight > 0 after drain).
-     * Those commands may still DMA. Leaking the refs (blocking
-     * deregister) is strictly safer than freeing mappings while the
-     * device may still access them. The caller should reset the
-     * controller if truly stuck. */
-    if (bs->in_flight == 0) {
+        if (bs->in_flight > 0) {
+            /* Wedge: commands still in flight after drain timeout.
+             * Retain everything (self, link, handle ref, batch_active)
+             * so force recovery can find the object. Transition to
+             * WEDGED and return -- the one-shot Destroy was consumed. */
+            bs->lifecycle = BATCH_LIFECYCLE_WEDGED;
+            hs->wedged.store(true, std::memory_order_release);
+            fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
+                    "flight after drain timeout -- handle is now wedged "
+                    "to prevent DMA-after-unmap. Controller reset required.\n",
+                    bs->in_flight);
+            return;
+        }
+
+        /* --- Resource release (allocation-free) --- */
+
+        /* Drain any live release_scratch prefix first. */
+        drain_release_scratch(bs);
+
+        /* Scan for remaining refs_held entries and queue them. */
         for (unsigned i = 0; i < bs->n_entries; ++i) {
             BatchIOEntry& entry = bs->entries[i];
-            if (entry.n_cmds > 0 && entry.n_cmds_done < entry.n_cmds) {
-                async_release_inflight_batch(entry.devPtr_base);
-                entry.status = UGDS_BATCH_FAILED;
+            if (entry.refs_held && !entry.release_queued) {
+                queue_entry_release(bs, i);
             }
         }
-    } else {
-        /* Commands still in flight after drain timeout.
-         * The NVMe device may still DMA through the PRP list and CQ,
-         * so we must NOT: free the PRP pool, release handle ref,
-         * delete the batch state, or clear batch_active.
-         *
-         * Keeping batch_active=true prevents a new BatchIOSetUp from
-         * reusing the same QP while old completions may still arrive.
-         * Keeping the handle ref prevents HandleDeregister from freeing
-         * the QP while DMA is in progress.
-         *
-         * This wedges the handle until the caller resets the controller.
-         * BatchIODestroy is void so the caller cannot detect this --
-         * the warning is the only signal. This is the safest option:
-         * a wedged handle is strictly better than DMA-after-unmap. */
-        fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
-                "flight after drain timeout -- handle is now wedged "
-                "to prevent DMA-after-unmap. Controller reset required.\n",
-                bs->in_flight);
-        hs->wedged.store(true, std::memory_order_release);
-        return;
-    }
+        /* Final drain for remaining held entries. */
+        drain_release_scratch(bs);
 
-    cleanup_prp_pool(bs);
+        cleanup_prp_pool(bs);
+        bs->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
 
-    /* Mark batch inactive before releasing handle ref.
-     * HandleDeregister waits on handle_in_flight==0, so we must not
-     * touch hs after release. */
-    hs->batch_active.store(false);
+        /* --- Link transaction: one g_driver.lock section --- */
+        {
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            if (hs->active_batch.get() == bs) {
+                /* Pointer-verified detach: move OUR link into a local pin,
+                 * then clear batch_active ONLY after the detach. */
+                link_pin = std::move(hs->active_batch);
+                hs->batch_active.store(false, std::memory_order_release);
+            }
+            /* else: a concurrent force walk already moved the link.
+             * Do NOT clear batch_active -- the handle is closing. */
+        }
 
-    /* Release handle reference acquired in BatchIOSetUp */
-    handle_release(hs);
+        /* Release the SetUp-time handle reference. hs stays alive via
+         * bs->hs_sp. */
+        handle_release(hs);
 
-    delete bs;
+        /* Pin rule: transfer self into last_pin. The object stays alive
+         * until the guard releases the mutex and last_pin drops. */
+        last_pin = std::move(bs->self);
+    }  /* bl unlocks here -- object alive via last_pin (+ link_pin) */
+
+    /* link_pin then last_pin drop here; whichever is the final reference
+     * runs ~BatchState with no guard addressing its members. */
 }

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -64,16 +64,22 @@ static void drain_release_scratch(BatchState* bs)
     bs->n_release_pending = 0;
 }
 
-/* Abort a Phase-3 entry that is WAITING or PENDING.
+/* Abort a Phase-3 entry that is WAITING, PENDING, or FAILED.
  * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
  * -ECANCELED, and queues the entry for deferred release if all its
  * submitted commands have already completed.  Must be called
- * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1). */
+ * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1).
+ *
+ * C4 (review R1): abort also accepts the FAILED state so a device
+ * error latched by drain_one_completion is not stranded: the submitted
+ * prefix still drains exactly once and refs are released.  A COMPLETE
+ * or TORN_DOWN entry is left untouched. */
 static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
 {
     BatchIOEntry& entry = bs->entries[idx];
     if (entry.status != UGDS_BATCH_WAITING &&
-        entry.status != UGDS_BATCH_PENDING)
+        entry.status != UGDS_BATCH_PENDING &&
+        entry.status != UGDS_BATCH_FAILED)
         return;
     entry.error_code = -ECANCELED;
     entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */
@@ -646,10 +652,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
-            /* M2: commit the slot map first, then increment
-             * n_cmds_submitted, then transition WAITING->PENDING. */
+            /* Commit the slot map first, then increment
+             * n_cmds_submitted, then transition WAITING->PENDING.
+             * Only WAITING -> PENDING is allowed; do not overwrite a
+             * latched FAILED state from an earlier
+             * drain_one_completion during backpressure. */
             entry.n_cmds_submitted++;
-            entry.status = UGDS_BATCH_PENDING;
+            if (entry.status == UGDS_BATCH_WAITING)
+                entry.status = UGDS_BATCH_PENDING;
         }
 
         // Single doorbell for all commands
@@ -1322,9 +1332,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
-            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING. */
+            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING.
+             * Only WAITING -> PENDING is allowed; a latched FAILED from
+             * an earlier drain_one_completion during backpressure must
+             * persist. */
             entry.n_cmds_submitted++;
-            entry.status = UGDS_BATCH_PENDING;
+            if (entry.status == UGDS_BATCH_WAITING)
+                entry.status = UGDS_BATCH_PENDING;
         }
 
         /* Single doorbell for all enqueued commands. */

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -11,6 +11,10 @@
 #include <new>
 #include <memory>
 
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
+
 /* Release in-flight reference held by batch submit.
  * Called on validation failure or when batch entry completes.
  * MUST be called WITHOUT holding g_driver.lock. */
@@ -350,6 +354,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         bs->n_entries = 0;
         bs->n_completed = 0;
         bs->n_events_read = 0;
+        /* Reset the segment arena allocation point.
+         * seg_arena.size()/capacity are never touched here; only the
+         * allocation cursor resets so the next Submitv rewrites from
+         * index 0.  Plain-only batches never resized the arena and
+         * this store is a harmless no-op on the zero-initialized
+         * value. */
+        bs->arena_used = 0;
     }
 
     if (bs->n_entries + nr > bs->capacity)

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -363,7 +363,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         bs->arena_used = 0;
     }
 
-    if (bs->n_entries + nr > bs->capacity)
+    /* Overflow-safe capacity check.  The old n_entries + nr >
+     * capacity used unsigned addition that wraps for large nr.
+     * Reject nr > capacity outright, then check the post-recycle
+     * base.  At this point n_entries is already recycled if the
+     * round was fully consumed, so n_entries is the effective base. */
+    if (nr > bs->capacity ||
+        bs->n_entries > bs->capacity - nr)
         return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
 
     HandleState* hs = bs->hs;
@@ -942,18 +948,23 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
     if (bs->lifecycle != BATCH_LIFECYCLE_ACTIVE)
         return make_error(UGDS_INVALID_VALUE);
 
-    if (bs->n_entries + nr > bs->capacity)
+    /* Overflow-safe capacity check with an effective base that accounts
+     * for a fully consumed recyclable round, WITHOUT mutating any
+     * state.  The old code computed n_entries + nr using unsigned
+     * addition (wraps for large nr) and ran recycle before this check,
+     * so a full-capacity batch rejected any new submit and a later
+     * value error violated consume-none.  We compute the effective base
+     * here and defer the actual recycle reset to the commit step after
+     * all validation, preflight, and allocation succeed. */
+    unsigned effective_base = bs->n_entries;
+    if (effective_base > 0 && bs->n_events_read == effective_base)
+        effective_base = 0;  /* round is fully consumed; would recycle */
+
+    if (nr > bs->capacity ||
+        effective_base > bs->capacity - nr)
         return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
 
     (void)flags;
-
-    /* recycle: same path as plain submit, plus arena_used reset. */
-    if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
-        bs->n_entries = 0;
-        bs->n_completed = 0;
-        bs->n_events_read = 0;
-        bs->arena_used = 0;
-    }
 
     HandleState* hs = bs->hs;
     IOQueuePair& qp = hs->batch_qp->qp;
@@ -980,7 +991,11 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
      * ================================================================== */
 
     /* --- Step 1: Pure value validation (all entries, no state write) --- */
-    unsigned base = bs->n_entries;
+    /* Use effective_base, which accounts for a recyclable round
+     * without mutating bs state.  The actual recycle reset is applied
+     * as part of the infallible commit (Step 4) after all validation,
+     * preflight, and allocation succeed. */
+    unsigned base = effective_base;
 
     uint32_t per_entry_n_cmds[UGDS_MAX_BATCH_IO_SIZE];
     uint64_t total_cmds = 0;
@@ -1056,10 +1071,22 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
     /* --- Step 4: Commit-copy (infallible) ---
      * From here, no allocation or throw is possible.  Capture the
      * watermark for rollback safety; populate entries and arena.
-     * The watermark is the 8.4 rollback anchor: it is never restored
-     * in this path because no operation after this point can fail, but
-     * it documents the invariant and serves as the audit point for the
-     * fixed-size arena model. */
+     * The watermark is the rollback anchor: it is never restored in
+     * this path because no operation after this point can fail, but it
+     * documents the invariant and serves as the audit point for the
+     * fixed-size arena model.
+     *
+     * Apply the recycle reset here as the first infallible commit
+     * action.  effective_base was 0 iff the current round was fully
+     * consumed.  This is the consume-none guarantee: a value error
+     * returns without touching n_entries, n_completed, n_events_read,
+     * or arena_used. */
+    if (effective_base == 0 && bs->n_entries > 0) {
+        bs->n_entries = 0;
+        bs->n_completed = 0;
+        bs->n_events_read = 0;
+        bs->arena_used = 0;
+    }
     const uint32_t watermark = bs->arena_used;
     (void)watermark;  /* documented rollback anchor; no post-commit failure */
     uint32_t work_used = 0;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,26 +212,25 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that rolls back ALL five items
-     * if the function exits via exception or early return before commit.
-     * Items (acquired in order, rolled back in reverse):
-     *   5. pool DMA mapping
-     *   4. pool host buffer
-     *   3. batch_active claim
-     *   2. handle_in_flight reference
-     *   1. batch_setting_up flag (cleared LAST, under g_driver.lock) */
+    /* M3: BatchSetupTxn - RAII scope guard that owns ALL five items by value.
+     * Declared before bs_sp so its destructor runs first on unwind.
+     * Pool resources are owned by value (not pointer to bs_sp members)
+     * so destruction order does not cause dangling dereferences.
+     * On commit, pool resources are transferred to bs_sp->prp_pool
+     * and txn.armed is cleared.
+     * Destructor uses try_lock to remain noexcept-safe. */
     struct BatchSetupTxn {
         HandleState* hs;
-        void** pool_buf;
-        nvm_dma_t** pool_dma;
+        void* pool_buf;
+        nvm_dma_t* pool_dma;
         bool armed;
         ~BatchSetupTxn() {
             if (!armed) return;
-            /* Rollback items 5, 4 (raw resources) */
-            if (pool_dma && *pool_dma) { nvm_dma_unmap(*pool_dma); *pool_dma = nullptr; }
-            if (pool_buf && *pool_buf) { free(*pool_buf); *pool_buf = nullptr; }
-            /* Rollback items 3, 2, 1 (gate state) */
-            std::lock_guard<std::mutex> g(g_driver.lock);
+            /* Rollback items 5, 4 (owned by value) */
+            if (pool_dma) { nvm_dma_unmap(pool_dma); }
+            if (pool_buf) { free(pool_buf); }
+            /* Rollback items 3, 2, 1 (gate state, best-effort lock) */
+            std::unique_lock<std::mutex> lk(g_driver.lock, std::try_to_lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
@@ -250,32 +249,33 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     bs_sp->release_scratch.resize(nr);
 
     const size_t page_size = hs->ctrl->page_size;
-    PRPPool& pool = bs_sp->prp_pool;
     size_t pool_bytes = UGDS_PRP_POOL_PAGES * page_size;
 
     uGDSError_t setup_err = UGDS_OK;
-    if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
+    void* pbuf = nullptr;
+    nvm_dma_t* pdma = nullptr;
+    if (posix_memalign(&pbuf, 4096, pool_bytes) != 0) {
         setup_err = make_error(UGDS_OUT_OF_MEMORY);
         goto setup_rollback;
     }
-    std::memset(pool.buf, 0, pool_bytes);
-    txn.pool_buf = &pool.buf;  /* arm item 4 */
+    std::memset(pbuf, 0, pool_bytes);
+    txn.pool_buf = pbuf;  /* txn owns the buffer now */
 
     {
-        int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
+        int rc = nvm_dma_map_host(&pdma, hs->ctrl, pbuf, pool_bytes);
         if (!nvm_ok(rc)) {
-            free(pool.buf);
-            pool.buf = nullptr;
-            txn.pool_buf = nullptr;  /* already freed */
+            txn.pool_buf = nullptr;  /* txn no longer owns; we free below */
+            free(pbuf);
+            pbuf = nullptr;
             setup_err = (rc == ENOMEM)
                 ? make_error(UGDS_OUT_OF_MEMORY)
                 : make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
     }
-    txn.pool_dma = &pool.dma;  /* arm item 5 */
-    pool.n_pages = UGDS_PRP_POOL_PAGES;
-    pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
+    txn.pool_dma = pdma;  /* txn owns the mapping now */
+    bs_sp->prp_pool.n_pages = UGDS_PRP_POOL_PAGES;
+    bs_sp->prp_pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
     /* --- Publication: one g_driver.lock critical section --- */
@@ -293,36 +293,34 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
             setup_err = make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
+        /* Transfer pool resources from txn to bs_sp */
+        bs_sp->prp_pool.buf = txn.pool_buf;
+        bs_sp->prp_pool.dma = txn.pool_dma;
+        txn.armed = false;       /* commit: txn no longer owns anything */
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
-        txn.armed = false;           /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
     return UGDS_OK;
 
 setup_rollback:
-    /* Rollback in reverse acquisition order:
-     * 5 (pool DMA) -> 4 (pool buf) -> 3 (BatchState shared_ptr)
-     * -> 2 (batch_active) -> 1 (handle ref + batch_setting_up LAST).
-     * pool.dma and pool.buf are cleaned up above or here; the shared_ptr
-     * reset handles item 3. */
+    /* Pool resources are owned by txn; txn.armed=false below prevents
+     * the destructor from double-freeing. Gate state is also unwound
+     * explicitly. bs_sp is reset for its own cleanup. */
+    txn.armed = false;  /* prevent double-run: we clean up explicitly */
     {
-        if (pool.dma) { nvm_dma_unmap(pool.dma); pool.dma = nullptr; }
-        if (pool.buf) { free(pool.buf); pool.buf = nullptr; }
+        if (txn.pool_dma) { nvm_dma_unmap(txn.pool_dma); txn.pool_dma = nullptr; }
+        if (txn.pool_buf) { free(txn.pool_buf); txn.pool_buf = nullptr; }
     }
-    bs_sp.reset();  /* RAII: releases BatchState if last owner */
+    bs_sp.reset();
     {
         std::lock_guard<std::mutex> g(g_driver.lock);
         hs->batch_active.store(false, std::memory_order_release);
         handle_release(hs);
-        /* batch_setting_up cleared LAST so a waiting force teardown
-         * proceeds only after every other side effect (including the
-         * DMA unmap, which needs hs->ctrl alive) has been undone. */
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
-    txn.armed = false;  /* explicit rollback done; prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <new>
+#include <cassert>
 
 /* RAII guard for a device DMA mapping.
  * Arms nvm_dma_unmap on construction (or explicit arm()); disarm() must
@@ -81,6 +82,16 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
         MappedDmaGuard map_guard(dma);
         uGDSBackend_t backend =
             nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
+        /* Post-map debug invariant: verify zero displacement so that
+         * dma->ioaddrs[0] corresponds to the exact registered base.
+         * A future mapping path that introduces displacement would
+         * silently corrupt PRP construction. */
+#ifndef NDEBUG
+        if (dma->n_ioaddrs > 0) {
+            assert((dma->ioaddrs[0] % mps) == 0);
+        }
+#endif
 
         /* try_emplace builds the BufEntry in place; if it throws bad_alloc
          * the mapping is still owned by map_guard and gets unmapped. */

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -2,6 +2,32 @@
 #include "internal/dma.h"
 #include <unistd.h>
 #include <fcntl.h>
+#include <new>
+
+/* RAII guard for a device DMA mapping.
+ * Arms nvm_dma_unmap on construction (or explicit arm()); disarm() must
+ * be called after the mapping is successfully handed off to its owner
+ * (e.g. inserted into the registry) so that the destructor does not
+ * unmap it.  Used to make registry insertion transactional with respect
+ * to bad_alloc. */
+class MappedDmaGuard {
+    nvm_dma_t* dma_ = nullptr;
+    bool       armed_ = false;
+public:
+    MappedDmaGuard() noexcept = default;
+    explicit MappedDmaGuard(nvm_dma_t* d) noexcept : dma_(d), armed_(true) {}
+    ~MappedDmaGuard() {
+        if (armed_ && dma_) nvm_dma_unmap(dma_);
+    }
+    MappedDmaGuard(const MappedDmaGuard&) = delete;
+    MappedDmaGuard& operator=(const MappedDmaGuard&) = delete;
+    MappedDmaGuard(MappedDmaGuard&&) = delete;
+    MappedDmaGuard& operator=(MappedDmaGuard&&) = delete;
+
+    void arm(nvm_dma_t* d) noexcept { dma_ = d; armed_ = true; }
+    void disarm() noexcept { armed_ = false; }
+    nvm_dma_t* get() const noexcept { return dma_; }
+};
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
     if (!g_driver.initialized) {
@@ -29,12 +55,33 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
     if (status != 0 || dma == nullptr) {
         if (status == ENOTSUP || status == EOPNOTSUPP)
             return make_error(UGDS_IO_NOT_SUPPORTED);
+        if (status == ENOMEM)
+            return make_error(UGDS_OUT_OF_MEMORY);
         return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
     }
 
-    g_driver.buf_registry[bufPtr_base].dma = dma;
-    g_driver.buf_registry[bufPtr_base].backend =
+    /* Guard the mapping so a bad_alloc from registry insertion unmaps it
+     * instead of leaking the device mapping across the C ABI.
+     * The transactional insert below disarms the guard only after the
+     * entry is fully constructed and stored. */
+    MappedDmaGuard map_guard(dma);
+    uGDSBackend_t backend =
         nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
+    try {
+        /* try_emplace builds the BufEntry in place; if it throws bad_alloc
+         * the mapping is still owned by map_guard and gets unmapped. */
+        auto [it, inserted] = g_driver.buf_registry.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(bufPtr_base),
+            std::forward_as_tuple(dma, backend, length, g_driver.default_ctrl));
+        (void)it; (void)inserted;
+    } catch (const std::bad_alloc&) {
+        /* map_guard destructor calls nvm_dma_unmap(dma) */
+        return make_error(UGDS_OUT_OF_MEMORY);
+    }
+
+    map_guard.disarm();
     return UGDS_OK;
 }
 

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -30,45 +30,58 @@ public:
 };
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
-    if (!g_driver.initialized) {
-        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
-    }
-
-    if (bufPtr_base == nullptr || length == 0) {
-        return make_error(UGDS_INVALID_VALUE);
-    }
-
-    std::lock_guard<std::mutex> guard(g_driver.lock);
-
-    if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
-        return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
-    }
-
-    if (g_driver.default_ctrl == nullptr) {
-        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
-    }
-
-    nvm_dma_t* dma = nullptr;
-    int status = nvm_dma_map_device_ex(&dma, g_driver.default_ctrl,
-                                       const_cast<void*>(bufPtr_base), length,
-                                       flags);
-    if (status != 0 || dma == nullptr) {
-        if (status == ENOTSUP || status == EOPNOTSUPP)
-            return make_error(UGDS_IO_NOT_SUPPORTED);
-        if (status == ENOMEM)
-            return make_error(UGDS_OUT_OF_MEMORY);
-        return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
-    }
-
-    /* Guard the mapping so a bad_alloc from registry insertion unmaps it
-     * instead of leaking the device mapping across the C ABI.
-     * The transactional insert below disarms the guard only after the
-     * entry is fully constructed and stored. */
-    MappedDmaGuard map_guard(dma);
-    uGDSBackend_t backend =
-        nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
-
     try {
+        if (!g_driver.initialized) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+
+        if (bufPtr_base == nullptr || length == 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+
+        if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
+            return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
+        }
+
+        if (g_driver.default_ctrl == nullptr) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+
+        /* The library layer rejects a base that is not MPS-aligned,
+         * that is not a multiple of the controller MPS. ioaddrs[] entries
+         * are MPS-granular, so a non-MPS-aligned base means ioaddrs[0]
+         * would not correspond to bufPtr_base. This is the universal PRP
+         * requirement. */
+        const size_t mps = g_driver.default_ctrl->page_size;
+        if (mps > 0 &&
+            (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        nvm_dma_t* dma = nullptr;
+        int status = nvm_dma_map_device_ex(&dma, g_driver.default_ctrl,
+                                           const_cast<void*>(bufPtr_base), length,
+                                           flags);
+        if (status != 0 || dma == nullptr) {
+            if (status == ENOTSUP || status == EOPNOTSUPP)
+                return make_error(UGDS_IO_NOT_SUPPORTED);
+            if (status == ENOMEM)
+                return make_error(UGDS_OUT_OF_MEMORY);
+            if (status == EINVAL)
+                return make_error(UGDS_INVALID_VALUE);
+            return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
+        }
+
+        /* Guard the mapping so a bad_alloc from registry insertion unmaps it
+         * instead of leaking the device mapping across the C ABI.
+         * The transactional insert below disarms the guard only after the
+         * entry is fully constructed and stored. */
+        MappedDmaGuard map_guard(dma);
+        uGDSBackend_t backend =
+            nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
         /* try_emplace builds the BufEntry in place; if it throws bad_alloc
          * the mapping is still owned by map_guard and gets unmapped. */
         auto [it, inserted] = g_driver.buf_registry.emplace(
@@ -76,13 +89,14 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
             std::forward_as_tuple(bufPtr_base),
             std::forward_as_tuple(dma, backend, length, g_driver.default_ctrl));
         (void)it; (void)inserted;
-    } catch (const std::bad_alloc&) {
-        /* map_guard destructor calls nvm_dma_unmap(dma) */
-        return make_error(UGDS_OUT_OF_MEMORY);
-    }
 
-    map_guard.disarm();
-    return UGDS_OK;
+        map_guard.disarm();
+        return UGDS_OK;
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -53,24 +53,19 @@ static void cleanup_timeout_resources(HandleState* hs) {
     for (auto& qp_ptr : hs->qps) {
         IOQueuePair& qp = *qp_ptr;
         nvm_dma_t* timeout_dma = nullptr;
-        const void* registered_buf = nullptr;
+        SglRefOwner timeout_refs;
         {
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             timeout_dma = qp.timeout_dma;
-            registered_buf = qp.timeout_registered_buf;
+            timeout_refs = std::move(qp.timeout_refs);
             qp.timeout_dma = nullptr;
-            qp.timeout_registered_buf = nullptr;
         }
 
         if (timeout_dma != nullptr)
             nvm_dma_unmap(timeout_dma);
 
-        if (registered_buf != nullptr) {
-            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
-            auto it = g_driver.buf_registry.find(registered_buf);
-            if (it != g_driver.buf_registry.end())
-                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-        }
+        /* SglRefOwner destructor releases in_flight refs under
+         * g_driver.lock; the move left timeout_refs non-empty. */
     }
 }
 

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -11,6 +11,9 @@
 #include <unistd.h>
 #include <time.h>
 
+/* Forward declaration: cleanup_prp_pool is defined in ugds_batch.cpp. */
+extern void cleanup_prp_pool(BatchState* bs);
+
 static void cleanup_qp(nvm_aq_ref aq_ref, IOQueuePair* qp, int dev_fd) {
     if (qp->sq_dma) {
         nvm_admin_sq_delete(aq_ref, &qp->sq, &qp->cq);
@@ -54,11 +57,14 @@ static void cleanup_timeout_resources(HandleState* hs) {
         IOQueuePair& qp = *qp_ptr;
         nvm_dma_t* timeout_dma = nullptr;
         SglRefOwner timeout_refs;
+        const void* timeout_registered_base = nullptr;
         {
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             timeout_dma = qp.timeout_dma;
             timeout_refs = std::move(qp.timeout_refs);
+            timeout_registered_base = qp.timeout_registered_base;
             qp.timeout_dma = nullptr;
+            qp.timeout_registered_base = nullptr;
         }
 
         if (timeout_dma != nullptr)
@@ -66,6 +72,14 @@ static void cleanup_timeout_resources(HandleState* hs) {
 
         /* SglRefOwner destructor releases in_flight refs under
          * g_driver.lock; the move left timeout_refs non-empty. */
+
+        /* Legacy scalar registered-buffer ref parked on timeout. */
+        if (timeout_registered_base != nullptr) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(timeout_registered_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        }
     }
 }
 
@@ -533,6 +547,65 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
             hs->closing.store(false, std::memory_order_release);
             return make_error(UGDS_BUSY);
         }
+    }
+
+    if (force) {
+        while (hs->batch_setting_up.load(std::memory_order_acquire)) {
+            __builtin_ia32_pause();
+        }
+    }
+
+    /* Batch release walk: pin the owning recovery link under
+     * link under g_driver.lock, release it, then perform lifecycle-
+     * sensitive cleanup before destroying QPs/controller.
+     * batch_setting_up drain: spin-wait with no locks held until the
+     * past-gate setup either publishes (observes closing, rolls back)
+     * or fails. Bounded because setup does only host-side work. */
+    if (force) {
+        std::shared_ptr<BatchState> pin;
+        std::shared_ptr<BatchState> self_pin;
+        {
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            pin = std::move(hs->active_batch);
+            /* batch_active is deliberately left true: closing blocks
+             * new setups and the handle is being destroyed. */
+        }
+        if (pin != nullptr) {
+            std::lock_guard<std::mutex> bl(pin->lock);
+            if (pin->lifecycle != BATCH_LIFECYCLE_TORN_DOWN) {
+                const bool destroy_consumed =
+                    (pin->lifecycle == BATCH_LIFECYCLE_WEDGED);
+
+                /* Release all in-flight refs for entries that still
+                 * hold them. */
+                for (unsigned i = 0; i < pin->n_entries; ++i) {
+                    BatchIOEntry& entry = pin->entries[i];
+                    if (entry.refs_held) {
+                        std::lock_guard<std::mutex> drv(g_driver.lock);
+                        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+                        if (it != g_driver.buf_registry.end())
+                            it->second.in_flight.fetch_sub(1,
+                                std::memory_order_acq_rel);
+                        entry.refs_held = false;
+                        entry.release_queued = false;
+                    }
+                }
+                pin->n_release_pending = 0;
+
+                cleanup_prp_pool(pin.get());
+                pin->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
+                handle_release(hs);
+
+                if (destroy_consumed) {
+                    /* WEDGED: no public Destroy remains; transfer self
+                     * under lock, never reset in place (pin rule). */
+                    self_pin = std::move(pin->self);
+                }
+                /* ACTIVE: retain self as tombstone for the still-
+                 * available one-shot Destroy. */
+            }
+        }
+        /* bl and g unlock; pin/self_pin drop here. */
     }
 
     if (force)

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -577,18 +577,13 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
                     (pin->lifecycle == BATCH_LIFECYCLE_WEDGED);
 
                 /* Release all in-flight refs for entries that still
-                 * hold them. */
+                 * hold them.  Use kind-aware release so VECTORED entries decrement
+                 * every base in their arena range, not the (nullptr)
+                 * devPtr_base. */
                 for (unsigned i = 0; i < pin->n_entries; ++i) {
                     BatchIOEntry& entry = pin->entries[i];
-                    if (entry.refs_held) {
-                        std::lock_guard<std::mutex> drv(g_driver.lock);
-                        auto it = g_driver.buf_registry.find(entry.devPtr_base);
-                        if (it != g_driver.buf_registry.end())
-                            it->second.in_flight.fetch_sub(1,
-                                std::memory_order_acq_rel);
-                        entry.refs_held = false;
-                        entry.release_queued = false;
-                    }
+                    if (entry.refs_held)
+                        release_entry_refs(pin.get(), entry);
                 }
                 pin->n_release_pending = 0;
 

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -588,6 +588,12 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
                 pin->n_release_pending = 0;
 
                 cleanup_prp_pool(pin.get());
+                /* Release arena capacity during force teardown so the
+                 * tombstone state retained for an ACTIVE batch does not
+                 * hold ~768 KiB. swap-with-empty releases the
+                 * allocation immediately. */
+                std::vector<SegView>().swap(pin->seg_arena);
+                pin->arena_used = 0;
                 pin->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
                 handle_release(hs);
 

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -104,6 +104,14 @@ struct DriverState {
         nvm_dma_t*           dma;
         uGDSBackend_t        backend;
         std::atomic<uint32_t> in_flight{0};
+        size_t               length;    /* exact bytes from uGDSBufRegister */
+        const nvm_ctrl_t*    map_ctrl;  /* controller at registration time */
+        BufEntry() noexcept
+            : dma(nullptr), backend(UGDS_BACKEND_DEFAULT),
+              in_flight(0), length(0), map_ctrl(nullptr) {}
+        BufEntry(nvm_dma_t* d, uGDSBackend_t b, size_t len,
+                 const nvm_ctrl_t* ctrl) noexcept
+            : dma(d), backend(b), in_flight(0), length(len), map_ctrl(ctrl) {}
     };
     std::unordered_map<const void*, BufEntry>     buf_registry;
 

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <cstdint>
 #include <cstddef>
+#include <type_traits>
 
 #define UGDS_DEFAULT_NUM_QPS     16
 #define UGDS_DEFAULT_QUEUE_DEPTH 64
@@ -36,6 +37,169 @@
 /* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec section 4.6.1. */
 #define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 
+/* Forward declarations: HandleOpGuard and SglRefOwner reference HandleState
+ * and handle_release, which are fully defined later in this header. */
+struct HandleState;
+static inline void handle_release(HandleState* hs);
+
+/* --- Per-IO resolved segment ------------------------------------------- */
+/* A segment resolved against the buffer registry under one g_driver.lock
+ * hold.  Identity fields (dma, base, registered_length, backend) are
+ * immutable snapshots valid as long as the owning SglRefOwner holds its
+ * reference; geometry fields (page_start, size) are filled at resolve time
+ * (sync/batch) or in the async callback (late binding). */
+struct SegView {
+    nvm_dma_t*     dma;
+    const void*    base;               /* registry key, for release/park */
+    size_t         registered_length;  /* snapshot of BufEntry::length */
+    uGDSBackend_t  backend;            /* snapshot, for async dispatch */
+    size_t         page_start;         /* offset / MPS (offset MPS-aligned) */
+    size_t         size;               /* bytes */
+};
+
+/* --- Reference ownership ----------------------------------------------- */
+/* Owns one in_flight reference per SGL occurrence.  Duplicate bases are
+ * intentionally repeated.  The representation has capacity for the public
+ * maximum and never allocates; this is ~8 KiB on LP64 and is stored in
+ * request/QP objects, not copied into a std::vector on timeout. */
+class SglRefOwner {
+    std::array<const void*, UGDS_IOV_MAX> bases_{};
+    uint16_t size_ = 0;                 /* UGDS_IOV_MAX == 1024 */
+public:
+    SglRefOwner() noexcept = default;
+    SglRefOwner(const SglRefOwner&) = delete;
+    SglRefOwner& operator=(const SglRefOwner&) = delete;
+    SglRefOwner(SglRefOwner&& other) noexcept;
+    SglRefOwner& operator=(SglRefOwner&& other) noexcept;
+    ~SglRefOwner() noexcept;            /* release() if still non-empty */
+
+    bool empty() const noexcept { return size_ == 0; }
+    uint16_t size() const noexcept { return size_; }
+    const void* base_at(uint16_t i) const noexcept { return bases_[i]; }
+
+    /* acquire(segs, nr): nr was already checked <= UGDS_IOV_MAX.  Under one
+     * g_driver.lock hold, validate registration, exact length, and affinity,
+     * then increment each counter and append its base.  All-or-nothing: a
+     * failure rolls back 0..k-1 inside the same hold.  Returns 0 on success
+     * or -EINVAL.  No reserve/growth/allocation exists.
+     *
+     * hs_ctrl is the submitting handle's controller (for affinity check).
+     * page_size is MPS for the offset-alignment and page-index math.
+     * seg_views_out (optional): if non-null, resolved SegView[] filled. */
+    int acquire(const uGDSIoSegment_t* segs, uint32_t nr,
+                const nvm_ctrl_t* hs_ctrl,
+                size_t page_size,
+                SegView* seg_views_out = nullptr);
+
+    /* release(): decrement each stored occurrence under one g_driver.lock
+     * hold and set size_ = 0.  Idempotent on empty. */
+    void release() noexcept;
+};
+
+static_assert(std::is_nothrow_move_constructible<SglRefOwner>::value);
+static_assert(std::is_nothrow_move_assignable<SglRefOwner>::value);
+static_assert(UGDS_IOV_MAX <= UINT16_MAX);
+
+/* --- Sync handle-operation ownership ----------------------------------- */
+/* handle_lookup() increments the bare HandleState::handle_in_flight counter
+ * independently of the returned shared_ptr.  This non-allocating guard is
+ * constructed immediately after a successful lookup and must be declared
+ * after the local hs_sp, so hs_sp outlives the guard.  Every early return
+ * and exception therefore calls handle_release() exactly once.  The normal
+ * path calls release() only after do_iov_engine returns; release() performs
+ * handle_release() and then disarms the destructor. */
+class HandleOpGuard {
+    HandleState* hs_ = nullptr;
+    bool         armed_ = false;
+public:
+    HandleOpGuard() noexcept = default;
+    explicit HandleOpGuard(HandleState* hs) noexcept
+        : hs_(hs), armed_(true) {}
+    HandleOpGuard(const HandleOpGuard&) = delete;
+    HandleOpGuard& operator=(const HandleOpGuard&) = delete;
+    HandleOpGuard(HandleOpGuard&&) = delete;
+    HandleOpGuard& operator=(HandleOpGuard&&) = delete;
+    ~HandleOpGuard() noexcept { if (armed_) handle_release(hs_); }
+
+    void arm(HandleState* hs) noexcept { hs_ = hs; armed_ = true; }
+    void release() noexcept {
+        if (armed_) { handle_release(hs_); armed_ = false; }
+    }
+};
+
+static_assert(std::is_nothrow_destructible<HandleOpGuard>::value);
+
+/* --- Engine result ------------------------------------------------------ */
+/* An integer alone cannot drive cleanup: the caller must know whether the
+ * engine consumed (parked) the resource owners. */
+struct IovEngineResult {
+    ssize_t ret;        /* bytes transferred or -errno */
+    bool    timed_out;  /* true <=> handle wedged AND the engine moved the
+                           owner (registered) or the transient dma
+                           (on-the-fly) into QP timeout parking; the
+                           caller's owner is empty / dma pointer stolen */
+};
+
+/* --- Command window ---------------------------------------------------- */
+struct CmdWindow {
+    uint32_t     first_seg;          /* index into SegView[] */
+    uint32_t     n_segs;             /* slices spanned by this command */
+    size_t       first_seg_page_off; /* pages already consumed from first_seg
+                                        by earlier windows (mid-segment split) */
+    size_t       bytes;              /* command length; block-multiple by construction */
+    size_t       n_pages;            /* ceil-sum of slice pages; <= MPS/8 + 1 */
+};
+
+/* --- SglWindowCursor --------------------------------------------------- */
+/* Stateful, allocation-free forward generator.  next() emits at most one
+ * window and advances (seg_idx, bytes_in_seg, open-window state).  It never
+ * owns or materializes an array of CmdWindow objects. */
+struct SglWindowCursor {
+    const SegView* segs;
+    uint32_t       nr_segs;
+    uint32_t       seg_idx;
+    size_t         bytes_in_seg;     /* consumed so far in segs[seg_idx] */
+    size_t         window_cap;
+    size_t         page_size;        /* MPS */
+    size_t         block_size;
+    size_t         split_unit;       /* lcm(MPS, block_size) */
+};
+
+/* Initialize a cursor.  Returns false if window_cap == 0 (reject). */
+bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
+                     size_t window_cap, size_t page_size, size_t block_size);
+
+/* Emit at most one window into out.  Returns true if a window was produced,
+ * false when the SGL is exhausted. */
+bool sgl_cursor_next(SglWindowCursor& c, CmdWindow& out) noexcept;
+
+/* O(nr_segs) analytic count.  Produces the same count as the cursor. */
+bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
+                                uint32_t nr_segs,
+                                size_t window_cap, size_t page_size,
+                                size_t block_size,
+                                uint32_t* out) noexcept;
+
+/* --- SglPageCursor ----------------------------------------------------- */
+/* Forward iterator over the MPS page addresses of a window.  Replaces
+ * buf_dma->ioaddrs[current_page + i] in the PRP builders.  Tracks position
+ * across segment boundaries. */
+struct SglPageCursor {
+    const SegView* segs;
+    uint32_t       seg_count;        /* n_segs from CmdWindow */
+    uint32_t       seg_idx;          /* current segment index (relative to window) */
+    size_t         page_in_seg;      /* absolute index into dma->ioaddrs */
+    size_t         seg_pages_left;   /* pages remaining in current segment slice */
+};
+
+void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
+                          uint32_t first_seg, size_t first_seg_page_off,
+                          uint32_t n_segs, size_t n_pages) noexcept;
+
+/* Returns current ioaddr, advances across segment boundaries.  Total calls
+ * bounded by CmdWindow::n_pages. */
+uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept;
+
 struct IOQueuePair {
     nvm_queue_t    sq{};
     nvm_queue_t    cq{};
@@ -48,9 +212,12 @@ struct IOQueuePair {
     int            irq_efd = -1;   /* eventfd for interrupt mode; -1 = poll */
     uint16_t       irq_vec = 0;    /* MSI-X vector bound to this CQ */
     /* Timeout resources remain owned by the QP until controller recovery.
-     * At most one synchronous operation can hold this QP lock. */
+     * At most one synchronous operation can hold this QP lock.
+     * timeout_dma: on-the-fly (1-buf) mapping parked by the scalar engine.
+     * timeout_refs: fixed-capacity registered-ref owner parked by the SGL
+     *               engine (also used by the refactored scalar path). */
     nvm_dma_t*     timeout_dma = nullptr;           /* on-the-fly mapping */
-    const void*    timeout_registered_buf = nullptr; /* registered ref */
+    SglRefOwner    timeout_refs;                    /* registered refs */
     std::mutex     lock;
 };
 
@@ -295,6 +462,38 @@ static inline uGDSError_t make_error(uGDSOpError err) {
 
 ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                        off_t file_offset, off_t bufPtr_offset, uint8_t opcode);
+
+/* --- SGL engine -------------------------------------------------------- */
+
+/* Publish PRP list stores before the doorbell/data pointer.  Centralizes the
+ * platform DMA-publish contract: on x86-64 the seq_cst fence is sufficient
+ * because PRP lists live in cache-coherent host memory and normal stores
+ * are ordered before the subsequent MMIO doorbell write.  Porting to a
+ * weaker platform changes this one helper. */
+static inline void sgl_publish_prp() noexcept {
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+
+/* Wait for one completion on a sync QP.  Returns nullptr on timeout.
+ * Defined in ugds_io.cpp; shared with ugds_iov.cpp. */
+nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp);
+
+/* Streaming windowed IO engine shared by scalar and vectored sync paths.
+ *
+ * hs: submitting handle state (must already be lookup-acquired).
+ * segs: resolved segment views (identity + geometry complete).
+ * nr_segs: number of entries in segs (>= 1).
+ * file_offset: starting byte offset in the namespace (block-aligned).
+ * opcode: NVM_IO_READ or NVM_IO_WRITE.
+ * owner: holds in-flight buffer refs (may be empty if on_the_fly).
+ * transient: on-the-fly DMA mapping, or nullptr for registered buffers.
+ *
+ * Returns {bytes, false} on success, {-errno, false} on device/validation
+ * failure, or {-errno, true} on timeout with owner/transient moved into
+ * qp.timeout_refs / qp.timeout_dma. */
+IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
+                              off_t file_offset, uint8_t opcode,
+                              SglRefOwner* owner, nvm_dma_t* transient);
 
 struct AsyncRequest {
     uGDSHandle_t    fh;

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -85,11 +85,28 @@ public:
      *
      * hs_ctrl is the submitting handle's controller (for affinity check).
      * page_size is MPS for the offset-alignment and page-index math.
-     * seg_views_out (optional): if non-null, resolved SegView[] filled. */
+     * seg_views_out (optional): if non-null, resolved SegView[] filled
+     * (identity + geometry; page_start uses segs[k].offset). */
     int acquire(const uGDSIoSegment_t* segs, uint32_t nr,
                 const nvm_ctrl_t* hs_ctrl,
                 size_t page_size,
                 SegView* seg_views_out = nullptr);
+
+    /* acquire_identity_only(segs, nr): like acquire() but performs only the
+     * registration + controller affinity checks and the in_flight
+     * reference acquisition.  The registered-range bound on
+     * offset/size is deliberately skipped because the async path
+     * defers offset/size validation to the stream callback
+     * (late binding).
+     *
+     * seg_views_out (optional): if non-null, identity-only SegView[] is
+     * filled -- dma, base, registered_length, and backend are snapshotted;
+     * page_start and size are left zero and completed by the caller once
+     * the late-bound offset/size are observed.  Returns 0 on success or
+     * -EINVAL. */
+    int acquire_identity_only(const uGDSIoSegment_t* segs, uint32_t nr,
+                              const nvm_ctrl_t* hs_ctrl,
+                              SegView* seg_views_out = nullptr);
 
     /* release(): decrement each stored occurrence under one g_driver.lock
      * hold and set size_ = 0.  Idempotent on empty. */
@@ -547,6 +564,31 @@ struct AsyncRequest {
     ssize_t*        bytes_done_p;
     uint8_t         opcode;
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
+
+    /* Vectored async fields (valid when nr_segs > 0).
+     *
+     * user_segs points to the caller's array (held until the callback runs);
+     * the identity fields of resolved[i] (dma, base, registered_length,
+     * backend) were snapshotted under g_driver.lock at enqueue, and the
+     * per-segment in_flight references live in owner.  Geometry
+     * (page_start/size) is filled in the callback from user_segs[i] after
+     * late binding.  launch_backend was computed once at enqueue from the
+     * segment-backend and stream-backend snapshots and is never re-read.
+     *
+     * Because SglRefOwner is noexcept move-only and not copyable, AsyncRequest
+     * itself becomes move-only; the public async path only heap-allocates it
+     * via new and deletes it from the callback, so no copy is required. */
+    uGDSIoSegment_t* user_segs = nullptr;
+    unsigned         nr_segs = 0;
+    SegView*         resolved = nullptr;  /* resolved segments (inline/heap) */
+    SglRefOwner      owner;               /* in-flight refs (single-owner handoff) */
+    uGDSBackend_t    launch_backend = UGDS_BACKEND_DEFAULT;
+
+    /* Inline SegView storage for the common nr <= 4 case (no heap at
+     * callback time, section 6.3).  resolved points here when nr_segs
+     * is in [1, 4]; otherwise it points at the heap allocation performed
+     * at enqueue. */
+    SegView          inline_resolved[4];
 };
 
 /* Internal stream type -- void* for backend neutrality */

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -219,9 +219,13 @@ struct IOQueuePair {
     /* Timeout resources remain owned by the QP until controller recovery.
      * At most one synchronous operation can hold this QP lock.
      * timeout_dma: on-the-fly (1-buf) mapping parked by the scalar engine.
+     * timeout_registered_base: a registered-buffer base whose in_flight
+     *   ref was parked by the legacy scalar path.  The ref
+     *   is released by cleanup_timeout_resources.
      * timeout_refs: fixed-capacity registered-ref owner parked by the SGL
      *               engine (also used by the refactored scalar path). */
     nvm_dma_t*     timeout_dma = nullptr;           /* on-the-fly mapping */
+    const void*    timeout_registered_base = nullptr; /* legacy scalar ref */
     SglRefOwner    timeout_refs;                    /* registered refs */
     std::mutex     lock;
 };

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -556,13 +556,17 @@ IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
                               SglRefOwner* owner, nvm_dma_t* transient);
 
 struct AsyncRequest {
-    uGDSHandle_t    fh;
-    void*           bufPtr_base;
-    size_t*         size_p;
-    off_t*          file_offset_p;
-    off_t*          bufPtr_offset_p;
-    ssize_t*        bytes_done_p;
-    uint8_t         opcode;
+    /* Scalar async fields (used by uGDSReadAsync/uGDSWriteAsync).
+     * Pointer parameters are caller-owned host-accessible storage
+     * read in the stream callback (late binding).  The caller MUST
+     * keep them valid until the callback runs. */
+    uGDSHandle_t    fh;             /* submitting handle (for do_io_internal) */
+    void*           bufPtr_base;    /* registered buffer base */
+    size_t*         size_p;         /* late-bound transfer size (bytes) */
+    off_t*          file_offset_p;  /* late-bound namespace offset */
+    off_t*          bufPtr_offset_p;/* late-bound offset inside bufPtr_base */
+    ssize_t*        bytes_done_p;   /* result sink (bytes or -errno) */
+    uint8_t         opcode;         /* NVM_IO_READ or NVM_IO_WRITE */
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
 
     /* Vectored async fields (valid when nr_segs > 0).

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -577,18 +577,34 @@ struct AsyncRequest {
      *
      * Because SglRefOwner is noexcept move-only and not copyable, AsyncRequest
      * itself becomes move-only; the public async path only heap-allocates it
-     * via new and deletes it from the callback, so no copy is required. */
+     * via new and deletes it from the callback, so no copy is required.
+     *
+     * resolved[] is owned by the request.  resolved_owns_heap records
+     * whether it points at a heap allocation (nr_segs > 4); the
+     * destructor releases it so every callback path frees it via a
+     * single `delete req`. */
     uGDSIoSegment_t* user_segs = nullptr;
     unsigned         nr_segs = 0;
     SegView*         resolved = nullptr;  /* resolved segments (inline/heap) */
+    bool             resolved_owns_heap = false; /* iff resolved is heap[] */
     SglRefOwner      owner;               /* in-flight refs (single-owner handoff) */
     uGDSBackend_t    launch_backend = UGDS_BACKEND_DEFAULT;
 
     /* Inline SegView storage for the common nr <= 4 case (no heap at
-     * callback time, section 6.3).  resolved points here when nr_segs
-     * is in [1, 4]; otherwise it points at the heap allocation performed
-     * at enqueue. */
+     * callback time).  resolved points here when nr_segs is in [1, 4];
+     * otherwise it points at the heap allocation performed at enqueue. */
     SegView          inline_resolved[4];
+
+    /* Owning destructor.  When the callback (or any early-return path)
+     * does `delete req`, the heap resolved[] is freed exactly once.
+     * inline_resolved is not heap-allocated, so it is left alone. */
+    ~AsyncRequest() noexcept {
+        if (resolved_owns_heap) {
+            delete[] resolved;
+            resolved = nullptr;
+            resolved_owns_heap = false;
+        }
+    }
 };
 
 /* Internal stream type -- void* for backend neutrality */

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -450,6 +450,14 @@ struct BatchState {
     std::vector<uint32_t> release_scratch;
     uint32_t              n_release_pending = 0;
 
+    /* SGL segment arena for vectored batch entries.
+     * Fixed-size, lazily resized to capacity * UGDS_BATCH_IOV_MAX at the
+     * first Submitv call; never resized again.  recycle resets
+     * arena_used to 0 but never touches size()/capacity.  Each vectored
+     * entry copies its segments into [seg_begin, seg_begin+seg_count). */
+    std::vector<SegView> seg_arena;
+    uint32_t             arena_used = 0;
+
     BatchLifecycle       lifecycle = BATCH_LIFECYCLE_ACTIVE;
 
     /* Public-handle ownership: the reference held on behalf of the user's
@@ -458,6 +466,17 @@ struct BatchState {
      * WEDGED-force cleanup, via the pin rule.  The object is destroyed when
      * the last reference (self, active_batch link, or transient pin) drops. */
     std::shared_ptr<BatchState> self;
+};
+
+/* SubCmdV: one windowed sub-command for vectored batch submit.
+ * The work array is sized to the analytic total_cmds, then filled by
+ * SglWindowCursor.  The enqueue loop iterates [0, work_used) and
+ * enqueues one NVMe command per element.  window references segments in
+ * bs->seg_arena[entry.seg_begin .. entry.seg_begin+seg_count). */
+struct SubCmdV {
+    unsigned  io_idx;        /* index into bs->entries */
+    uint64_t  lba;           /* starting LBA for this window */
+    CmdWindow window;        /* window geometry (bytes, n_pages, etc.) */
 };
 
 static inline uGDSError_t make_error(uGDSOpError err) {

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -80,6 +80,20 @@ struct HandleState {
     std::unique_ptr<IOQueuePairHuge> batch_qp;
     uint16_t                    batch_queue_depth;
     std::atomic<bool>           batch_active{false};
+    /* Owning recovery link to the active batch.  Together with
+     * batch_active and batch_setting_up it forms one link-state machine
+     * whose every transition happens inside a g_driver.lock critical
+     * section.  Set by BatchIOSetUp publication; detached by exactly one
+     * of the successful-destroy link transaction or the force-deregister
+     * walk. */
+    std::shared_ptr<struct BatchState> active_batch;
+    /* True while a BatchIOSetUp that passed the setup gate (closing check
+     * + batch_active CAS, one g_driver.lock section) has not yet committed
+     * or rolled back.  Only the gate winner can set it; only that call
+     * clears it (at publication, or as the LAST rollback action).  Written
+     * only under g_driver.lock; read lock-free by force teardown, which
+     * drains it to false before freeing any host-side QP/controller. */
+    std::atomic<bool>           batch_setting_up{false};
     bool                        interrupt_mode = false;  /* UGDS_INTERRUPT_MODE */
     std::atomic<bool>           wedged{false};          /* batch timeout: handle poisoned, controller reset required */
     std::atomic<uint32_t>       handle_in_flight{0};  /* IO refcount for safe deregister */
@@ -210,6 +224,31 @@ struct BatchIOEntry {
     uint16_t            n_cmds        = 0;
     uint16_t            n_cmds_done   = 0;
     bool                event_returned = false;
+
+    /* SGL/lifecycle extensions */
+    uint8_t             kind          = 0;  /* BatchEntryKind: 0=PLAIN, 1=VECTORED */
+    uint32_t            seg_begin     = 0;  /* arena range start; valid iff VECTORED */
+    uint32_t            seg_count     = 0;  /* number of segments in this entry */
+    bool                refs_held     = false;  /* true while in-flight ref is held */
+    bool                release_queued = false; /* true iff index is in release_scratch */
+    uint16_t            n_cmds_submitted = 0;  /* successfully enqueued sub-commands */
+};
+
+/* Batch entry kind: plain (single buffer) or vectored (scatter-gather). */
+enum BatchEntryKind : uint8_t {
+    BATCH_ENTRY_PLAIN    = 0,
+    BATCH_ENTRY_VECTORED = 1,
+};
+
+/* Batch lifecycle states (under bs->lock).
+ * ACTIVE   -- normal operation; the public one-shot Destroy is available.
+ * WEDGED   -- Destroy could not drain; one-shot Destroy was consumed.
+ *             Force teardown drops self (no cycle retained).
+ * TORN_DOWN-- all resources released; any further API call is a no-op. */
+enum BatchLifecycle : uint8_t {
+    BATCH_LIFECYCLE_ACTIVE    = 0,
+    BATCH_LIFECYCLE_WEDGED    = 1,
+    BATCH_LIFECYCLE_TORN_DOWN = 2,
 };
 
 struct BatchState {
@@ -226,6 +265,23 @@ struct BatchState {
     HandleState* hs = nullptr;
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive for batch lifetime */
     std::mutex   lock;
+
+    /* Deferred-release scratch: entry indices whose registry refs must be
+     * dropped after qp.lock is released.  Fixed-size, resized to capacity
+     * at SetUp.  Written by index only under bs->lock; drained in one
+     * g_driver.lock hold after qp.lock drops.  release_queued on each
+     * BatchIOEntry is the authoritative membership bit. */
+    std::vector<uint32_t> release_scratch;
+    uint32_t              n_release_pending = 0;
+
+    BatchLifecycle       lifecycle = BATCH_LIFECYCLE_ACTIVE;
+
+    /* Public-handle ownership: the reference held on behalf of the user's
+     * uGDSBatchHandle_t.  Accessed only under bs->lock.  Moved out -- never
+     * reset in place -- at successful destroy, tombstone destroy, or
+     * WEDGED-force cleanup, via the pin rule.  The object is destroyed when
+     * the last reference (self, active_batch link, or transient pin) drops. */
+    std::shared_ptr<BatchState> self;
 };
 
 static inline uGDSError_t make_error(uGDSOpError err) {

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -183,13 +183,18 @@ bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
 /* --- SglPageCursor ----------------------------------------------------- */
 /* Forward iterator over the MPS page addresses of a window.  Replaces
  * buf_dma->ioaddrs[current_page + i] in the PRP builders.  Tracks position
- * across segment boundaries. */
+ * across segment boundaries.
+ *
+ * Usage contract: the caller initializes the cursor for a CmdWindow, then
+ * calls sgl_page_cursor_next() exactly CmdWindow::n_pages times.  The
+ * cursor walks the segment slices in order, emitting MPS-granular bus
+ * addresses from each segment's dma->ioaddrs[]. */
 struct SglPageCursor {
-    const SegView* segs;
-    uint32_t       seg_count;        /* n_segs from CmdWindow */
-    uint32_t       seg_idx;          /* current segment index (relative to window) */
-    size_t         page_in_seg;      /* absolute index into dma->ioaddrs */
-    size_t         seg_pages_left;   /* pages remaining in current segment slice */
+    const SegView* segs;        /* pointer to segs[0] (absolute base) */
+    uint32_t       abs_seg;     /* absolute segment index into segs[] */
+    uint32_t       end_seg;     /* one-past-last absolute segment index */
+    size_t         page_in_seg; /* absolute ioaddr index within current seg */
+    size_t         slice_pages_left; /* pages left in current segment slice */
 };
 
 void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -94,6 +94,13 @@ public:
     /* release(): decrement each stored occurrence under one g_driver.lock
      * hold and set size_ = 0.  Idempotent on empty. */
     void release() noexcept;
+
+    /* disarm(): set size_ = 0 so the destructor does not release.
+     * The acquired in_flight references remain in the registry; the
+     * caller becomes responsible for releasing them by other means
+     * (the batch owns the release via kind-aware
+     * drain_release_scratch). */
+    void disarm() noexcept { size_ = 0; }
 };
 
 static_assert(std::is_nothrow_move_constructible<SglRefOwner>::value);
@@ -478,6 +485,14 @@ struct SubCmdV {
     uint64_t  lba;           /* starting LBA for this window */
     CmdWindow window;        /* window geometry (bytes, n_pages, etc.) */
 };
+
+/* Kind-aware release of the in-flight reference(s) held by a batch
+ * entry.  Defined in ugds_batch.cpp.
+ * - BATCH_ENTRY_PLAIN: one ref at entry.devPtr_base.
+ * - BATCH_ENTRY_VECTORED: one ref per base in
+ *   bs->seg_arena[entry.seg_begin .. seg_begin + seg_count).
+ * Must be called WITHOUT holding g_driver.lock. */
+void release_entry_refs(BatchState* bs, BatchIOEntry& entry);
 
 static inline uGDSError_t make_error(uGDSOpError err) {
     uGDSError_t e;

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <time.h>
 
-static nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp)
+nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp)
 {
     if (qp.irq_efd < 0) {
         nvm_cpl_t* cpl = nullptr;
@@ -288,9 +288,12 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         if (timed_out) {
             if (on_the_fly) {
                 qp.timeout_dma = buf_dma;
-            } else {
-                qp.timeout_registered_buf = bufPtr_base;
             }
+            /* Registered buffer refs are parked via SglRefOwner move
+             * into qp.timeout_refs by the caller (do_iov_engine or
+             * do_io_internal when refactored). For the legacy scalar
+             * path the ref remains held until the explicit release
+             * below is skipped on timeout. */
             buf_dma = nullptr;
         }
 

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -108,13 +108,30 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     nvm_dma_t* buf_dma = nullptr;
     bool on_the_fly = false;
     size_t buf_page_start = 0;
+    /* owner tracks the registered-buffer in-flight ref so it can be
+     * parked into qp.timeout_refs on timeout. */
+    bool ref_held = false;
 
     {
         std::lock_guard<std::mutex> drv_lock(g_driver.lock);
         auto it = g_driver.buf_registry.find(bufPtr_base);
         if (it != g_driver.buf_registry.end()) {
+            /* Controller affinity: mapping controller must
+             * match the submitting handle's controller. */
+            if (it->second.map_ctrl != hs->ctrl) {
+                return -EINVAL;
+            }
+            /* Exact-length bounds in
+             * subtraction form. bufPtr_offset was checked >= 0 above. */
+            const uint64_t off = static_cast<uint64_t>(bufPtr_offset);
+            const uint64_t sz  = static_cast<uint64_t>(size);
+            if (off > it->second.length ||
+                sz > it->second.length - off) {
+                return -EINVAL;
+            }
             buf_dma = it->second.dma;
             it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+            ref_held = true;
         }
     }
 
@@ -124,12 +141,11 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             auto it = g_driver.buf_registry.find(bufPtr_base);
             if (it != g_driver.buf_registry.end())
                 it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+            ref_held = false;
             return -EINVAL;
         }
         buf_page_start = static_cast<size_t>(bufPtr_offset) / page_size;
-        /* Overflow-safe bounds check: compute pages_needed separately,
-         * then verify buf_page_start + pages_needed <= n_ioaddrs
-         * without risking wrap. */
+        /* Defensive page-count check. */
         size_t pages_needed = (size - 1) / page_size + 1;
         if (pages_needed > buf_dma->n_ioaddrs ||
             buf_page_start > buf_dma->n_ioaddrs - pages_needed) {
@@ -137,6 +153,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             auto it = g_driver.buf_registry.find(bufPtr_base);
             if (it != g_driver.buf_registry.end())
                 it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+            ref_held = false;
             return -EINVAL;
         }
     } else {
@@ -210,9 +227,18 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 if (drain == nullptr) {
                     result = -EIO;
                     /* An older submitted command may still DMA. Treat this
-                     * exactly like a post-submit completion timeout. */
+                     * exactly like a post-submit completion timeout.
+                     * Park the resource while qp.lock is held:
+                     * the post-lock parking block below is bypassed by this
+                     * goto, so we must park here. */
                     timed_out = true;
                     hs->wedged.store(true, std::memory_order_release);
+                    if (on_the_fly) {
+                        qp.timeout_dma = buf_dma;
+                        buf_dma = nullptr;
+                    } else if (ref_held) {
+                        qp.timeout_registered_base = bufPtr_base;
+                    }
                     goto out;
                 }
                 uint16_t st = UGDS_CPL_SCT_SC(drain);
@@ -258,8 +284,16 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 result = -EIO;
                 timed_out = true;
                 /* Mark wedged while still holding qp.lock to prevent
-                 * QP reuse before the flag is visible. */
+                 * QP reuse before the flag is visible.
+                 * Park the resource at the timeout site:
+                 * the post-lock block below is skipped by this goto. */
                 hs->wedged.store(true, std::memory_order_release);
+                if (on_the_fly) {
+                    qp.timeout_dma = buf_dma;
+                    buf_dma = nullptr;
+                } else if (ref_held) {
+                    qp.timeout_registered_base = bufPtr_base;
+                }
                 goto out;
             }
 
@@ -281,28 +315,17 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 
         result = static_cast<ssize_t>(bytes_done);
 
-        /* Transfer timeout resources to the QP while we still hold
-         * qp.lock.  A concurrent force teardown also acquires qp.lock
-         * in cleanup_timeout_resources(), so this prevents the race
-         * where teardown destroys the QP before we store the mapping. */
-        if (timed_out) {
-            if (on_the_fly) {
-                qp.timeout_dma = buf_dma;
-            }
-            /* Registered buffer refs are parked via SglRefOwner move
-             * into qp.timeout_refs by the caller (do_iov_engine or
-             * do_io_internal when refactored). For the legacy scalar
-             * path the ref remains held until the explicit release
-             * below is skipped on timeout. */
-            buf_dma = nullptr;
-        }
+        /* Parking was already done at each timeout site while qp.lock
+         * was held. The old post-lock block below was
+         * unreachable on the timeout path due to the goto. */
 
     out:;
     }
 
     if (timed_out) {
         /* NVMe command may still be executing. wedged was set
-         * under qp.lock. Resources were transferred to the QP above. */
+         * under qp.lock. Resources were parked to the QP at the
+         * timeout site. */
         fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
                 "Controller reset required.\n");
     } else if (on_the_fly && buf_dma != nullptr) {

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -1,21 +1,36 @@
+/*
+ * Copyright (c) 2024, Guanyi Chen <felixlinker02@gmail.com>
+ * Copyright (c) 2017, Jonas Markauss <jonassm@ifi.uio.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 /* uGDS SGL (scatter-gather) streaming engine and sync vectored API.
  *
- * Implements the pure streaming primitives (SglPageCursor, SglWindowCursor,
- * analytic counter), the fixed-capacity reference owner (SglRefOwner), the
- * shared windowed IO engine (do_iov_engine), and the public sync vectored
- * entry points (uGDSReadv/uGDSWritev).
+ * Public APIs implemented here:
+ *   - uGDSReadv / uGDSWritev       (sync vectored IO)
+ *
+ * Internal primitives implemented here (consumed by ugds_batch.cpp and
+ * ugds_async.cpp):
+ *   - SglRefOwner                  (fixed-capacity in-flight ref owner)
+ *   - SglWindowCursor / SglPageCursor / sgl_count_windows_analytic
+ *   - do_iov_engine                (shared streaming windowed IO engine)
+ *
+ * Implements the pure streaming primitives (SglPageCursor,
+ * SglWindowCursor, analytic counter), the fixed-capacity reference
+ * owner (SglRefOwner), the shared windowed IO engine (do_iov_engine),
+ * and the public sync vectored entry points (uGDSReadv/uGDSWritev).
  *
  * Design constraints honored here:
  *  - SglWindowCursor yields one CmdWindow at a time into caller-local
- *    storage; no array of windows is ever materialized (independent M-2).
+ *    storage; no array of windows is ever materialized.
  *  - SglRefOwner is fixed-capacity for UGDS_IOV_MAX and never allocates;
- *    it is noexcept move-only so timeout parking is a bounded array move
- *    (independent M-3, section 6.4).
+ *    it is noexcept move-only so timeout parking is a bounded array move.
  *  - HandleOpGuard owns the handle-operation reference from immediately
  *    after handle_lookup through engine return, closing the OOM-strand
- *    window (V6-M-1).
+ *    window.
  *  - Exact registered-length bounds and controller affinity are checked
- *    under g_driver.lock before the first cursor.next() (sections 5.1/5.3).
+ *    under g_driver.lock before the first cursor.next().
  */
 
 #include "ugds_internal.h"
@@ -204,6 +219,10 @@ static size_t compute_split_unit(size_t mps, size_t block_size) noexcept
     return (mps / a) * block_size;
 }
 
+/* Initialize a cursor for a resolved SegView array.  Returns false
+ * (reject) if window_cap, page_size, block_size, or nr_segs is zero.
+ * The cursor holds no storage of its own; 'segs' must outlive the
+ * cursor walk. */
 bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
                      size_t window_cap, size_t page_size, size_t block_size)
 {
@@ -355,9 +374,12 @@ bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
 }
 
 /* ========================================================================
- * SglPageCursor (section 3.2)
+ * SglPageCursor
  * ======================================================================== */
 
+/* Initialize a page cursor for one CmdWindow.  The caller then calls
+ * sgl_page_cursor_next() exactly CmdWindow::n_pages times to walk the
+ * MPS-granular bus addresses across segment boundaries. */
 void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
                           uint32_t first_seg, size_t first_seg_page_off,
                           uint32_t n_segs, size_t n_pages) noexcept
@@ -385,6 +407,9 @@ void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
     (void)first_seg_page_off;
 }
 
+/* Return the current segment's ioaddr and advance the cursor across
+ * segment boundaries.  Total calls bounded by CmdWindow::n_pages.
+ * Returns 0 only on misuse (caller overran n_pages). */
 uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept
 {
     /* Walk the segment slices in order, emitting MPS-granular bus addresses.
@@ -573,23 +598,38 @@ IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
 }
 
 /* ========================================================================
- * uGDSReadv / uGDSWritev (sections 1.2, 6.1, 8.1)
+ * uGDSReadv / uGDSWritev
  * ======================================================================== */
 
 /* Common validation + engine dispatch for vectored read/write.
- * opcode is NVM_IO_READ or NVM_IO_WRITE.
- * Returns total bytes or -errno. */
+ *
+ * Performs, in order:
+ *   1. Malformed-call checks (null segs, nr_segs == 0, nr_segs >
+ *      UGDS_IOV_MAX) per the value matrix.
+ *   2. handle_lookup + HandleOpGuard so every early return releases
+ *      the handle-operation reference exactly once.
+ *   3. Per-segment value validation (base/size nonzero, offset >= 0,
+ *      offset MPS-aligned, size block-multiple, overflow-safe total).
+ *   4. file_offset alignment and window_cap == 0 rejection.
+ *   5. SglRefOwner::acquire under g_driver.lock (registration +
+ *      controller affinity + exact-length bound, all-or-nothing).
+ *   6. do_iov_engine dispatch.
+ *   7. owner.release() (no-op if the engine parked it on timeout) and
+ *      handle_guard.release().
+ *
+ * 'opcode' is NVM_IO_READ or NVM_IO_WRITE.  Returns total bytes or
+ * -errno. */
 static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                unsigned nr_segs, off_t file_offset,
                                uint8_t opcode)
 {
-    /* --- Malformed-call checks (8.1 value rows) --- */
+    /* --- Malformed-call checks --- */
     if (segs == nullptr || nr_segs == 0)
         return -EINVAL;
     if (nr_segs > UGDS_IOV_MAX)
         return -EINVAL;
 
-    /* handle_lookup + HandleOpGuard (V6-M-1) */
+    /* handle_lookup + HandleOpGuard */
     std::shared_ptr<HandleState> hs_sp;
     HandleState* hs = handle_lookup(fh, &hs_sp);
     if (!hs)

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -644,7 +644,7 @@ extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     try {
         return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
     } catch (...) {
-        return -UGDS_INTERNAL_ERROR;
+        return -EIO;
     }
 }
 
@@ -654,7 +654,7 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     try {
         return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
     } catch (...) {
-        return -UGDS_INTERNAL_ERROR;
+        return -EIO;
     }
 }
 

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -661,15 +661,9 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 /* Phase 2/3 stubs: declared in the public header so the API surface is
  * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
  * implementations land.  This keeps the library linkable without
- * undefined-reference errors. */
-
-extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t /*batch*/,
-                                            unsigned /*nr*/,
-                                            uGDSIOSegParams_t* /*iocb*/,
-                                            unsigned /*flags*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
+ * undefined-reference errors.
+ *
+ * uGDSBatchIOSubmitv is implemented in ugds_batch.cpp. */
 
 extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
                                         uGDSIoSegment_t* /*segs*/,

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -649,3 +649,36 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 {
     return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
 }
+
+/* Phase 2/3 stubs: declared in the public header so the API surface is
+ * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
+ * implementations land.  This keeps the library linkable without
+ * undefined-reference errors. */
+
+extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t /*batch*/,
+                                            unsigned /*nr*/,
+                                            uGDSIOSegParams_t* /*iocb*/,
+                                            unsigned /*flags*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}
+
+extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
+                                        uGDSIoSegment_t* /*segs*/,
+                                        unsigned /*nr_segs*/,
+                                        off_t* /*file_offset_p*/,
+                                        ssize_t* /*bytes_read_p*/,
+                                        void* /*stream*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}
+
+extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t /*fh*/,
+                                         uGDSIoSegment_t* /*segs*/,
+                                         unsigned /*nr_segs*/,
+                                         off_t* /*file_offset_p*/,
+                                         ssize_t* /*bytes_written_p*/,
+                                         void* /*stream*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -641,13 +641,21 @@ static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                unsigned nr_segs, off_t file_offset)
 {
-    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+    try {
+        return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+    } catch (...) {
+        return -UGDS_INTERNAL_ERROR;
+    }
 }
 
 extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                 unsigned nr_segs, off_t file_offset)
 {
-    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+    try {
+        return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+    } catch (...) {
+        return -UGDS_INTERNAL_ERROR;
+    }
 }
 
 /* Phase 2/3 stubs: declared in the public header so the API surface is

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -133,6 +133,56 @@ int SglRefOwner::acquire(const uGDSIoSegment_t* segs, uint32_t nr,
     return 0;
 }
 
+/* Identity-only acquire for the async path: skips the exact-length bound
+ * because offset/size are late-bound and not yet observable at enqueue.
+ * Fills only dma/base/registered_length/backend in seg_views_out; geometry
+ * is completed by the callback. */
+int SglRefOwner::acquire_identity_only(const uGDSIoSegment_t* segs, uint32_t nr,
+                                       const nvm_ctrl_t* hs_ctrl,
+                                       SegView* seg_views_out)
+{
+    std::lock_guard<std::mutex> g(g_driver.lock);
+
+    for (uint32_t k = 0; k < nr; ++k) {
+        const void* base = segs[k].base;
+        auto it = g_driver.buf_registry.find(base);
+        if (it == g_driver.buf_registry.end()) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        DriverState::BufEntry& entry = it->second;
+
+        /* Controller affinity check. */
+        if (entry.map_ctrl != hs_ctrl) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Acquire the reference and record the base. */
+        entry.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        bases_[k] = base;
+
+        /* Identity-only SegView: geometry (page_start/size) left zero for
+         * the callback to fill after late binding. */
+        if (seg_views_out != nullptr) {
+            SegView& sv = seg_views_out[k];
+            sv.dma               = entry.dma;
+            sv.base              = base;
+            sv.registered_length = entry.length;
+            sv.backend           = entry.backend;
+            sv.page_start        = 0;
+            sv.size              = 0;
+        }
+    }
+    size_ = static_cast<uint16_t>(nr);
+    return 0;
+}
+
 /* ========================================================================
  * SglWindowCursor
  * ======================================================================== */
@@ -658,29 +708,5 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     }
 }
 
-/* Phase 2/3 stubs: declared in the public header so the API surface is
- * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
- * implementations land.  This keeps the library linkable without
- * undefined-reference errors.
- *
- * uGDSBatchIOSubmitv is implemented in ugds_batch.cpp. */
-
-extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
-                                        uGDSIoSegment_t* /*segs*/,
-                                        unsigned /*nr_segs*/,
-                                        off_t* /*file_offset_p*/,
-                                        ssize_t* /*bytes_read_p*/,
-                                        void* /*stream*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
-
-extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t /*fh*/,
-                                         uGDSIoSegment_t* /*segs*/,
-                                         unsigned /*nr_segs*/,
-                                         off_t* /*file_offset_p*/,
-                                         ssize_t* /*bytes_written_p*/,
-                                         void* /*stream*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
+/* The async vectored entry points (uGDSReadvAsync / uGDSWritevAsync) are
+ * implemented in ugds_async.cpp. */

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -1,0 +1,651 @@
+/* uGDS SGL (scatter-gather) streaming engine and sync vectored API.
+ *
+ * Implements the pure streaming primitives (SglPageCursor, SglWindowCursor,
+ * analytic counter), the fixed-capacity reference owner (SglRefOwner), the
+ * shared windowed IO engine (do_iov_engine), and the public sync vectored
+ * entry points (uGDSReadv/uGDSWritev).
+ *
+ * Design constraints honored here:
+ *  - SglWindowCursor yields one CmdWindow at a time into caller-local
+ *    storage; no array of windows is ever materialized (independent M-2).
+ *  - SglRefOwner is fixed-capacity for UGDS_IOV_MAX and never allocates;
+ *    it is noexcept move-only so timeout parking is a bounded array move
+ *    (independent M-3, section 6.4).
+ *  - HandleOpGuard owns the handle-operation reference from immediately
+ *    after handle_lookup through engine return, closing the OOM-strand
+ *    window (V6-M-1).
+ *  - Exact registered-length bounds and controller affinity are checked
+ *    under g_driver.lock before the first cursor.next() (sections 5.1/5.3).
+ */
+
+#include "ugds_internal.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cerrno>
+#include <atomic>
+#include <algorithm>
+#include <new>
+
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
+
+/* ========================================================================
+ * SglRefOwner implementation
+ * ======================================================================== */
+
+SglRefOwner::SglRefOwner(SglRefOwner&& other) noexcept
+    : bases_(other.bases_), size_(other.size_)
+{
+    other.size_ = 0;
+}
+
+SglRefOwner& SglRefOwner::operator=(SglRefOwner&& other) noexcept
+{
+    if (this != &other) {
+        /* Release anything we currently hold before overwriting. */
+        release();
+        bases_ = other.bases_;
+        size_  = other.size_;
+        other.size_ = 0;
+    }
+    return *this;
+}
+
+SglRefOwner::~SglRefOwner() noexcept
+{
+    release();
+}
+
+void SglRefOwner::release() noexcept
+{
+    if (size_ == 0) return;
+    std::lock_guard<std::mutex> g(g_driver.lock);
+    for (uint16_t i = 0; i < size_; ++i) {
+        auto it = g_driver.buf_registry.find(bases_[i]);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    size_ = 0;
+}
+
+/* Acquire in-flight references for all segments under one g_driver.lock hold.
+ * All-or-nothing: on any failure, rolls back [0..k-1].  Returns 0 on success
+ * or -EINVAL.  If seg_views_out is non-null, fills the resolved SegView[]. */
+int SglRefOwner::acquire(const uGDSIoSegment_t* segs, uint32_t nr,
+                         const nvm_ctrl_t* hs_ctrl,
+                         size_t page_size,
+                         SegView* seg_views_out)
+{
+    std::lock_guard<std::mutex> g(g_driver.lock);
+
+    for (uint32_t k = 0; k < nr; ++k) {
+        const void* base = segs[k].base;
+        auto it = g_driver.buf_registry.find(base);
+        if (it == g_driver.buf_registry.end()) {
+            /* Rollback [0..k-1] */
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        DriverState::BufEntry& entry = it->second;
+
+        /* Controller affinity check: mapping controller must match the
+         * submitting handle's controller. */
+        if (entry.map_ctrl != hs_ctrl) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Exact-length bounds, subtraction form.  offset and size were
+         * already value-checked MPS/block-aligned by the caller; here we
+         * enforce the registered-range bound. */
+        const uint64_t off = static_cast<uint64_t>(segs[k].offset);
+        const uint64_t sz  = static_cast<uint64_t>(segs[k].size);
+        if (off > entry.length || sz > entry.length - off) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Acquire the reference and record the base. */
+        entry.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        bases_[k] = base;
+
+        /* Fill the resolved SegView if requested. */
+        if (seg_views_out != nullptr) {
+            SegView& sv = seg_views_out[k];
+            sv.dma               = entry.dma;
+            sv.base              = base;
+            sv.registered_length = entry.length;
+            sv.backend           = entry.backend;
+            sv.page_start        = off / page_size;
+            sv.size              = segs[k].size;
+        }
+    }
+    size_ = static_cast<uint16_t>(nr);
+    return 0;
+}
+
+/* ========================================================================
+ * SglWindowCursor
+ * ======================================================================== */
+
+/* Compute SU = lcm(MPS, block_size).  Both are powers of two (MPS = 2^(12+n),
+ * LBADS >= 9), so lcm = max; the code computes the power-of-two case directly
+ * and falls back to lcm defensively. */
+static size_t compute_split_unit(size_t mps, size_t block_size) noexcept
+{
+    /* Power-of-two check: if both have exactly one bit set, lcm = max. */
+    if (mps > 0 && block_size > 0 &&
+        (mps & (mps - 1)) == 0 &&
+        (block_size & (block_size - 1)) == 0) {
+        return std::max(mps, block_size);
+    }
+    /* Defensive gcd/lcm for non-power-of-two (should not occur per NVMe). */
+    size_t a = mps, b = block_size;
+    while (b != 0) { size_t t = a % b; a = b; b = t; }
+    return (mps / a) * block_size;
+}
+
+bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
+                     size_t window_cap, size_t page_size, size_t block_size)
+{
+    if (window_cap == 0 || page_size == 0 || block_size == 0 || nr_segs == 0)
+        return false;
+    c.segs       = segs;
+    c.nr_segs    = nr_segs;
+    c.seg_idx    = 0;
+    c.bytes_in_seg = 0;
+    c.window_cap = window_cap;
+    c.page_size  = page_size;
+    c.block_size = block_size;
+    c.split_unit = compute_split_unit(page_size, block_size);
+    return true;
+}
+
+/* Emit at most one window into out.  Returns true if a window was produced,
+ * false when the SGL is exhausted.  Implements the capacity / PRP-tail /
+ * end-of-SGL rules without materializing a window array. */
+bool sgl_cursor_next(SglWindowCursor& c, CmdWindow& out) noexcept
+{
+    if (c.seg_idx >= c.nr_segs)
+        return false;
+
+    out.first_seg          = c.seg_idx;
+    out.first_seg_page_off = c.bytes_in_seg / c.page_size;
+    out.n_segs             = 0;
+    out.bytes              = 0;
+    out.n_pages            = 0;
+
+    while (c.seg_idx < c.nr_segs) {
+        const SegView& seg = c.segs[c.seg_idx];
+        size_t rem  = seg.size - c.bytes_in_seg;
+        size_t take = std::min(rem, c.window_cap - out.bytes);
+
+        /* Capacity rule: if this take splits mid-segment, round down to an
+         * SU boundary so the continuation starts page-aligned. */
+        if (take < rem) {
+            take = (take / c.split_unit) * c.split_unit;
+            /* Safety: window contents before a split are SU-multiples up to
+             * here, window_cap is an SU multiple, and a non-closed window
+             * has window_cap - out.bytes >= SU, so take >= SU > 0. */
+        }
+
+        size_t slice_pages = (take + c.page_size - 1) / c.page_size;
+        out.n_segs++;
+        out.bytes   += take;
+        out.n_pages += slice_pages;
+        c.bytes_in_seg += take;
+
+        bool segment_ended = (c.bytes_in_seg == seg.size);
+        if (segment_ended) {
+            /* PRP tail rule: a segment whose size is not page-multiple
+             * must be the window's last slice. */
+            bool non_page_tail = (seg.size % c.page_size != 0);
+            c.seg_idx++;
+            c.bytes_in_seg = 0;
+            if (non_page_tail) {
+                return true;  /* PRP tail */
+            }
+        }
+
+        /* Capacity rule */
+        if (out.bytes >= c.window_cap)
+            return true;
+    }
+
+    /* End of SGL: return whatever was accumulated. */
+    return true;
+}
+
+/* ========================================================================
+ * sgl_count_windows_analytic
+ * O(nr_segs) exact count via room/cap arithmetic.
+ * ======================================================================== */
+
+bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
+                                uint32_t nr_segs,
+                                size_t window_cap, size_t page_size,
+                                size_t block_size,
+                                uint32_t* out) noexcept
+{
+    if (window_cap == 0 || page_size == 0 || block_size == 0 || nr_segs == 0)
+        return false;
+
+    /* SU is used by the cursor to round capacity-rule split points; the
+     * analytic counter uses quotient/remainder against window_cap, which
+     * the caller already guaranteed is an SU multiple (so full windows
+     * need no rounding).  We keep SU here only as a debug sanity
+     * reference. */
+    const size_t SU = compute_split_unit(page_size, block_size);
+    (void)SU;
+
+    uint64_t count = 0;
+    uint64_t open  = 0;  /* bytes accumulated in the current open window */
+
+    for (uint32_t i = 0; i < nr_segs; ++i) {
+        uint64_t s = segs[i].size;
+
+        /* Absorb into the open window if one exists. */
+        if (open != 0) {
+            uint64_t room = window_cap - open;
+            if (s < room) {
+                open += s;
+                s = 0;
+            } else {
+                /* s >= room: the open window fills to capacity.
+                 * But we must respect the capacity-rule mid-segment
+                 * rounding: the actual take is round_down(room, SU).
+                 * Since window contents before a split are SU-multiples
+                 * and window_cap is an SU multiple, room itself is an SU
+                 * multiple when open is an SU multiple (which it is by
+                 * induction).  So take == room exactly, no rounding
+                 * loss. */
+                s -= room;
+                count++;
+                open = 0;
+            }
+        }
+
+        if (s != 0) {
+            /* All full capacity-rule windows at once.  Each full window
+             * takes window_cap bytes (an SU multiple), so no rounding. */
+            count += s / window_cap;
+            open = s % window_cap;
+        }
+
+        /* PRP tail rule: if this segment's size is not page-multiple, it closes the
+         * window. */
+        if (segs[i].size % page_size != 0) {
+            /* open must be nonzero here: the segment just contributed
+             * remainder bytes and was not absorbed entirely into a prior
+             * open window. */
+            if (open != 0) {
+                count++;
+                open = 0;
+            }
+        }
+    }
+
+    /* End of SGL: trailing open window */
+    if (open != 0) count++;
+
+    if (count > UINT32_MAX)
+        return false;
+
+    *out = static_cast<uint32_t>(count);
+    return true;
+}
+
+/* ========================================================================
+ * SglPageCursor (section 3.2)
+ * ======================================================================== */
+
+void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
+                          uint32_t first_seg, size_t first_seg_page_off,
+                          uint32_t n_segs, size_t n_pages) noexcept
+{
+    c.segs            = segs;
+    c.abs_seg         = first_seg;
+    c.end_seg         = first_seg + n_segs;
+    c.page_in_seg     = segs[first_seg].page_start + first_seg_page_off;
+    /* Compute the pages in the first slice.  For the first segment the slice
+     * may start mid-segment (first_seg_page_off > 0).  The total pages in
+     * the slice is ceil(slice_bytes / MPS).  We don't have slice_bytes
+     * directly, but we know:
+     *  - For the last segment in the window, the slice may be partial.
+     *  - For non-last segments (or single-segment full), the slice covers
+     *    from page_in_seg to the end of the segment's registered pages,
+     *    minus what later windows consume (but within this window it's the
+     *    full remainder).
+     *
+     * Since the caller will call next() exactly n_pages times total, and
+     * each segment boundary is page-aligned (alignment + cursor rules), we
+     * can lazily compute slice pages as: for a given segment, the slice
+     * runs from page_in_seg to min(seg_end_page, page_in_seg + remaining).
+     * We track pages_remaining_total and cap each segment's contribution. */
+    c.slice_pages_left = n_pages;  /* total; will be reduced per-segment */
+    (void)first_seg_page_off;
+}
+
+uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept
+{
+    /* Walk the segment slices in order, emitting MPS-granular bus addresses.
+     * slice_pages_left tracks the total pages remaining across all slices
+     * in this window; each segment boundary naturally caps a slice. */
+    while (c.abs_seg < c.end_seg && c.slice_pages_left > 0) {
+        const SegView& seg = c.segs[c.abs_seg];
+        /* The slice for this segment runs from page_in_seg up to either the
+         * segment's page boundary or slice_pages_left exhaustion.  Since all
+         * slices except possibly the last are page-multiple (alignment +
+         * cursor rules), and the last slice is capped by slice_pages_left,
+         * this walk is correct. */
+        size_t seg_end_page = seg.page_start +
+            (seg.size + seg.dma->page_size - 1) / seg.dma->page_size;
+        if (c.page_in_seg < seg_end_page) {
+            uint64_t addr = seg.dma->ioaddrs[c.page_in_seg];
+            c.page_in_seg++;
+            c.slice_pages_left--;
+            return addr;
+        }
+        /* Advance to the next segment in the window. */
+        c.abs_seg++;
+        if (c.abs_seg < c.end_seg) {
+            c.page_in_seg = c.segs[c.abs_seg].page_start;
+        }
+    }
+    return 0;  /* safety; should not happen with correct use */
+}
+
+/* ========================================================================
+ * do_iov_engine
+ * Shared streaming windowed IO engine.
+ * ======================================================================== */
+
+IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
+                              off_t file_offset, uint8_t opcode,
+                              SglRefOwner* owner, nvm_dma_t* transient)
+{
+    IovEngineResult result{0, false};
+
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    /* Compute max_xfer (parity with the original scalar path). */
+    const size_t prp_capacity = page_size / sizeof(uint64_t);
+    size_t max_xfer = hs->max_transfer_size;
+    if (max_xfer == 0)
+        max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
+    if (max_xfer < page_size)
+        max_xfer = page_size;
+    size_t prp_max = (prp_capacity + 1) * page_size;
+    if (max_xfer > prp_max)
+        max_xfer = prp_max;
+
+    /* Compute SU and window_cap = round_down(max_xfer, SU). */
+    const size_t SU = compute_split_unit(page_size, block_size);
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0) {
+        result.ret = -EINVAL;
+        return result;
+    }
+
+    /* Initialize the window cursor. */
+    SglWindowCursor cursor;
+    if (!sgl_cursor_init(cursor, segs, nr_segs, window_cap, page_size, block_size)) {
+        result.ret = -EINVAL;
+        return result;
+    }
+
+    const uint64_t start_lba = static_cast<uint64_t>(file_offset) / block_size;
+
+    /* QP selection: round-robin, one QP per IO (unchanged concurrency story). */
+    const uint16_t qp_idx = static_cast<uint16_t>(
+        hs->rr_counter.fetch_add(1) % hs->num_qps);
+    IOQueuePair& qp = *hs->qps[qp_idx];
+
+    ssize_t bytes_done = 0;
+    uint64_t current_lba = start_lba;
+
+    {
+        std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        /* Re-check wedged after acquiring QP lock. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            result.ret = -EBADF;
+            return result;
+        }
+
+        CmdWindow window;
+        while (sgl_cursor_next(cursor, window)) {
+            /* Enqueue a command, draining the CQ if the SQ is full. */
+            nvm_cmd_t* cmd = nullptr;
+            while ((cmd = nvm_sq_enqueue(&qp.sq)) == nullptr) {
+                nvm_cpl_t* drain = wait_for_completion(hs, qp);
+                if (drain == nullptr) {
+                    /* Timeout during drain.  Park resources immediately
+                     * while qp.lock is held. */
+                    result.ret = -EIO;
+                    result.timed_out = true;
+                    hs->wedged.store(true, std::memory_order_release);
+                    if (transient != nullptr) {
+                        qp.timeout_dma = transient;
+                        transient = nullptr;
+                    } else if (owner != nullptr && !owner->empty()) {
+                        qp.timeout_refs = std::move(*owner);
+                    }
+                    return result;
+                }
+                uint16_t st = UGDS_CPL_SCT_SC(drain);
+                nvm_sq_update(&qp.sq);
+                sgl_publish_prp();
+                nvm_cq_update(&qp.cq);
+                if (st != 0) {
+                    result.ret = -EIO;
+                    return result;
+                }
+            }
+
+            memset(cmd, 0, sizeof(nvm_cmd_t));
+            uint16_t cid = NVM_DEFAULT_CID(&qp.sq);
+            nvm_cmd_header(cmd, cid, opcode, hs->ns_id);
+
+            /* Build PRP using SglPageCursor. */
+            SglPageCursor pc;
+            sgl_page_cursor_init(pc, segs, window.first_seg,
+                                 window.first_seg_page_off,
+                                 window.n_segs, window.n_pages);
+
+            if (window.n_pages == 1) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, 0);
+            } else if (window.n_pages == 2) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                uint64_t prp2 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, prp2);
+            } else {
+                volatile uint64_t* prp_list =
+                    reinterpret_cast<volatile uint64_t*>(qp.prp_dma->vaddr);
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                for (size_t i = 1; i < window.n_pages; ++i)
+                    prp_list[i - 1] = sgl_page_cursor_next(pc);
+                sgl_publish_prp();
+                nvm_cmd_data_ptr(cmd, prp1, qp.prp_dma->ioaddrs[0]);
+            }
+
+            size_t n_blocks = window.bytes / block_size;
+            nvm_cmd_rw_blks(cmd, current_lba, static_cast<uint16_t>(n_blocks));
+
+            sgl_publish_prp();
+            nvm_sq_submit(&qp.sq);
+            sgl_publish_prp();
+
+            nvm_cpl_t* cpl = wait_for_completion(hs, qp);
+            if (cpl == nullptr) {
+                /* Timeout: park resources immediately while qp.lock is held. */
+                result.ret = -EIO;
+                result.timed_out = true;
+                hs->wedged.store(true, std::memory_order_release);
+                if (transient != nullptr) {
+                    qp.timeout_dma = transient;
+                    transient = nullptr;
+                } else if (owner != nullptr && !owner->empty()) {
+                    qp.timeout_refs = std::move(*owner);
+                }
+                return result;
+            }
+
+            uint16_t status = UGDS_CPL_SCT_SC(cpl);
+            nvm_sq_update(&qp.sq);
+            sgl_publish_prp();
+            nvm_cq_update(&qp.cq);
+
+            if (status != 0) {
+                result.ret = -EIO;
+                return result;
+            }
+
+            bytes_done += static_cast<ssize_t>(window.bytes);
+            current_lba += n_blocks;
+        }
+
+        result.ret = bytes_done;
+    }
+
+    return result;
+}
+
+/* ========================================================================
+ * uGDSReadv / uGDSWritev (sections 1.2, 6.1, 8.1)
+ * ======================================================================== */
+
+/* Common validation + engine dispatch for vectored read/write.
+ * opcode is NVM_IO_READ or NVM_IO_WRITE.
+ * Returns total bytes or -errno. */
+static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                               unsigned nr_segs, off_t file_offset,
+                               uint8_t opcode)
+{
+    /* --- Malformed-call checks (8.1 value rows) --- */
+    if (segs == nullptr || nr_segs == 0)
+        return -EINVAL;
+    if (nr_segs > UGDS_IOV_MAX)
+        return -EINVAL;
+
+    /* handle_lookup + HandleOpGuard (V6-M-1) */
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs)
+        return -EBADF;
+    HandleOpGuard handle_guard(hs);  /* owns handle_in_flight from here */
+
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    if (page_size == 0 || block_size == 0) {
+        return -EINVAL;
+    }
+
+    /* --- Per-segment value validation --- */
+    uint64_t total_size = 0;
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr || segs[i].size == 0)
+            return -EINVAL;
+        if (segs[i].offset < 0)
+            return -EINVAL;
+        if ((static_cast<size_t>(segs[i].offset) % page_size) != 0)
+            return -EINVAL;
+        if ((segs[i].size % block_size) != 0)
+            return -EINVAL;
+
+        /* Overflow-safe total accumulation. Guard order matters:
+         * total_size is already known to be <= SSIZE_MAX, so
+         * SSIZE_MAX - total_size cannot underflow. */
+        uint64_t seg_size = static_cast<uint64_t>(segs[i].size);
+        if (seg_size > static_cast<uint64_t>(SSIZE_MAX) - total_size)
+            return -EINVAL;  /* total overflow */
+        total_size += seg_size;
+    }
+
+    /* file_offset alignment. */
+    if (file_offset < 0 ||
+        (static_cast<size_t>(file_offset) % block_size) != 0)
+        return -EINVAL;
+
+    /* window_cap == 0 check (block > max_xfer). */
+    const size_t prp_capacity = page_size / sizeof(uint64_t);
+    size_t max_xfer = hs->max_transfer_size;
+    if (max_xfer == 0) max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
+    if (max_xfer < page_size) max_xfer = page_size;
+    size_t prp_max = (prp_capacity + 1) * page_size;
+    if (max_xfer > prp_max) max_xfer = prp_max;
+    const size_t SU = compute_split_unit(page_size, block_size);
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0)
+        return -EINVAL;
+
+    /* --- SegView storage: stack for nr <= 4, heap otherwise --- */
+    /* HandleOpGuard protects the handle reference across this allocation,
+     * so a bad_alloc here cannot strand handle_in_flight. */
+    SegView stack_views[4];
+    std::vector<SegView> heap_views;
+    SegView* views = nullptr;
+
+    if (nr_segs <= 4) {
+        views = stack_views;
+    } else {
+        try {
+            heap_views.resize(nr_segs);
+        } catch (const std::bad_alloc&) {
+            return -ENOMEM;
+        }
+        views = heap_views.data();
+    }
+
+    /* --- Acquire in-flight refs + resolve segments (all-or-nothing) --- */
+    SglRefOwner owner;
+    int rc = owner.acquire(segs, static_cast<uint32_t>(nr_segs),
+                           hs->ctrl, page_size, views);
+    if (rc != 0) {
+        return rc;  /* -EINVAL: unregistered / bounds / affinity */
+    }
+
+    /* --- Engine dispatch --- */
+    IovEngineResult result = do_iov_engine(hs, views,
+                                           static_cast<uint32_t>(nr_segs),
+                                           file_offset, opcode,
+                                           &owner, nullptr);
+
+    /* --- Cleanup --- */
+    /* owner.release() is a no-op if the engine parked it on timeout. */
+    owner.release();
+    /* handle_guard.release() disarms the destructor and calls
+     * handle_release exactly once. */
+    handle_guard.release();
+
+    if (result.timed_out) {
+        fprintf(stderr, "uGDS: vectored I/O timeout -- handle wedged. "
+                "Controller reset required.\n");
+    }
+
+    return result.ret;
+}
+
+extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                               unsigned nr_segs, off_t file_offset)
+{
+    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+}
+
+extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                                unsigned nr_segs, off_t file_offset)
+{
+    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+}


### PR DESCRIPTION
## Summary

Adds five public vectored-IO entry points across three API families, enabling scatter-gather operations over multiple registered GPU memory regions in a single call. Registered segments are streamed into MDTS-bounded command windows using NVMe PRP lists rather than native SGL descriptors, since the underlying libnvm layer does not support SGL command building and PRP already expresses non-contiguous pages.

**New public APIs:**

- **Sync vectored**: `uGDSReadv` / `uGDSWritev`
- **Batch vectored**: `uGDSBatchIOSubmitv` (extends existing batch infrastructure)
- **Async vectored**: `uGDSReadvAsync` / `uGDSWritevAsync` (late-binding on CUDA/HIP streams)

**New public types:** `uGDSIoSegment_t`, `uGDSIOSegParams_t`, `UGDS_IOV_MAX` (1024), `UGDS_BATCH_IOV_MAX` (128)

## Changes

### SGL streaming engine (`src/ugds_iov.cpp`, new file)

- `SglWindowCursor`: forward-only MDTS window generator that splits multi-segment IO into controller-friendly command boundaries
- `SglPageCursor`: PRP address walker across segment boundaries
- `sgl_count_windows_analytic`: O(n) exact window count matching the cursor output
- `do_iov_engine`: shared windowed IO engine consumed by sync, batch, and async paths
- `SglRefOwner`: fixed-capacity in-flight reference owner; never heap-allocates; noexcept move-only

### Batch vectored (`src/ugds_batch.cpp`)

- `uGDSBatchIOSubmitv` with lazily-allocated segment arena
- Kind-aware lifecycle (`BATCH_ENTRY_PLAIN` / `BATCH_ENTRY_VECTORED`)
- `BatchSetupTxn` RAII for setup resource safety
- Deferred reference release via `release_scratch`
- Plain and vectored entries may be mixed on the same batch handle

### Async vectored (`src/ugds_async.cpp`)

- Late-binding contract: `base` fixed at enqueue; `offset`/`size`/`file_offset` read in stream callback
- `unique_ptr<AsyncRequest>` pre-launch ownership; `HandleRefGuard` and `HandleReleaseGuard` RAII for `handle_in_flight` across every exception path
- `async_iov_callback` (noexcept) as the exception boundary
- Dual-backend launch dispatch based on segment backend and stream registration

### Buffer registration hardening (`src/ugds_buf.cpp`)

- `BufEntry::length` for exact registered-range bounds checking
- `BufEntry::map_ctrl` for controller-affinity enforcement
- `MappedDmaGuard` RAII for transactional DMA mapping lifetime
- MPS-aligned base check for registered buffers; 64 KiB base check for CUDA P2P mapper

### Existing-path hardening

- Exact registered-length and controller-affinity checks added to scalar sync IO, plain batch, and scalar async paths
- Scalar timeout resource parking repaired (resources moved to QP `timeout_refs` / `timeout_dma` while `qp.lock` is held)
- Batch setup, destroy, and force-teardown reworked: `BatchSetupTxn`, ACTIVE/WEDGED/TORN_DOWN lifecycle states, partial-submit abort accounting, overflow-safe capacity checks
- C ABI `try/catch(...)` exception boundaries added to batch and async entry points

## Build

| Backend | Status |
|---------|--------|
| CUDA-only | Pass |
| HIP-only | Pass |
| Dual (CUDA + HIP) | Pass |


