### PR TITLE
fix: restore move_notify callback for Linux < 7.1 compatibility

### DIFF
--- a/drv/map.c
+++ b/drv/map.c
@@ -587,13 +587,40 @@ struct dmabuf_region
 
 
 /*
- * We intentionally do NOT provide move_notify / invalidate_mappings.
- * The buffer is pinned (dma_buf_pin) for the entire mapping lifetime,
- * so the exporter cannot move it. If the kernel ever requires this
- * callback, the attachment will fail at dma_buf_attach time.
+ * Callback invoked by the exporter if it needs to move the buffer.
+ *
+ * With dma_buf_pin() held for the mapping lifetime, the exporter
+ * cannot move the buffer after pin succeeds. However, amdgpu may
+ * fire this callback during dma_buf_pin() as part of normal BO
+ * settling -- that case is handled by clearing map->invalid after
+ * pin completes (see map_dmabuf_memory).
+ *
+ * If the callback fires after pin (genuine migration), map->invalid
+ * stays set and pci.c returns -EIO during address exposure. The
+ * primary safety invariant is that successful pin prevents movement.
+ *
+ * On Linux 7.1+, this callback was renamed to invalidate_mappings
+ * and carries a stronger revocation contract. We do not set it there
+ * because uGDS does not implement bounded revocation; pin is the
+ * sole mechanism preventing buffer movement.
  */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7,1,0)
+static void ugds_dmabuf_move_notify(struct dma_buf_attachment* attachment)
+{
+    struct map* map = (struct map*) attachment->importer_priv;
+
+    if (map)
+    {
+        atomic_set(&map->invalid, 1);
+    }
+}
+#endif
+
 static const struct dma_buf_attach_ops ugds_dmabuf_attach_ops = {
     .allow_peer2peer = true,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7,1,0)
+    .move_notify     = ugds_dmabuf_move_notify,
+#endif
 };
 
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #16. That commit removed the
`move_notify` callback from `ugds_dmabuf_attach_ops`, but the struct
is still passed as non-NULL `importer_ops` to
`dma_buf_dynamic_attach()`. Linux 5.7+ enforces
`WARN_ON(importer_ops && !importer_ops->move_notify)` and returns
`-EINVAL`, breaking all dmabuf-based GPU memory mapping on kernels
using the `move_notify` ABI.

## Changes

### move_notify restoration
- Restore `ugds_dmabuf_move_notify` callback for kernels < 7.1
- Flag-only body (`atomic_set(&map->invalid, 1)`) without `WARN_ONCE`,
  since amdgpu may fire it during `dma_buf_pin()` as normal BO settling
- Existing clear at `map_dmabuf_memory` handles the pin-time spurious flag

### Linux 7.1+ compatibility
- On 7.1+, `move_notify` was renamed to `invalidate_mappings` with a
  stronger revocation contract (importer must stop DMA and unmap within
  bounded time)
- Leave callback NULL on 7.1+ because uGDS relies on `dma_buf_pin()` for
  stability, not bounded revocation
- Function definition compiled out on 7.1+ via `#if` guard

## Build

| Kernel | Status |
|--------|--------|
| 6.18.43 (lts) | Pass |
| 7.1.8 (arch) | Pass |