### PR TITLE
[func] Add uGDSGetDeviceCapacity

### DIFF
--- a/include/ugds.h
+++ b/include/ugds.h
@@ -128,7 +128,8 @@ uGDSError_t uGDSDriverClose(void);
 uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
 
 /* Return the usable NVMe namespace capacity in bytes for a registered handle. */
-uGDSError_t uGDSGetDeviceSize(uGDSHandle_t fh, uint64_t* size_bytes);
+uGDSError_t uGDSGetDeviceCapacity(uGDSHandle_t fh,
+                                  uint64_t* capacity_bytes);
 
 void uGDSHandleDeregister(uGDSHandle_t fh);
 

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -85,6 +85,7 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_INVALID_VALUE:               return "invalid arguments";
     case UGDS_MEMORY_ALREADY_REGISTERED:   return "memory already registered";
     case UGDS_MEMORY_NOT_REGISTERED:       return "memory not registered";
+    case UGDS_HANDLE_NOT_REGISTERED:       return "handle not registered";
     case UGDS_INTERNAL_ERROR:              return "internal error";
     case UGDS_GPU_MEMORY_PINNING_FAILED:   return "GPU memory pinning failed";
     case UGDS_BATCH_CAPACITY_EXCEEDED:     return "batch capacity exceeded";
@@ -125,6 +126,9 @@ uGDSError_t uGDSDriverOpen(void);
 uGDSError_t uGDSDriverClose(void);
 
 uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
+
+/* Return the usable NVMe namespace capacity in bytes for a registered handle. */
+uGDSError_t uGDSGetDeviceSize(uGDSHandle_t fh, uint64_t* size_bytes);
 
 void uGDSHandleDeregister(uGDSHandle_t fh);
 

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -406,6 +406,34 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     return UGDS_OK;
 }
 
+extern "C" uGDSError_t uGDSGetDeviceSize(uGDSHandle_t fh,
+                                           uint64_t* size_bytes)
+{
+    if (fh == nullptr || size_bytes == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (hs == nullptr)
+        return make_error(UGDS_HANDLE_NOT_REGISTERED);
+
+    const uint64_t capacity_blocks =
+        static_cast<uint64_t>(hs->ns_info.capacity);
+    const uint64_t block_size =
+        static_cast<uint64_t>(hs->ns_info.lba_data_size);
+
+    uGDSError_t result = UGDS_OK;
+    if (capacity_blocks == 0 || block_size == 0 ||
+        capacity_blocks > UINT64_MAX / block_size) {
+        result = make_error(UGDS_INTERNAL_ERROR);
+    } else {
+        *size_bytes = capacity_blocks * block_size;
+    }
+
+    handle_release(hs);
+    return result;
+}
+
 extern "C" void uGDSHandleDeregister(uGDSHandle_t fh)
 {
     /* Legacy API: infinite wait. This void API cannot return an error

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -406,10 +406,10 @@ extern "C" uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr)
     return UGDS_OK;
 }
 
-extern "C" uGDSError_t uGDSGetDeviceSize(uGDSHandle_t fh,
-                                           uint64_t* size_bytes)
+extern "C" uGDSError_t uGDSGetDeviceCapacity(uGDSHandle_t fh,
+                                               uint64_t* capacity_bytes)
 {
-    if (fh == nullptr || size_bytes == nullptr)
+    if (fh == nullptr || capacity_bytes == nullptr)
         return make_error(UGDS_INVALID_VALUE);
 
     std::shared_ptr<HandleState> hs_sp;
@@ -427,7 +427,7 @@ extern "C" uGDSError_t uGDSGetDeviceSize(uGDSHandle_t fh,
         capacity_blocks > UINT64_MAX / block_size) {
         result = make_error(UGDS_INTERNAL_ERROR);
     } else {
-        *size_bytes = capacity_blocks * block_size;
+        *capacity_bytes = capacity_blocks * block_size;
     }
 
     handle_release(hs);

--- a/test/functional/test_handle_register.cu
+++ b/test/functional/test_handle_register.cu
@@ -20,26 +20,39 @@ int main(int argc, char** argv) {
     st = uGDSHandleRegister(&fh, &descr);
     ASSERT_OK(st, "HandleRegister");
 
-    // 2. Deregister
-    uGDSHandleDeregister(fh);
+    // 2. Query the registered namespace capacity
+    uint64_t device_size = 0;
+    st = uGDSGetDeviceSize(fh, &device_size);
+    ASSERT_OK(st, "GetDeviceSize");
+    if (device_size == 0) TEST_FAIL("GetDeviceSize returned zero capacity");
 
-    // 3. Register again on the same fd (reuse after deregister)
+    st = uGDSGetDeviceSize(fh, nullptr);
+    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceSize nullptr output");
+    st = uGDSGetDeviceSize(nullptr, &device_size);
+    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceSize nullptr handle");
+
+    // 3. Deregister and reject the stale handle
+    uGDSHandleDeregister(fh);
+    st = uGDSGetDeviceSize(fh, &device_size);
+    ASSERT_ERR(st, UGDS_HANDLE_NOT_REGISTERED, "GetDeviceSize stale handle");
+
+    // 4. Register again on the same fd (reuse after deregister)
     fh = nullptr;
     st = uGDSHandleRegister(&fh, &descr);
     ASSERT_OK(st, "HandleRegister after deregister");
     uGDSHandleDeregister(fh);
     close(fd);
 
-    // 4. nullptr fh pointer -> INVALID_VALUE
+    // 5. nullptr fh pointer -> INVALID_VALUE
     st = uGDSHandleRegister(nullptr, &descr);
     ASSERT_ERR(st, UGDS_INVALID_VALUE, "nullptr fh");
 
-    // 5. nullptr descr -> INVALID_VALUE
+    // 6. nullptr descr -> INVALID_VALUE
     uGDSHandle_t fh2 = nullptr;
     st = uGDSHandleRegister(&fh2, nullptr);
     ASSERT_ERR(st, UGDS_INVALID_VALUE, "nullptr descr");
 
-    // 6. Invalid handle type (WIN32) -> INVALID_FILE_TYPE
+    // 7. Invalid handle type (WIN32) -> INVALID_FILE_TYPE
     fd = open(g_dev_path, O_RDWR);
     if (fd < 0) TEST_FAIL("open(%s) failed for win32 test", g_dev_path);
     uGDSDescr_t bad_descr;
@@ -51,7 +64,7 @@ int main(int argc, char** argv) {
     ASSERT_ERR(st, UGDS_INVALID_FILE_TYPE, "WIN32 handle type");
     close(fd);
 
-    // 7. Deregister nullptr should not crash
+    // 8. Deregister nullptr should not crash
     uGDSHandleDeregister(nullptr);
 
     uGDSDriverClose();

--- a/test/functional/test_handle_register.cu
+++ b/test/functional/test_handle_register.cu
@@ -21,20 +21,22 @@ int main(int argc, char** argv) {
     ASSERT_OK(st, "HandleRegister");
 
     // 2. Query the registered namespace capacity
-    uint64_t device_size = 0;
-    st = uGDSGetDeviceSize(fh, &device_size);
-    ASSERT_OK(st, "GetDeviceSize");
-    if (device_size == 0) TEST_FAIL("GetDeviceSize returned zero capacity");
+    uint64_t device_capacity = 0;
+    st = uGDSGetDeviceCapacity(fh, &device_capacity);
+    ASSERT_OK(st, "GetDeviceCapacity");
+    if (device_capacity == 0)
+        TEST_FAIL("GetDeviceCapacity returned zero capacity");
 
-    st = uGDSGetDeviceSize(fh, nullptr);
-    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceSize nullptr output");
-    st = uGDSGetDeviceSize(nullptr, &device_size);
-    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceSize nullptr handle");
+    st = uGDSGetDeviceCapacity(fh, nullptr);
+    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceCapacity nullptr output");
+    st = uGDSGetDeviceCapacity(nullptr, &device_capacity);
+    ASSERT_ERR(st, UGDS_INVALID_VALUE, "GetDeviceCapacity nullptr handle");
 
     // 3. Deregister and reject the stale handle
     uGDSHandleDeregister(fh);
-    st = uGDSGetDeviceSize(fh, &device_size);
-    ASSERT_ERR(st, UGDS_HANDLE_NOT_REGISTERED, "GetDeviceSize stale handle");
+    st = uGDSGetDeviceCapacity(fh, &device_capacity);
+    ASSERT_ERR(st, UGDS_HANDLE_NOT_REGISTERED,
+               "GetDeviceCapacity stale handle");
 
     // 4. Register again on the same fd (reuse after deregister)
     fh = nullptr;


### PR DESCRIPTION
# Expose NVMe namespace capacity for registered handles

## Summary

Add `uGDSGetDeviceSize()` to return the usable NVMe namespace capacity, in bytes, for a registered uGDS handle.

```c
uGDSError_t uGDSGetDeviceSize(
    uGDSHandle_t fh,
    uint64_t* size_bytes
);
```

This is an additive userspace API change. It does not change the kernel driver ABI or any existing I/O path.

## Motivation

LMCache can use a raw uGDS device as its L1 KV-cache slab. Unlike the regular file used by the cuFile and hipFile backends, a uGDS character device cannot use `posix_fallocate()` to reject a slab larger than the underlying NVMe namespace. LMCache therefore needs a supported way to query the capacity before issuing I/O.

Without this API, an oversized L1 configuration could only be detected after an out-of-range I/O reached the device. Exposing the capacity lets LMCache fail during initialization with a clear configuration error.

## Implementation

- Reuse the namespace information collected by `nvm_admin_ns_info()` during `uGDSHandleRegister()`; the API does not issue another Identify command. 
- Calculate the byte capacity as `NCAP * lba_data_size`.
- Reject null arguments, unregistered handles, zero capacity/block size, and multiplication overflow.
- Acquire the handle through `handle_lookup()` and release it through  `handle_release()`. This keeps the `HandleState` alive and participates in the existing in-flight accounting, so concurrent handle deregistration cannot tear down resources during the query.
- Extend `test_handle_register` to cover a successful non-zero query, null arguments, a stale handle, and successful deregistration after the query.

## LMCache integration

LMCache calls this API only for the uGDS backend. cuFile and hipFile keep their existing regular-file allocation behavior.

During uGDS initialization, LMCache:

1. Opens and registers the raw `/dev/ugds_drv*` device.
2. Calls `uGDSGetDeviceSize()` through its ctypes binding.
3. Compares the aligned L1 slab size with the returned capacity.
4. Rejects an oversized slab and deregisters the handle before any data I/O.

The integration was tested with:

- Device: Samsung SSD 990 PRO 1TB
- PCI address: `0000:0f:00.0`
- CUDA: 12.4
- Returned namespace capacity: `1,000,204,886,016` bytes

Observed LMCache results:

```text
BINDING_CAPACITY_BYTES=1000204886016
LMCACHE_64_MIB=ACCEPTED
LMCACHE_2_TIB=REJECTED: GDS L1 slab size (2199023255552 bytes) exceeds backing device capacity (1000204886016 bytes): /dev/ugds_drv0
```

The 64 MiB configuration initialized and closed successfully. The 2 TiB configuration was rejected during initialization, before an async handle could submit data I/O.

## Validation

The CUDA build, exported symbol, native functional test, and LMCache integration were validated as follows:

```bash
cmake -S . -B build \
  -DUGDS_BACKEND_CUDA=ON \
  -DUGDS_BACKEND_HIP=OFF \
  -DUGDS_ENABLE_RDMA=OFF \
  -DCUDAToolkit_ROOT=/usr/local/cuda
cmake --build build --target test_handle_register -j2
nm -D build/libugds.so | grep ' uGDSGetDeviceSize$'
LD_LIBRARY_PATH=build:$LD_LIBRARY_PATH \
  build/test_handle_register /dev/ugds_drv0 0
```

Results:

```text
000000000000a4a0 T uGDSGetDeviceSize
PASS
```

The hardware validation performed handle registration, capacity queries, and handle deregistration only; it did not issue read or write requests to the SSD.

## Compatibility

- Existing uGDS callers are unaffected.
- No kernel-module change is required.
- Consumers that call `uGDSGetDeviceSize()` must use a `libugds.so` containing
  this new symbol.
