### PR TITLE
[feat] Add external dma-buf registration API for Intel GPU support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(UGDS_SOURCES
     src/ugds_handle.cpp
     src/ugds_buf.cpp
     src/ugds_io.cpp
+    src/ugds_iov.cpp
     src/ugds_batch.cpp
     src/ugds_async.cpp
     src/ugds_rdma.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,10 +184,17 @@ if(UGDS_BACKEND_HIP)
     endif()
 endif()
 
-# UGDS_HAVE_DMABUF: unified dmabuf guard (HIP or CUDA-dmabuf)
+# UGDS_HAVE_DMABUF: unified dmabuf guard (HIP, CUDA-dmabuf, or external import)
 # Use PUBLIC so test targets linking against ugds also see the definition.
-if(UGDS_BACKEND_HIP OR (UGDS_BACKEND_CUDA AND HAVE_CUDA_DMABUF))
+option(UGDS_ENABLE_DMABUF_IMPORT "Enable uGDSBufRegisterDmabuf (external fd)" ON)
+
+if(UGDS_BACKEND_HIP OR (UGDS_BACKEND_CUDA AND HAVE_CUDA_DMABUF)
+   OR UGDS_ENABLE_DMABUF_IMPORT)
     target_compile_definitions(ugds PUBLIC UGDS_HAVE_DMABUF)
+endif()
+
+if(UGDS_ENABLE_DMABUF_IMPORT)
+    target_compile_definitions(ugds PRIVATE UGDS_ENABLE_DMABUF_IMPORT=1)
 endif()
 
 # RDMA support

--- a/drv/Makefile
+++ b/drv/Makefile
@@ -16,20 +16,8 @@ ifneq ($(KERNELRELEASE),)
 	obj-m := ugds_drv.o
 	ugds_drv-objs := pci.o list.o ctrl.o map.o irq.o
 
-	# KUnit self-test module (opt-in, HIP-only)
- ifeq ($(BUILD_KUNIT),1)
-  ifneq ($(BUILD_HIP),1)
-  $(error BUILD_KUNIT requires BUILD_HIP=1 -- SG flatten tests are HIP-only)
-  endif
-	obj-m += sg_flatten_test.o
-	sg_flatten_test-objs := test/sg_flatten_test.o
-	ccflags-y += -DUGDS_KUNIT
- endif
-
-	# AMD HIP backend (optional)
- ifeq ($(BUILD_HIP),1)
-	ccflags-y += -D_HIP
- endif
+	# Step 1: Resolve CUDA enablement and compute the aggregate dma-buf
+	# flag BEFORE any gate that depends on it.
 
 	# NVIDIA CUDA backend (optional)
 	# BUILD_CUDA: 1 = force enable, 0 = force disable, unset = auto (if NVIDIA_DIR found)
@@ -45,17 +33,10 @@ ifneq ($(KERNELRELEASE),)
   endif
  endif
 
-	# Error if neither backend is selected
- ifndef ENABLE_CUDA
- ifneq ($(BUILD_HIP),1)
-	$(error No GPU backend selected. Set BUILD_HIP=1 for AMD HIP, or install NVIDIA driver source for CUDA)
- endif
- endif
-
-	# dmabuf backend available when HIP is enabled, or when CUDA
-	# explicitly requests it via HAVE_CUDA_DMABUF=1.
+	# Compute aggregate dma-buf support. Available when HIP, standalone
+	# BUILD_DMABUF, or CUDA with HAVE_CUDA_DMABUF is enabled.
 UGDS_HAVE_DMABUF := 0
-ifeq ($(BUILD_HIP),1)
+ifneq ($(filter 1,$(BUILD_HIP) $(BUILD_DMABUF)),)
   UGDS_HAVE_DMABUF := 1
 endif
 ifdef HAVE_CUDA_DMABUF
@@ -63,6 +44,33 @@ ifdef HAVE_CUDA_DMABUF
     UGDS_HAVE_DMABUF := 1
   endif
 endif
+
+	# Step 2: Backend gate -- at least one of CUDA, HIP, or standalone
+	# dmabuf must be selected.
+ ifndef ENABLE_CUDA
+  ifneq ($(BUILD_HIP),1)
+   ifneq ($(BUILD_DMABUF),1)
+	$(error No backend selected. Set BUILD_HIP=1, BUILD_DMABUF=1, or install NVIDIA driver source for CUDA)
+   endif
+  endif
+ endif
+
+	# Step 3: KUnit gate -- requires dma-buf support.
+ ifeq ($(BUILD_KUNIT),1)
+  ifneq ($(UGDS_HAVE_DMABUF),1)
+  $(error BUILD_KUNIT requires dma-buf support -- enable BUILD_HIP=1, BUILD_DMABUF=1, or CUDA dmabuf)
+  endif
+	obj-m += sg_flatten_test.o
+	sg_flatten_test-objs := test/sg_flatten_test.o
+	ccflags-y += -DUGDS_KUNIT
+ endif
+
+	# Step 4: Compile definitions and objects.
+
+	# AMD HIP backend (optional)
+ ifeq ($(BUILD_HIP),1)
+	ccflags-y += -D_HIP
+ endif
 
 ifeq ($(UGDS_HAVE_DMABUF),1)
   ccflags-y += -DUGDS_HAVE_DMABUF

--- a/drv/ioctl.h
+++ b/drv/ioctl.h
@@ -42,6 +42,92 @@ struct nvm_ioctl_irq
     __s32  eventfd;           /* eventfd to signal on IRQ (register only) */
 };
 
+/* --- V2 dma-buf map ioctl -----------------------------------------
+ *
+ * Command 4 (NVM_MAP_DMABUF_MEMORY) is frozen for ABI compatibility.
+ * V2 is command 9 with a versioned, extensible struct that adds:
+ *   - UGDS_DMABUF_REQUIRE_P2P flag for strict peer-BAR enforcement
+ *   - mapping_class output (SYSTEM vs PEER_BAR)
+ *   - failure_reason for diagnostics
+ *   - peer device identification (domain/bus/devfn/bar)
+ *
+ * The kernel classifies the mapped SG addresses against PCI BAR
+ * windows of peer devices. When REQUIRE_P2P is set, any address
+ * that cannot be matched to a single peer device's memory BAR
+ * causes the mapping to fail with -EOPNOTSUPP before any DMA
+ * address is exposed to userspace.
+ */
+
+#define NVM_DMABUF_MAP_VERSION_1      1u
+#define UGDS_DMABUF_REQUIRE_P2P       (1u << 0)
+
+enum nvm_dmabuf_mapping_class {
+    NVM_DMABUF_MAPPING_UNKNOWN  = 0,
+    NVM_DMABUF_MAPPING_SYSTEM   = 1,
+    NVM_DMABUF_MAPPING_PEER_BAR = 2,
+};
+
+enum nvm_dmabuf_failure_reason {
+    NVM_DMABUF_FAIL_NONE          = 0,
+    NVM_DMABUF_FAIL_BAD_FD        = 1,
+    NVM_DMABUF_FAIL_NOT_DMABUF    = 2,
+    NVM_DMABUF_FAIL_RANGE         = 3,
+    NVM_DMABUF_FAIL_PIN           = 4,
+    NVM_DMABUF_FAIL_FENCE         = 5,
+    NVM_DMABUF_FAIL_MAP           = 6,
+    NVM_DMABUF_FAIL_SG_LAYOUT     = 7,
+    NVM_DMABUF_FAIL_NOT_PEER_BAR  = 8,
+    NVM_DMABUF_FAIL_PIN_LIMIT     = 9,
+};
+
+struct nvm_ioctl_dmabuf_v2 {
+    __u32  struct_size;          /* sizeof(struct nvm_ioctl_dmabuf_v2) */
+    __u16  version;              /* NVM_DMABUF_MAP_VERSION_1 */
+    __u16  flags;                /* UGDS_DMABUF_REQUIRE_P2P, etc. */
+
+    __u64  gpu_ptr;              /* Buffer VA -- ledger identity */
+    __s32  dmabuf_fd;            /* DMA-buf fd from exporter */
+    __u32  reserved0;            /* Must be zero */
+    __u64  dmabuf_offset;        /* Offset within dma-buf object */
+    __u64  size;                 /* Page-rounded map bytes */
+    __u64  ioaddrs_capacity;     /* Max entries in ioaddrs buffer */
+    __u64  ioaddrs;              /* Output: DMA bus addresses (__user) */
+
+    /* Output fields -- valid when kernel can classify the attempt */
+    __u32  mapping_class;        /* enum nvm_dmabuf_mapping_class */
+    __u32  failure_reason;       /* enum nvm_dmabuf_failure_reason */
+    __u16  peer_domain;          /* PCI domain of matched peer */
+    __u8   peer_bus;             /* PCI bus number */
+    __u8   peer_devfn;           /* PCI devfn */
+    __u32  peer_bar;             /* BAR index on peer device */
+    __u64  peer_bar_start;       /* Bus address of peer BAR */
+    __u64  peer_bar_length;      /* Length of peer BAR */
+    __u64  reserved[4];          /* Must be zero */
+};
+
+/* --- Capability query ioctl --------------------------------------- */
+
+#define NVM_CAPS_VERSION_1            1u
+
+#define NVM_CAP_DMABUF_V1             (1ull << 0)
+#define NVM_CAP_DMABUF_V2             (1ull << 1)
+#define NVM_CAP_DMABUF_REQUIRE_P2P    (1ull << 2)
+#define NVM_CAP_DMABUF_MAPPING_CLASS  (1ull << 3)
+#define NVM_CAP_DMABUF_PIN_ACCOUNTING (1ull << 4)
+
+struct nvm_ioctl_caps {
+    __u32  struct_size;                /* sizeof(struct nvm_ioctl_caps) */
+    __u16  version;                    /* NVM_CAPS_VERSION_1 */
+    __u16  kernel_uapi_version;        /* Highest V2 struct version understood */
+    __u64  flags;                      /* NVM_CAP_* bitmask */
+    __u64  max_dmabuf_map_bytes;       /* Per-map ceiling (1M pages * PAGE_SIZE) */
+    __u64  per_file_pin_limit_bytes;   /* Module parameter: per-file pin limit */
+    __u64  global_pin_limit_bytes;     /* Module parameter: global pin limit */
+    __u64  current_file_pinned_bytes;  /* This file context's current pin charge */
+    __u64  current_global_pinned_bytes;/* System-wide current pin charge */
+    __u64  reserved[4];                /* Must be zero */
+};
+
 enum nvm_ioctl_type
 {
     NVM_MAP_HOST_MEMORY         = _IOW(NVM_IOCTL_TYPE, 1, struct nvm_ioctl_map),
@@ -53,6 +139,8 @@ enum nvm_ioctl_type
     NVM_REGISTER_INTERRUPT      = _IOW(NVM_IOCTL_TYPE, 5, struct nvm_ioctl_irq),
     NVM_UNREGISTER_INTERRUPT    = _IOW(NVM_IOCTL_TYPE, 6, struct nvm_ioctl_irq),
     NVM_GET_NUM_VECTORS         = _IOR(NVM_IOCTL_TYPE, 7, __u32),
+    NVM_GET_CAPS                = _IOWR(NVM_IOCTL_TYPE, 8, struct nvm_ioctl_caps),
+    NVM_MAP_DMABUF_MEMORY_V2    = _IOWR(NVM_IOCTL_TYPE, 9, struct nvm_ioctl_dmabuf_v2),
 };
 
 #endif /* __linux__ */

--- a/drv/map.c
+++ b/drv/map.c
@@ -973,14 +973,17 @@ static bool ugds_range_in_bar(struct pci_dev* pdev, int bar,
 /*
  * Scan all PCI devices in the same domain as the importer (NVMe),
  * skipping the importer itself, and find the one whose memory BAR
- * contains the given address range. Returns a pci_dev reference
- * (held) or NULL.
+ * contains the given address range.
+ *
+ * Returns a pci_dev reference (held) or NULL. If more than one device
+ * matches (ambiguous ownership), returns NULL to fail closed.
  */
 static struct pci_dev* ugds_find_peer_bar_owner(struct pci_dev* importer,
                                                   u64 addr, u64 len,
                                                   int* matched_bar)
 {
     struct pci_dev* peer = NULL;
+    struct pci_dev* found = NULL;
     int bar;
 
     for_each_pci_dev(peer) {
@@ -991,12 +994,22 @@ static struct pci_dev* ugds_find_peer_bar_owner(struct pci_dev* importer,
 
         for (bar = 0; bar < PCI_STD_NUM_BARS; bar++) {
             if (ugds_range_in_bar(peer, bar, addr, len)) {
+                if (found) {
+                    /* Ambiguous: more than one device claims this
+                     * address range. Fail closed by dropping the
+                     * first reference and returning NULL. */
+                    pci_dev_put(found);
+                    return NULL;
+                }
                 *matched_bar = bar;
-                return peer;  /* for_each_pci_dev holds a reference */
+                found = peer;
+                /* Keep the for_each_pci_dev reference; continue
+                 * scanning to check for ambiguity. */
+                break;
             }
         }
     }
-    return NULL;
+    return found;
 }
 
 /*

--- a/drv/map.c
+++ b/drv/map.c
@@ -977,6 +977,10 @@ static bool ugds_range_in_bar(struct pci_dev* pdev, int bar,
  *
  * Returns a pci_dev reference (held) or NULL. If more than one device
  * matches (ambiguous ownership), returns NULL to fail closed.
+ *
+ * Implementation note: for_each_pci_dev automatically drops the reference
+ * on each iteration, so we must take an extra pci_dev_get() to keep the
+ * matched device alive beyond the loop.
  */
 static struct pci_dev* ugds_find_peer_bar_owner(struct pci_dev* importer,
                                                   u64 addr, u64 len,
@@ -996,15 +1000,14 @@ static struct pci_dev* ugds_find_peer_bar_owner(struct pci_dev* importer,
             if (ugds_range_in_bar(peer, bar, addr, len)) {
                 if (found) {
                     /* Ambiguous: more than one device claims this
-                     * address range. Fail closed by dropping the
-                     * first reference and returning NULL. */
+                     * address range. Fail closed. */
                     pci_dev_put(found);
                     return NULL;
                 }
                 *matched_bar = bar;
-                found = peer;
-                /* Keep the for_each_pci_dev reference; continue
-                 * scanning to check for ambiguity. */
+                /* Take an extra reference so the device survives
+                 * beyond the for_each_pci_dev loop body. */
+                found = pci_dev_get(peer);
                 break;
             }
         }
@@ -1223,11 +1226,12 @@ static int map_dmabuf_memory_v2(struct map* map, int dmabuf_fd,
                info->mapping_class, info->failure_reason);
         goto fail;
     }
-    /* Non-strict mode: classification may have set failure_reason to
-     * NOT_PEER_BAR even though the mapping is accepted. Clear it so
-     * the returned result is consistent with success. */
-    if (!err && info->failure_reason == NVM_DMABUF_FAIL_NOT_PEER_BAR) {
+    /* Non-strict mode: clear failure_reason if classification
+     * failed but we accept the mapping anyway. The caller gets
+     * mapping_class=SYSTEM with failure_reason=NONE. */
+    if (err && !(map_flags & UGDS_DMABUF_REQUIRE_P2P)) {
         info->failure_reason = NVM_DMABUF_FAIL_NONE;
+        err = 0;  /* non-strict accepts system memory */
     }
 
     /* Transfer peer device reference to dmabuf_region */
@@ -1263,6 +1267,10 @@ struct map* map_dmabuf_v2(const struct ctrl* ctrl,
 {
     int err;
     struct map* md;
+
+    /* Zero the entire info struct at entry so every early return
+     * path produces clean output for userspace. */
+    memset(info, 0, sizeof(*info));
 
     if (n_pages < 1) {
         info->mapping_class = NVM_DMABUF_MAPPING_UNKNOWN;

--- a/drv/map.c
+++ b/drv/map.c
@@ -583,6 +583,7 @@ struct dmabuf_region
     struct dma_buf*            dmabuf;
     struct dma_buf_attachment* attachment;
     struct sg_table*           sgt;
+    struct pci_dev*            peer_pdev;  /* matched peer device, or NULL */
 };
 
 
@@ -640,6 +641,8 @@ void release_dmabuf_memory(struct map* map)
             dma_buf_detach(dr->dmabuf, dr->attachment);
         if (dr->dmabuf != NULL)
             dma_buf_put(dr->dmabuf);
+        if (dr->peer_pdev != NULL)
+            pci_dev_put(dr->peer_pdev);
         kfree(dr);
         map->data = NULL;
     }
@@ -922,3 +925,343 @@ struct map* map_dmabuf(const struct ctrl* ctrl,
     return md;
 }
 #endif
+
+
+/* --- V2: P2P BAR verification and strict mapping ------------------- */
+
+#if defined(UGDS_HAVE_DMABUF)
+
+/*
+ * Check whether a DMA address range falls within a specific PCI BAR
+ * of the given device. The addresses returned by dma_buf_map_attachment
+ * are in the NVMe importer's bus DMA domain, which on direct-mapped
+ * platforms equals the PCI bus address space.
+ *
+ * Returns true if [addr, addr+len) is entirely within the BAR window.
+ */
+static bool ugds_range_in_bar(struct pci_dev* pdev, int bar,
+                               u64 addr, u64 len)
+{
+    u64 bar_start;
+    u64 bar_len;
+    u64 range_end;
+
+    if (!(pci_resource_flags(pdev, bar) & IORESOURCE_MEM))
+        return false;
+
+    bar_len = pci_resource_len(pdev, bar);
+    if (bar_len == 0 || len == 0)
+        return false;
+
+    /* Guard against overflow in addr + len */
+    if (check_add_overflow(addr, len - 1, &range_end))
+        return false;
+
+    bar_start = pci_bus_address(pdev, bar);
+
+    return addr >= bar_start && (range_end - bar_start) < bar_len;
+}
+
+/*
+ * Scan all PCI devices in the same domain as the importer (NVMe),
+ * skipping the importer itself, and find the one whose memory BAR
+ * contains the given address range. Returns a pci_dev reference
+ * (held) or NULL.
+ */
+static struct pci_dev* ugds_find_peer_bar_owner(struct pci_dev* importer,
+                                                  u64 addr, u64 len,
+                                                  int* matched_bar)
+{
+    struct pci_dev* peer = NULL;
+    int bar;
+
+    for_each_pci_dev(peer) {
+        if (peer == importer)
+            continue;
+        if (pci_domain_nr(peer->bus) != pci_domain_nr(importer->bus))
+            continue;
+
+        for (bar = 0; bar < PCI_STD_NUM_BARS; bar++) {
+            if (ugds_range_in_bar(peer, bar, addr, len)) {
+                *matched_bar = bar;
+                return peer;  /* for_each_pci_dev holds a reference */
+            }
+        }
+    }
+    return NULL;
+}
+
+/*
+ * Classify the flattened DMA address list against peer PCI BAR windows.
+ *
+ * Identifies whether all pages belong to a single peer device's memory
+ * BAR (PEER_BAR) or not (SYSTEM). When strict P2P is required, a
+ * non-PEER_BAR result causes the mapping to fail with -EOPNOTSUPP.
+ *
+ * On success (PEER_BAR), info->peer_pdev holds a referenced pci_dev
+ * that the caller transfers to dmabuf_region.
+ */
+static int ugds_classify_peer_bar(struct map* map,
+                                   unsigned long expected_pages,
+                                   struct ugds_dmabuf_map_info* info)
+{
+    struct pci_dev* peer;
+    unsigned long i;
+    int first_bar;
+
+    if (expected_pages == 0 || map->n_addrs == 0) {
+        info->mapping_class = NVM_DMABUF_MAPPING_SYSTEM;
+        info->failure_reason = NVM_DMABUF_FAIL_NOT_PEER_BAR;
+        return -EOPNOTSUPP;
+    }
+
+    /* Find the peer device that owns the first page */
+    peer = ugds_find_peer_bar_owner(map->pdev, map->addrs[0],
+                                     map->page_size, &first_bar);
+    if (peer == NULL)
+        goto not_peer;
+
+    /* Verify every subsequent page is in a BAR of the SAME device */
+    for (i = 1; i < expected_pages; i++) {
+        bool found = false;
+        int bar;
+
+        for (bar = 0; bar < PCI_STD_NUM_BARS; bar++) {
+            if (ugds_range_in_bar(peer, bar, map->addrs[i],
+                                   map->page_size)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            pci_dev_put(peer);
+            goto not_peer;
+        }
+    }
+
+    info->mapping_class = NVM_DMABUF_MAPPING_PEER_BAR;
+    info->failure_reason = NVM_DMABUF_FAIL_NONE;
+    info->peer_domain = pci_domain_nr(peer->bus);
+    info->peer_bus = peer->bus->number;
+    info->peer_devfn = peer->devfn;
+    info->peer_bar = first_bar;
+    info->peer_bar_start = pci_bus_address(peer, first_bar);
+    info->peer_bar_length = pci_resource_len(peer, first_bar);
+    info->peer_pdev = peer;
+    return 0;
+
+not_peer:
+    info->mapping_class = NVM_DMABUF_MAPPING_SYSTEM;
+    info->failure_reason = NVM_DMABUF_FAIL_NOT_PEER_BAR;
+    return -EOPNOTSUPP;
+}
+
+/*
+ * V2 map_dmabuf_memory: extends the V1 sequence with classification
+ * and strict P2P enforcement. The attach/pin/fence/map/flatten
+ * sequence is identical to V1; the new logic is purely post-flatten.
+ *
+ * Returns 0 on success with info populated. On failure, info contains
+ * the best-effort failure_reason and no addresses reach userspace.
+ */
+static int map_dmabuf_memory_v2(struct map* map, int dmabuf_fd,
+                                  u64 dmabuf_offset, unsigned long expected_pages,
+                                  size_t ioaddrs_capacity,
+                                  u16 map_flags,
+                                  struct ugds_dmabuf_map_info* info)
+{
+    struct dmabuf_region* dr;
+    unsigned long ctrl_page_size = PAGE_SIZE;
+    int err;
+    long fence_ret;
+
+    info->mapping_class = NVM_DMABUF_MAPPING_UNKNOWN;
+    info->failure_reason = NVM_DMABUF_FAIL_NONE;
+    info->peer_pdev = NULL;
+
+    if (expected_pages > ioaddrs_capacity) {
+        info->failure_reason = NVM_DMABUF_FAIL_RANGE;
+        return -EOVERFLOW;
+    }
+
+    dr = kmalloc(sizeof(struct dmabuf_region), GFP_KERNEL);
+    if (dr == NULL) {
+        printk(KERN_CRIT "uGDS: failed to allocate dmabuf region\n");
+        return -ENOMEM;
+    }
+    dr->dmabuf = NULL;
+    dr->attachment = NULL;
+    dr->sgt = NULL;
+    dr->peer_pdev = NULL;
+
+    dr->dmabuf = dma_buf_get(dmabuf_fd);
+    if (IS_ERR(dr->dmabuf)) {
+        err = PTR_ERR(dr->dmabuf);
+        if (err == -EBADF)
+            info->failure_reason = NVM_DMABUF_FAIL_BAD_FD;
+        else
+            info->failure_reason = NVM_DMABUF_FAIL_NOT_DMABUF;
+        kfree(dr);
+        return err;
+    }
+
+    /* Range check */
+    if (expected_pages > dr->dmabuf->size / ctrl_page_size ||
+        dmabuf_offset > dr->dmabuf->size - expected_pages * ctrl_page_size) {
+        printk(KERN_ERR "uGDS: requested range (%llu + %lu pages) "
+               "exceeds dma-buf size %zu\n",
+               (unsigned long long)dmabuf_offset, expected_pages,
+               dr->dmabuf->size);
+        info->failure_reason = NVM_DMABUF_FAIL_RANGE;
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return -EINVAL;
+    }
+
+    /* Attach with peer2peer enabled */
+    dr->attachment = dma_buf_dynamic_attach(dr->dmabuf, &map->pdev->dev,
+                                             &ugds_dmabuf_attach_ops, map);
+    if (IS_ERR(dr->attachment)) {
+        err = PTR_ERR(dr->attachment);
+        info->failure_reason = NVM_DMABUF_FAIL_MAP;
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return err;
+    }
+
+    /* Pin */
+    dma_resv_lock(dr->dmabuf->resv, NULL);
+    err = dma_buf_pin(dr->attachment);
+    if (!err) {
+        atomic_set(&map->invalid, 0);
+    }
+    dma_resv_unlock(dr->dmabuf->resv);
+    if (err) {
+        printk(KERN_ERR "uGDS: dma_buf_pin failed: %d\n", err);
+        info->failure_reason = NVM_DMABUF_FAIL_PIN;
+        dma_buf_detach(dr->dmabuf, dr->attachment);
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return err;
+    }
+
+    /* Wait for write fences, then map for DMA */
+    dma_resv_lock(dr->dmabuf->resv, NULL);
+    fence_ret = dma_resv_wait_timeout(dr->dmabuf->resv,
+                                       DMA_RESV_USAGE_WRITE, true,
+                                       msecs_to_jiffies(10000));
+    if (fence_ret == 0)
+        fence_ret = -ETIMEDOUT;
+    if (fence_ret < 0) {
+        dma_resv_unlock(dr->dmabuf->resv);
+        printk(KERN_ERR "uGDS: dma_resv_wait_timeout failed: %ld\n",
+               fence_ret);
+        info->failure_reason = NVM_DMABUF_FAIL_FENCE;
+        dma_resv_lock(dr->dmabuf->resv, NULL);
+        dma_buf_unpin(dr->attachment);
+        dma_resv_unlock(dr->dmabuf->resv);
+        dma_buf_detach(dr->dmabuf, dr->attachment);
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return fence_ret;
+    }
+    dr->sgt = dma_buf_map_attachment(dr->attachment, DMA_BIDIRECTIONAL);
+    dma_resv_unlock(dr->dmabuf->resv);
+    if (IS_ERR(dr->sgt)) {
+        err = PTR_ERR(dr->sgt);
+        info->failure_reason = NVM_DMABUF_FAIL_MAP;
+        dma_resv_lock(dr->dmabuf->resv, NULL);
+        dma_buf_unpin(dr->attachment);
+        dma_resv_unlock(dr->dmabuf->resv);
+        dma_buf_detach(dr->dmabuf, dr->attachment);
+        dma_buf_put(dr->dmabuf);
+        kfree(dr);
+        return err;
+    }
+
+    map->page_size = ctrl_page_size;
+    map->data = dr;
+    map->release = release_dmabuf_memory;
+
+    /* Flatten SG table */
+    err = sg_flatten_to_addrs(dr->sgt, map->addrs, expected_pages,
+                               ctrl_page_size, dmabuf_offset);
+    if (err) {
+        info->failure_reason = NVM_DMABUF_FAIL_SG_LAYOUT;
+        goto fail;
+    }
+
+    /* Classify: are these addresses peer-BAR or system memory? */
+    err = ugds_classify_peer_bar(map, expected_pages, info);
+    if (err && (map_flags & UGDS_DMABUF_REQUIRE_P2P)) {
+        /* Strict mode: reject non-P2P mappings */
+        printk(KERN_INFO "uGDS: strict P2P required but mapping "
+               "classified as %u (reason %u)\n",
+               info->mapping_class, info->failure_reason);
+        goto fail;
+    }
+
+    /* Transfer peer device reference to dmabuf_region */
+    if (info->peer_pdev) {
+        dr->peer_pdev = info->peer_pdev;
+        info->peer_pdev = NULL;
+    }
+
+    return 0;
+
+fail:
+    dma_resv_lock(dr->dmabuf->resv, NULL);
+    dma_buf_unmap_attachment(dr->attachment, dr->sgt, DMA_BIDIRECTIONAL);
+    dma_buf_unpin(dr->attachment);
+    dma_resv_unlock(dr->dmabuf->resv);
+    dma_buf_detach(dr->dmabuf, dr->attachment);
+    dma_buf_put(dr->dmabuf);
+    if (info->peer_pdev) {
+        pci_dev_put(info->peer_pdev);
+        info->peer_pdev = NULL;
+    }
+    kfree(dr);
+    map->data = NULL;
+    return err;
+}
+
+struct map* map_dmabuf_v2(const struct ctrl* ctrl,
+                           u64 gpu_ptr, int dmabuf_fd,
+                           u64 dmabuf_offset, unsigned long n_pages,
+                           size_t ioaddrs_capacity,
+                           u16 map_flags,
+                           struct ugds_dmabuf_map_info* info)
+{
+    int err;
+    struct map* md;
+
+    if (n_pages < 1) {
+        info->mapping_class = NVM_DMABUF_MAPPING_UNKNOWN;
+        info->failure_reason = NVM_DMABUF_FAIL_RANGE;
+        return ERR_PTR(-EINVAL);
+    }
+
+    md = create_descriptor(ctrl, gpu_ptr, n_pages);
+    if (IS_ERR(md)) {
+        info->mapping_class = NVM_DMABUF_MAPPING_UNKNOWN;
+        info->failure_reason = NVM_DMABUF_FAIL_NONE;
+        return md;
+    }
+
+    md->page_size = PAGE_SIZE;
+    err = map_dmabuf_memory_v2(md, dmabuf_fd, dmabuf_offset, n_pages,
+                                ioaddrs_capacity, map_flags, info);
+    if (err != 0) {
+        unmap_and_release(md);
+        return ERR_PTR(err);
+    }
+
+    printk(KERN_DEBUG "uGDS: V2 mapped %lu dmabuf pages at %llx "
+           "(class=%u, peer=%u:%u:%u.%u bar=%u)\n",
+           md->n_addrs, md->vaddr, info->mapping_class,
+           info->peer_domain, info->peer_bus,
+           PCI_SLOT(info->peer_devfn), PCI_FUNC(info->peer_devfn),
+           info->peer_bar);
+    return md;
+}
+#endif /* UGDS_HAVE_DMABUF */

--- a/drv/map.c
+++ b/drv/map.c
@@ -756,6 +756,14 @@ static int map_dmabuf_memory(struct map* map, int dmabuf_fd,
         return -ENOMEM;
     }
 
+    /* Initialize all fields so common teardown is safe regardless
+     * of which step fails. peer_pdev is V2-only but release_dmabuf_memory
+     * checks it unconditionally, so it must be NULL for V1 mappings. */
+    dr->dmabuf = NULL;
+    dr->attachment = NULL;
+    dr->sgt = NULL;
+    dr->peer_pdev = NULL;
+
     dr->dmabuf = dma_buf_get(dmabuf_fd);
     if (IS_ERR(dr->dmabuf))
     {
@@ -1075,9 +1083,11 @@ static int map_dmabuf_memory_v2(struct map* map, int dmabuf_fd,
     int err;
     long fence_ret;
 
+    /* Zero-initialize the entire struct so error-path copies to userspace
+     * never disclose uninitialized kernel stack data. */
+    memset(info, 0, sizeof(*info));
     info->mapping_class = NVM_DMABUF_MAPPING_UNKNOWN;
     info->failure_reason = NVM_DMABUF_FAIL_NONE;
-    info->peer_pdev = NULL;
 
     if (expected_pages > ioaddrs_capacity) {
         info->failure_reason = NVM_DMABUF_FAIL_RANGE;
@@ -1199,6 +1209,12 @@ static int map_dmabuf_memory_v2(struct map* map, int dmabuf_fd,
                "classified as %u (reason %u)\n",
                info->mapping_class, info->failure_reason);
         goto fail;
+    }
+    /* Non-strict mode: classification may have set failure_reason to
+     * NOT_PEER_BAR even though the mapping is accepted. Clear it so
+     * the returned result is consistent with success. */
+    if (!err && info->failure_reason == NVM_DMABUF_FAIL_NOT_PEER_BAR) {
+        info->failure_reason = NVM_DMABUF_FAIL_NONE;
     }
 
     /* Transfer peer device reference to dmabuf_region */

--- a/drv/map.h
+++ b/drv/map.h
@@ -72,7 +72,7 @@ struct map* map_device_memory(const struct ctrl* ctrl, u64 vaddr, unsigned long 
 #if defined(UGDS_HAVE_DMABUF)
 /*
  * Map GPU memory via standard Linux DMA-buf framework.
- * Used by AMD HIP/ROCm backend.
+ * Used by AMD HIP/ROCm backend and external dma-buf import.
  */
 struct map* map_dmabuf(const struct ctrl* ctrl,
                         u64 gpu_ptr, int dmabuf_fd,
@@ -94,6 +94,51 @@ int sg_flatten_to_addrs(struct sg_table* sgt, u64* addrs,
                         unsigned long expected_pages,
                         unsigned long ctrl_page_size,
                         u64 hsa_offset);
+#endif
+
+
+
+/* --- V2 dma-buf mapping with P2P verification ---------------------- */
+
+#include "ioctl.h"
+
+/*
+ * Result of a dma-buf mapping attempt. The kernel fills this before
+ * returning addresses to userspace. pci.c copies the relevant fields
+ * into the V2 ioctl output.
+ */
+struct ugds_dmabuf_map_info {
+    u32     mapping_class;      /* enum nvm_dmabuf_mapping_class */
+    u32     failure_reason;     /* enum nvm_dmabuf_failure_reason */
+    u16     peer_domain;
+    u8      peer_bus;
+    u8      peer_devfn;
+    u32     peer_bar;
+    u64     peer_bar_start;
+    u64     peer_bar_length;
+    struct pci_dev* peer_pdev;  /* referenced device, or NULL */
+};
+
+
+#if defined(UGDS_HAVE_DMABUF)
+/*
+ * Map a dma-buf with optional strict P2P enforcement.
+ *
+ * When map_flags has UGDS_DMABUF_REQUIRE_P2P set, every flattened
+ * DMA address must fall within a memory BAR of a single peer PCI
+ * device (other than the NVMe importer). If any address is in
+ * system memory or matches a different device, the function fails
+ * with -EOPNOTSUPP and no addresses are exposed.
+ *
+ * info is always populated with mapping_class and failure_reason
+ * so callers can report diagnostics even on failure.
+ */
+struct map* map_dmabuf_v2(const struct ctrl* ctrl,
+                           u64 gpu_ptr, int dmabuf_fd,
+                           u64 dmabuf_offset, unsigned long n_pages,
+                           size_t ioaddrs_capacity,
+                           u16 map_flags,
+                           struct ugds_dmabuf_map_info* info);
 #endif
 
 

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -281,8 +281,16 @@ static int dev_release(struct inode* inode, struct file* file)
     {
         list_del(&handle->node);
         unmap_and_release(handle->map);
+
+        /* Release pin accounting charge for V2 mappings */
+        if (handle->pinned_bytes > 0)
+        {
+            atomic64_sub(handle->pinned_bytes, &dmabuf_pinned_global);
+        }
+
         kfree(handle);
     }
+    ctx->dmabuf_pinned_bytes = 0;
     mutex_unlock(&ctx->lock);
 
     ctrl_put(ctx->ctrl);
@@ -500,6 +508,7 @@ static long do_map(struct ugds_file_ctx* ctx, enum handle_type type,
     handle->dmabuf_fd = dmabuf_fd;
     handle->dmabuf_offset = dmabuf_offset;
     handle->count = 1;
+    handle->pinned_bytes = 0;  /* V2 sets this; V1/host/CUDA stay zero */
     list_add(&handle->node, &ctx->handles);
 
 out:

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -91,14 +91,14 @@ static DEFINE_IDA(ctrl_ida);
 /* --- Pin accounting (V2 dma-buf) ----------------------------------- */
 static atomic64_t dmabuf_pinned_global = ATOMIC64_INIT(0);
 static int dmabuf_pin_limit_per_file_mb = 16384; /* 16 GiB default */
-module_param(dmabuf_pin_limit_per_file_mb, int, 0644);
+module_param(dmabuf_pin_limit_per_file_mb, int, 0444);
 MODULE_PARM_DESC(dmabuf_pin_limit_per_file_mb,
-    "Per-file dma-buf pin limit in MiB (0 = unlimited)");
+    "Per-file dma-buf pin limit in MiB (0 = unlimited, read-only after load)");
 
 static int dmabuf_pin_limit_global_mb = 65536; /* 64 GiB default */
-module_param(dmabuf_pin_limit_global_mb, int, 0644);
+module_param(dmabuf_pin_limit_global_mb, int, 0444);
 MODULE_PARM_DESC(dmabuf_pin_limit_global_mb,
-    "Global dma-buf pin limit in MiB (0 = unlimited)");
+    "Global dma-buf pin limit in MiB (0 = unlimited, read-only after load)");
 
 
 enum handle_type
@@ -774,6 +774,18 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             {
                 return -EINVAL;
             }
+            /* Reject nonzero reserved fields */
+            if (dreq.reserved0 != 0)
+            {
+                return -EINVAL;
+            }
+            {
+                int ri;
+                for (ri = 0; ri < 4; ri++) {
+                    if (dreq.reserved[ri] != 0)
+                        return -EINVAL;
+                }
+            }
 
             n_pages = dreq.size / PAGE_SIZE;
             if (n_pages > 1024 * 1024)
@@ -855,16 +867,6 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                 return -ENOMEM;
             }
 
-            if (copy_to_user((void __user*)(uintptr_t) dreq.ioaddrs,
-                              map->addrs, map->n_addrs * sizeof(uint64_t)))
-            {
-                kfree(handle);
-                unmap_and_release(map);
-                ctx->dmabuf_pinned_bytes -= pin_charge;
-                atomic64_sub(pin_charge, &dmabuf_pinned_global);
-                return -EFAULT;
-            }
-
             if (map_is_dead(HANDLE_DMABUF, map))
             {
                 kfree(handle);
@@ -913,12 +915,29 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             handle->n_pages = n_pages;
             handle->dmabuf_fd = dreq.dmabuf_fd;
             handle->dmabuf_offset = dreq.dmabuf_offset;
-            handle->count = 1;
             handle->pinned_bytes = pin_charge;
+
+            /* Copy addresses to user BEFORE committing to the ledger.
+             * If this fails we can still fully unwind. */
+            if (copy_to_user((void __user*)(uintptr_t) dreq.ioaddrs,
+                              map->addrs, map->n_addrs * sizeof(uint64_t)))
+            {
+                mutex_unlock(&ctx->lock);
+                kfree(handle);
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EFAULT;
+            }
+
             list_add(&handle->node, &ctx->handles);
             mutex_unlock(&ctx->lock);
 
-            /* Copy classification result to user */
+            /* Copy classification result to user after the mapping is
+             * committed. At this point the mapping is live; if the copy
+             * fails the mapping is valid but the user does not receive
+             * classification metadata. Log a warning since the caller
+             * has a valid mapping but incomplete result data. */
             dreq.mapping_class = info.mapping_class;
             dreq.failure_reason = info.failure_reason;
             dreq.peer_domain = info.peer_domain;
@@ -929,10 +948,8 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             dreq.peer_bar_length = info.peer_bar_length;
             if (copy_to_user((void __user*) arg, &dreq, sizeof(dreq)))
             {
-                /* Mapping is already committed; cannot unwind.
-                 * The ioctl return value signals partial success. */
                 printk(KERN_WARNING "uGDS: V2 result copy failed for "
-                       "mapping %llx (committed)\n", dreq.gpu_ptr);
+                       "mapping %llx (mapping is valid)\n", dreq.gpu_ptr);
             }
             return 0;
         }

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -793,24 +793,42 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
                 return -EINVAL;
             }
 
-            /* Pin accounting: charge before mapping */
-            pin_charge = dreq.size;
-            if (dmabuf_pin_limit_per_file_mb > 0 &&
-                ctx->dmabuf_pinned_bytes + pin_charge >
-                (u64)dmabuf_pin_limit_per_file_mb * 1024 * 1024)
-            {
-                return -EDQUOT;
+            /* Check ctx->dead under lock before proceeding. The map
+             * operation itself sleeps (dma_buf_pin, fence wait) so
+             * the lock is released during mapping; a hot-remove that
+             * sets ctx->dead concurrently will still be caught by
+             * the ledger commit section's dead re-check below. */
+            if (mutex_lock_killable(&ctx->lock))
+                return -EINTR;
+            if (ctx->dead) {
+                mutex_unlock(&ctx->lock);
+                return -ENODEV;
             }
+            mutex_unlock(&ctx->lock);
+
+            /* Pin accounting: charge before mapping.
+             * Validate limits are positive before multiplication to
+             * avoid overflow from negative module parameter values. */
+            pin_charge = dreq.size;
             {
-                u64 old, new_val;
-                u64 global_limit = (u64)dmabuf_pin_limit_global_mb * 1024 * 1024;
-                do {
-                    old = atomic64_read(&dmabuf_pinned_global);
-                    new_val = old + pin_charge;
-                    if (dmabuf_pin_limit_global_mb > 0 && new_val > global_limit)
+                u64 per_file_limit = 0;
+                u64 global_limit = 0;
+                if (dmabuf_pin_limit_per_file_mb > 0) {
+                    per_file_limit = (u64)dmabuf_pin_limit_per_file_mb * 1024ULL * 1024ULL;
+                    if (ctx->dmabuf_pinned_bytes + pin_charge > per_file_limit)
                         return -EDQUOT;
-                } while (atomic64_cmpxchg(&dmabuf_pinned_global,
-                                          old, new_val) != old);
+                }
+                if (dmabuf_pin_limit_global_mb > 0) {
+                    u64 old, new_val;
+                    global_limit = (u64)dmabuf_pin_limit_global_mb * 1024ULL * 1024ULL;
+                    do {
+                        old = atomic64_read(&dmabuf_pinned_global);
+                        new_val = old + pin_charge;
+                        if (new_val > global_limit)
+                            return -EDQUOT;
+                    } while (atomic64_cmpxchg(&dmabuf_pinned_global,
+                                              old, new_val) != old);
+                }
             }
             ctx->dmabuf_pinned_bytes += pin_charge;
 
@@ -915,6 +933,7 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             handle->n_pages = n_pages;
             handle->dmabuf_fd = dreq.dmabuf_fd;
             handle->dmabuf_offset = dreq.dmabuf_offset;
+            handle->count = 1;
             handle->pinned_bytes = pin_charge;
 
             /* Copy addresses to user BEFORE committing to the ledger.
@@ -1174,8 +1193,16 @@ static void remove_pci_dev(struct pci_dev* dev)
         {
             list_del(&handle->node);
             unmap_and_release(handle->map);
+
+            /* Refund pin accounting for V2 mappings */
+            if (handle->pinned_bytes > 0)
+            {
+                atomic64_sub(handle->pinned_bytes, &dmabuf_pinned_global);
+            }
+
             kfree(handle);
         }
+        ctx->dmabuf_pinned_bytes = 0;
         ctx->dead = true;
         mutex_unlock(&ctx->lock);
     }

--- a/drv/pci.c
+++ b/drv/pci.c
@@ -88,6 +88,18 @@ MODULE_PARM_DESC(max_num_ctrls, "Number of controller devices");
 /* Only the minor number is tracked; IDA is the ID-only allocator. */
 static DEFINE_IDA(ctrl_ida);
 
+/* --- Pin accounting (V2 dma-buf) ----------------------------------- */
+static atomic64_t dmabuf_pinned_global = ATOMIC64_INIT(0);
+static int dmabuf_pin_limit_per_file_mb = 16384; /* 16 GiB default */
+module_param(dmabuf_pin_limit_per_file_mb, int, 0644);
+MODULE_PARM_DESC(dmabuf_pin_limit_per_file_mb,
+    "Per-file dma-buf pin limit in MiB (0 = unlimited)");
+
+static int dmabuf_pin_limit_global_mb = 65536; /* 64 GiB default */
+module_param(dmabuf_pin_limit_global_mb, int, 0644);
+MODULE_PARM_DESC(dmabuf_pin_limit_global_mb,
+    "Global dma-buf pin limit in MiB (0 = unlimited)");
+
 
 enum handle_type
 {
@@ -110,6 +122,7 @@ struct ugds_file_ctx
     struct mutex        lock;           /* Protects handles and dead */
     bool                dead;           /* Controller removed */
     struct ugds_irq_owner irq_owner;
+    u64                 dmabuf_pinned_bytes; /* V2 pin accounting */
 };
 
 
@@ -130,6 +143,7 @@ struct map_handle
     int                 dmabuf_fd;      /* -1 unless HANDLE_DMABUF */
     u64                 dmabuf_offset;
     unsigned int        count;          /* Registrations from this file */
+    u64                 pinned_bytes;   /* V2 pin charge for this handle */
 };
 
 
@@ -225,6 +239,7 @@ static int dev_open(struct inode* inode, struct file* file)
     INIT_LIST_HEAD(&ctx->handles);
     mutex_init(&ctx->lock);
     ctx->dead = false;
+    ctx->dmabuf_pinned_bytes = 0;
     ugds_irq_owner_init(&ctx->irq_owner);
     file->private_data = ctx;
 
@@ -521,6 +536,14 @@ static long do_unmap(struct ugds_file_ctx* ctx, u64 vaddr)
     {
         list_del(&handle->node);
         unmap_and_release(handle->map);
+
+        /* Release pin accounting charge */
+        if (handle->pinned_bytes > 0)
+        {
+            ctx->dmabuf_pinned_bytes -= handle->pinned_bytes;
+            atomic64_sub(handle->pinned_bytes, &dmabuf_pinned_global);
+        }
+
         kfree(handle);
     }
 
@@ -655,6 +678,260 @@ static long map_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
             }
             return 0;
         }
+
+#if defined(UGDS_HAVE_DMABUF)
+        case NVM_GET_CAPS:
+        {
+            struct nvm_ioctl_caps caps;
+
+            if (copy_from_user(&caps, (void __user*) arg, sizeof(caps)))
+            {
+                return -EFAULT;
+            }
+
+            /* Validate version */
+            if (caps.version != NVM_CAPS_VERSION_1)
+            {
+                return -EPROTONOSUPPORT;
+            }
+
+            /* Build capability flags */
+            caps.kernel_uapi_version = NVM_DMABUF_MAP_VERSION_1;
+            caps.flags = 0;
+            caps.flags |= NVM_CAP_DMABUF_V1;
+            caps.flags |= NVM_CAP_DMABUF_V2;
+            caps.flags |= NVM_CAP_DMABUF_REQUIRE_P2P;
+            caps.flags |= NVM_CAP_DMABUF_MAPPING_CLASS;
+            caps.flags |= NVM_CAP_DMABUF_PIN_ACCOUNTING;
+
+            caps.max_dmabuf_map_bytes = (u64)1024 * 1024 * PAGE_SIZE;
+            caps.per_file_pin_limit_bytes = dmabuf_pin_limit_per_file_mb * 1024ULL * 1024;
+            caps.global_pin_limit_bytes = dmabuf_pin_limit_global_mb * 1024ULL * 1024;
+            caps.current_file_pinned_bytes = ctx->dmabuf_pinned_bytes;
+            caps.current_global_pinned_bytes = atomic64_read(&dmabuf_pinned_global);
+
+            if (copy_to_user((void __user*) arg, &caps, sizeof(caps)))
+            {
+                return -EFAULT;
+            }
+            return 0;
+        }
+
+        case NVM_MAP_DMABUF_MEMORY_V2:
+        {
+            struct nvm_ioctl_dmabuf_v2 dreq;
+            struct ugds_dmabuf_map_info info;
+            unsigned long n_pages;
+            struct map* map;
+            struct map_handle* handle;
+            u64 pin_charge;
+
+            if (copy_from_user(&dreq, (void __user*) arg, sizeof(dreq)))
+            {
+                return -EFAULT;
+            }
+
+            /* Validate V2 fields */
+            if (dreq.version != NVM_DMABUF_MAP_VERSION_1)
+            {
+                return -EPROTONOSUPPORT;
+            }
+            if (dreq.struct_size < sizeof(struct nvm_ioctl_dmabuf_v2))
+            {
+                return -EINVAL;
+            }
+            if (dreq.size == 0 || dreq.size % PAGE_SIZE != 0)
+            {
+                return -EINVAL;
+            }
+            if (dreq.gpu_ptr == 0 || dreq.gpu_ptr % PAGE_SIZE != 0)
+            {
+                return -EINVAL;
+            }
+            if (dreq.ioaddrs == 0 || dreq.ioaddrs_capacity == 0)
+            {
+                return -EINVAL;
+            }
+            if (dreq.dmabuf_offset != 0 && dreq.dmabuf_offset % PAGE_SIZE != 0)
+            {
+                return -EINVAL;
+            }
+            if (dreq.dmabuf_fd < 0)
+            {
+                return -EINVAL;
+            }
+            /* Reject unknown flag bits */
+            if (dreq.flags & ~UGDS_DMABUF_REQUIRE_P2P)
+            {
+                return -EINVAL;
+            }
+
+            n_pages = dreq.size / PAGE_SIZE;
+            if (n_pages > 1024 * 1024)
+            {
+                return -EINVAL;
+            }
+
+            /* Pin accounting: charge before mapping */
+            pin_charge = dreq.size;
+            if (dmabuf_pin_limit_per_file_mb > 0 &&
+                ctx->dmabuf_pinned_bytes + pin_charge >
+                (u64)dmabuf_pin_limit_per_file_mb * 1024 * 1024)
+            {
+                return -EDQUOT;
+            }
+            {
+                u64 old, new_val;
+                u64 global_limit = (u64)dmabuf_pin_limit_global_mb * 1024 * 1024;
+                do {
+                    old = atomic64_read(&dmabuf_pinned_global);
+                    new_val = old + pin_charge;
+                    if (dmabuf_pin_limit_global_mb > 0 && new_val > global_limit)
+                        return -EDQUOT;
+                } while (atomic64_cmpxchg(&dmabuf_pinned_global,
+                                          old, new_val) != old);
+            }
+            ctx->dmabuf_pinned_bytes += pin_charge;
+
+            /* Map with classification */
+            map = map_dmabuf_v2(ctx->ctrl, dreq.gpu_ptr,
+                                 dreq.dmabuf_fd, dreq.dmabuf_offset,
+                                 n_pages, dreq.ioaddrs_capacity,
+                                 dreq.flags, &info);
+
+            if (IS_ERR_OR_NULL(map))
+            {
+                long ret = (map == NULL) ? -EIO : PTR_ERR(map);
+
+                /* Rollback pin charge */
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+
+                /* Best-effort: copy classification info to user */
+                dreq.mapping_class = info.mapping_class;
+                dreq.failure_reason = info.failure_reason;
+                dreq.peer_domain = info.peer_domain;
+                dreq.peer_bus = info.peer_bus;
+                dreq.peer_devfn = info.peer_devfn;
+                dreq.peer_bar = info.peer_bar;
+                dreq.peer_bar_start = info.peer_bar_start;
+                dreq.peer_bar_length = info.peer_bar_length;
+                /* Ignore copy_to_user failure on error path */
+                copy_to_user((void __user*) arg, &dreq, sizeof(dreq));
+                return ret;
+            }
+
+            if (map_is_dead(HANDLE_DMABUF, map))
+            {
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EIO;
+            }
+
+            if (map->n_addrs > dreq.ioaddrs_capacity)
+            {
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EOVERFLOW;
+            }
+
+            handle = kmalloc(sizeof(*handle), GFP_KERNEL);
+            if (handle == NULL)
+            {
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -ENOMEM;
+            }
+
+            if (copy_to_user((void __user*)(uintptr_t) dreq.ioaddrs,
+                              map->addrs, map->n_addrs * sizeof(uint64_t)))
+            {
+                kfree(handle);
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EFAULT;
+            }
+
+            if (map_is_dead(HANDLE_DMABUF, map))
+            {
+                kfree(handle);
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EIO;
+            }
+
+            /* Commit to ledger */
+            if (mutex_lock_killable(&ctx->lock))
+            {
+                kfree(handle);
+                unmap_and_release(map);
+                ctx->dmabuf_pinned_bytes -= pin_charge;
+                atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                return -EINTR;
+            }
+            {
+                u64 page_sz = PAGE_SIZE;
+                u64 map_size;
+                if (check_mul_overflow((u64)n_pages, page_sz, &map_size))
+                {
+                    mutex_unlock(&ctx->lock);
+                    kfree(handle);
+                    unmap_and_release(map);
+                    ctx->dmabuf_pinned_bytes -= pin_charge;
+                    atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                    return -EINVAL;
+                }
+                if (handle_find_overlap(ctx, dreq.gpu_ptr, map_size) != NULL)
+                {
+                    mutex_unlock(&ctx->lock);
+                    kfree(handle);
+                    unmap_and_release(map);
+                    ctx->dmabuf_pinned_bytes -= pin_charge;
+                    atomic64_sub(pin_charge, &dmabuf_pinned_global);
+                    return -EEXIST;
+                }
+            }
+
+            handle->map = map;
+            handle->type = HANDLE_DMABUF;
+            handle->vaddr = dreq.gpu_ptr;
+            handle->size = (size_t)n_pages * PAGE_SIZE;
+            handle->n_pages = n_pages;
+            handle->dmabuf_fd = dreq.dmabuf_fd;
+            handle->dmabuf_offset = dreq.dmabuf_offset;
+            handle->count = 1;
+            handle->pinned_bytes = pin_charge;
+            list_add(&handle->node, &ctx->handles);
+            mutex_unlock(&ctx->lock);
+
+            /* Copy classification result to user */
+            dreq.mapping_class = info.mapping_class;
+            dreq.failure_reason = info.failure_reason;
+            dreq.peer_domain = info.peer_domain;
+            dreq.peer_bus = info.peer_bus;
+            dreq.peer_devfn = info.peer_devfn;
+            dreq.peer_bar = info.peer_bar;
+            dreq.peer_bar_start = info.peer_bar_start;
+            dreq.peer_bar_length = info.peer_bar_length;
+            if (copy_to_user((void __user*) arg, &dreq, sizeof(dreq)))
+            {
+                /* Mapping is already committed; cannot unwind.
+                 * The ioctl return value signals partial success. */
+                printk(KERN_WARNING "uGDS: V2 result copy failed for "
+                       "mapping %llx (committed)\n", dreq.gpu_ptr);
+            }
+            return 0;
+        }
+#else
+        case NVM_GET_CAPS:
+        case NVM_MAP_DMABUF_MEMORY_V2:
+            return -EOPNOTSUPP;
+#endif
 
         default:
             printk(KERN_NOTICE "Unknown ioctl command from process %d: %u\n",

--- a/include/libnvm/nvm_dma.h
+++ b/include/libnvm/nvm_dma.h
@@ -92,6 +92,39 @@ int nvm_dma_map_device(nvm_dma_t** map, const nvm_ctrl_t* ctrl, void* devptr, si
 #define NVM_MAP_FORCE_CUDA  0x4    /* Force CUDA path (skip auto-probe) */
 int nvm_dma_map_device_ex(nvm_dma_t** map, const nvm_ctrl_t* ctrl, void* devptr, size_t size, int flags);
 
+/*
+ * Map an external application-exported dma-buf fd for the controller.
+ * The fd is duplicated (F_DUPFD_CLOEXEC) so uGDS owns the duplicate.
+ * Uses the V1 NVM_MAP_DMABUF_MEMORY ioctl (cmd 4).
+ *
+ * Only available when UGDS_HAVE_DMABUF is defined (HIP, CUDA dmabuf,
+ * or external import build).
+ */
+#if defined(UGDS_HAVE_DMABUF)
+int nvm_dma_map_dmabuf_fd(nvm_dma_t** handle, const nvm_ctrl_t* ctrl,
+                           void* devptr, size_t size,
+                           int dmabuf_fd, uint64_t dmabuf_offset);
+
+/* Forward declaration for the V2 struct (defined in internal/ioctl.h,
+ * but we avoid pulling it into the public header to keep the ABI clean).
+ * Callers that need the V2 result struct include internal/ioctl.h or
+ * the kernel mirror header directly. */
+struct nvm_ioctl_dmabuf_v2;
+
+/*
+ * Map an external dma-buf fd using the V2 ioctl with classification.
+ * Issues NVM_MAP_DMABUF_MEMORY_V2 (cmd 9) with flags and receives
+ * the kernel classification output in *result.
+ *
+ * Only available when UGDS_HAVE_DMABUF is defined.
+ */
+int nvm_dma_map_dmabuf_v2(nvm_dma_t** handle, const nvm_ctrl_t* ctrl,
+                           void* devptr, size_t size,
+                           int dmabuf_fd, uint64_t dmabuf_offset,
+                           uint16_t flags,
+                           struct nvm_ioctl_dmabuf_v2* result);
+#endif /* UGDS_HAVE_DMABUF */
+
 /* (nvm_dma_get_dmabuf_info is internal-only -- declared in internal/dma.h) */
 
 //#endif /* __CUDA__ */

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -121,16 +121,28 @@ typedef struct uGDSDescr_t {
 
 typedef void* uGDSHandle_t;
 
+/* Open the uGDS driver: discover the NVMe controller and initialize
+ * the global driver state.  Must be called once before any other API.
+ * Returns UGDS_OK or an error if the controller cannot be opened. */
 uGDSError_t uGDSDriverOpen(void);
 
+/* Close the driver and release controller resources.  All handles and
+ * buffers should be deregistered first. */
 uGDSError_t uGDSDriverClose(void);
 
+/* Register a file/Windows handle obtained from the user as a uGDS
+ * handle.  'descr' describes the underlying OS handle type (opaque fd
+ * on Linux, opaque handle on Windows, userspace FS).  The returned
+ * *fh is the opaque handle used by all IO entry points. */
 uGDSError_t uGDSHandleRegister(uGDSHandle_t* fh, uGDSDescr_t* descr);
 
 /* Return the usable NVMe namespace capacity in bytes for a registered handle. */
 uGDSError_t uGDSGetDeviceCapacity(uGDSHandle_t fh,
                                   uint64_t* capacity_bytes);
 
+/* Deregister a handle (non-blocking, equivalent to DeregisterEx with
+ * timeout_sec == -1).  Blocks until all in-flight operations on this
+ * handle have drained. */
 void uGDSHandleDeregister(uGDSHandle_t fh);
 
 /* Deregister a handle with a drain timeout.
@@ -151,6 +163,11 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * API may use it. The caller must have already reset the controller. */
 uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
 
+/* Register a device/host buffer for direct IO.  'bufPtr_base' is the
+ * exact base pointer of the allocation; 'length' is in bytes.  'flags'
+ * may include UGDS_REGISTER_DMABUF to use the AMD HIP/dma-buf path.
+ * The registration creates the dma mapping used by subsequent IO calls;
+ * it must be released by uGDSBufDeregister. */
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 
 /* Flag for uGDSBufRegister: use AMD HIP/dma-buf path */
@@ -162,6 +179,9 @@ uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);
 #define NVM_MAP_RDMA        0x2    /* Retain dmabuf fd for RDMA use */
 #define NVM_MAP_FORCE_CUDA  0x4    /* Force CUDA path (skip auto-probe) */
 
+/* Release a buffer registration previously created by uGDSBufRegister
+ * or uGDSBufRegisterEx.  Blocks until all in-flight IO on this buffer
+ * has drained; returns UGDS_BUSY if the drain cannot complete. */
 uGDSError_t uGDSBufDeregister(const void* bufPtr_base);
 
 /* Backend identifier for dual-backend dispatch. */
@@ -177,6 +197,10 @@ typedef struct uGDSBufConfig {
     bool            enable_export;
 } uGDSBufConfig_t;
 
+/* Register a device/host buffer with an explicit backend selection
+ * (CUDA or HIP) and optional dma-buf export flag.  In dual-backend
+ * builds the backend drives async launch dispatch; in single-backend
+ * builds it is validated against the compiled-in backend. */
 uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,
                                const uGDSBufConfig_t* config);
 
@@ -188,6 +212,11 @@ typedef struct uGDSDmabufExport {
     size_t    length;
 } uGDSDmabufExport_t;
 
+/* Export a dma-buf file descriptor for a registered buffer so it can
+ * be registered with an RDMA NIC via ibv_reg_dmabuf_mr().  'out->fd'
+ * is dup()'d -- the caller owns it and MUST close() it after use.
+ * Requires the buffer to have been registered with NVM_MAP_RDMA at
+ * uGDSBufRegister time. */
 uGDSError_t uGDSExportDmabuf(const void* bufPtr_base,
                               uGDSDmabufExport_t* out);
 
@@ -215,9 +244,17 @@ uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
 uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
                                 uGDSRDMARegion_t* region);
 
+/* Synchronous read from the namespace into a registered device buffer.
+ * 'bufPtr_base' must have been registered via uGDSBufRegister/
+ * uGDSBufRegisterEx (exact value); 'bufPtr_offset' is the byte offset
+ * inside that registration.  'size' must be a multiple of the namespace
+ * block size and bounded by the controller MDTS.  Returns the number of
+ * bytes read, or -errno on failure. */
 ssize_t uGDSRead(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                    off_t file_offset, off_t bufPtr_offset);
 
+/* Synchronous write to the namespace from a registered device buffer.
+ * Argument and return conventions match uGDSRead. */
 ssize_t uGDSWrite(uGDSHandle_t fh, const void* bufPtr_base, size_t size,
                     off_t file_offset, off_t bufPtr_offset);
 
@@ -254,16 +291,36 @@ typedef struct uGDSIOEvents {
     ssize_t             ret;
 } uGDSIOEvents_t;
 
+/* Create a batch IO context bound to 'fh' with capacity for 'nr'
+ * entries.  Allocates the batch's private submission/completion
+ * resources and a dedicated QP (UGDS_BATCH_QUEUE_DEPTH).  The handle
+ * is pinned for the lifetime of the batch via an internal shared_ptr.
+ * Only one batch may be active per handle at a time; a second SetUp
+ * returns UGDS_BUSY. */
 uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch, uGDSHandle_t fh,
                                unsigned nr);
 
+/* Submit up to 'nr' plain (single-buffer) IO entries.  Each iocb[k]
+ * describes a single devPtr_base/file_offset/size transfer.  Entries
+ * are appended to the batch ring; completions are reaped via
+ * uGDSBatchIOGetStatus.  Vectored entries may be mixed on the same
+ * batch via uGDSBatchIOSubmitv. */
 uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                                uGDSIOParams_t* iocb, unsigned flags);
 
+/* Reap completions.  Blocks until at least 'min_nr' entries have
+ * completed or 'timeout' elapses, then copies up to *nr events into
+ * 'events'.  On return *nr holds the number actually reaped (0 on
+ * timeout).  Events may be returned in any order. */
 uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
                                   unsigned* nr, uGDSIOEvents_t* events,
                                   struct timespec* timeout);
 
+/* Destroy the batch context.  Drains in-flight commands under a
+ * bounded timeout.  If the drain fails the handle is wedged and the
+ * batch transitions to WEDGED; the caller must reset the controller
+ * and then call uGDSHandleDeregisterEx with timeout_sec < -1 to force
+ * teardown. */
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
 /* -- Vectored (scatter-gather) IO -- */
@@ -274,34 +331,52 @@ void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
  * multiple of the controller page size (MPS).  'size' must be a
  * multiple of the namespace block size and non-zero.  offset + size
  * must not exceed the length passed at registration (the exact byte
- * length, not a page-rounded value). */
+ * length, not a page-rounded value).
+ *
+ * The registration invariants enforced at acquire time are:
+ *   - registered-range bound on offset + size
+ *   - controller affinity between the buffer and the submitting handle */
 typedef struct uGDSIoSegment {
-    void*   base;
-    off_t   offset;
-    size_t  size;
+    void*   base;     /* registered buffer base (exact registry key) */
+    off_t   offset;   /* byte offset inside base; must be MPS-aligned */
+    size_t  size;     /* transfer size in bytes; must be block-multiple */
 } uGDSIoSegment_t;
 
-#define UGDS_IOV_MAX        1024   /* sync/async: POSIX IOV_MAX parity */
-#define UGDS_BATCH_IOV_MAX  128    /* per batch entry (bounds arena) */
+/* Maximum number of segments per sync/async vectored call.
+ * Mirrors POSIX IOV_MAX so callers can reuse existing iov sizing. */
+#define UGDS_IOV_MAX        1024
 
-/* Vectored read/write.  Segments are consumed in array order:
- * segs[0] maps to [file_offset, file_offset + segs[0].size), etc.
- * Returns total bytes transferred, or -errno (same convention as
- * uGDSRead/uGDSWrite).  The segment array is fully consumed during
- * the call (synchronous); the caller may free/reuse it on return.
- * (Implementation in Phase 1.) */
+/* Maximum number of segments per vectored batch entry.  Bounds the
+ * arena allocation: capacity * UGDS_BATCH_IOV_MAX SegView slots are
+ * reserved once per batch object lifetime. */
+#define UGDS_BATCH_IOV_MAX  128
+
+/* Vectored read.  Segments are consumed in array order: segs[0] maps
+ * to [file_offset, file_offset + segs[0].size), segs[1] continues at
+ * file_offset + segs[0].size, and so on.  Returns total bytes read, or
+ * -errno (same convention as uGDSRead/uGDSWrite).
+ *
+ * The segment array is fully consumed during the call (synchronous);
+ * the caller may free/reuse it on return.
+ *
+ * Validation is performed up-front under g_driver.lock (exact-length
+ * bound, controller affinity check, MPS alignment of offset,
+ * block-multiple of size, overflow-safe total).  On timeout the handle
+ * is marked wedged and -EIO is returned; a controller reset is then
+ * required before the handle can be reused. */
 ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                     unsigned nr_segs, off_t file_offset);
 
+/* Vectored write.  Layout and error conventions match uGDSReadv. */
 ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                      unsigned nr_segs, off_t file_offset);
 
 /* Vectored batch IO.  Because uGDSIOParams_t has no mode/union/reserved
  * field, SGL batch entries use this new params struct and submit function;
  * setup/status/destroy are shared with the existing batch object.
+ *
  * 'segs' is copied at submit, so the caller may free iocb and the arrays
- * on return -- parity with uGDSBatchIOSubmit.
- * (Implementation in Phase 2.) */
+ * on return -- parity with uGDSBatchIOSubmit. */
 typedef struct uGDSIOSegParams {
     const uGDSIoSegment_t* segs;      /* copied at submit */
     unsigned               nr_segs;   /* <= UGDS_BATCH_IOV_MAX */
@@ -310,13 +385,19 @@ typedef struct uGDSIOSegParams {
     void*                  cookie;
 } uGDSIOSegParams_t;
 
-/* Same semantics as uGDSBatchIOSubmit: entries join the batch created
- * by uGDSBatchIOSetUp; completions are reaped via uGDSBatchIOGetStatus.
- * Plain and vectored submits may be mixed on the same batch handle. */
+/* Submit vectored (scatter-gather) batch entries.  Same semantics as
+ * uGDSBatchIOSubmit: entries join the batch created by uGDSBatchIOSetUp;
+ * completions are reaped via uGDSBatchIOGetStatus.  Plain and vectored
+ * submits may be mixed on the same batch handle.
+ *
+ * Per-entry validation follows the value matrix (alignment, sizes,
+ * overflow-safe total) and the analytic window counter.  Preflight
+ * failures become terminal FAILED entries with -EINVAL and contribute
+ * zero commands to the work array. */
 uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
                                  uGDSIOSegParams_t* iocb, unsigned flags);
 
-/* Vectored async IO on a CUDA/HIP stream.
+/* Vectored async read on a CUDA/HIP stream.
  * Binding contract (mirrors uGDSReadAsync late binding):
  *   - segs (the array pointer) and nr_segs are fixed at enqueue.
  *   - segs[i].base is read at enqueue (validation + in-flight refs)
@@ -324,11 +405,17 @@ uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
  *   - segs[i].offset, segs[i].size and *file_offset_p are read in the
  *     stream callback (late binding).  The segs array must remain
  *     valid until the callback runs.
- * (Implementation in Phase 3.) */
+ *
+ * *bytes_read_p is pre-zeroed at enqueue. On validation or launch
+ *     failure the return value remains zero and the error is returned
+ *     via the uGDSError_t return code. On success the callback writes
+ *     the byte count (or -errno on runtime failure) exactly once. */
 uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                              unsigned nr_segs, off_t* file_offset_p,
                              ssize_t* bytes_read_p, void* stream);
 
+/* Vectored async write on a CUDA/HIP stream.  Binding contract and
+ * lifecycle match uGDSReadvAsync. */
 uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                               unsigned nr_segs, off_t* file_offset_p,
                               ssize_t* bytes_written_p, void* stream);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -68,6 +68,17 @@ typedef enum uGDSOpError {
     UGDS_RDMA_MR_STILL_ACTIVE        = UGDS_BASE_ERR + 41,
     UGDS_BUSY                        = UGDS_BASE_ERR + 42,
     UGDS_OUT_OF_MEMORY               = UGDS_BASE_ERR + 43,
+    UGDS_BAD_FILE_DESCRIPTOR         = UGDS_BASE_ERR + 44,
+    UGDS_DMABUF_INVALID_FD           = UGDS_BASE_ERR + 45,
+    UGDS_DMABUF_NOT_P2P              = UGDS_BASE_ERR + 46,
+    UGDS_FD_LIMIT_REACHED            = UGDS_BASE_ERR + 47,
+    UGDS_INTERRUPTED                 = UGDS_BASE_ERR + 48,
+    UGDS_DEVICE_LOST                 = UGDS_BASE_ERR + 49,
+    UGDS_INVALID_USER_ADDRESS        = UGDS_BASE_ERR + 50,
+    UGDS_ASYNC_QUEUE_FULL            = UGDS_BASE_ERR + 51,
+    UGDS_PIN_LIMIT_EXCEEDED          = UGDS_BASE_ERR + 53,
+    UGDS_TIMED_OUT                   = UGDS_BASE_ERR + 54,
+    UGDS_STRUCT_VERSION_MISMATCH     = UGDS_BASE_ERR + 55,
 } uGDSOpError;
 
 static inline const char* uGDS_status_error(uGDSOpError status) {
@@ -93,6 +104,17 @@ static inline const char* uGDS_status_error(uGDSOpError status) {
     case UGDS_BUSY:                        return "resource busy, retry";
     case UGDS_RDMA_MR_STILL_ACTIVE:       return "RDMA MR still active";
     case UGDS_OUT_OF_MEMORY:               return "out of memory";
+    case UGDS_BAD_FILE_DESCRIPTOR:         return "bad file descriptor";
+    case UGDS_DMABUF_INVALID_FD:           return "invalid dma-buf file descriptor";
+    case UGDS_DMABUF_NOT_P2P:              return "dma-buf is not PCIe peer BAR";
+    case UGDS_FD_LIMIT_REACHED:            return "file descriptor limit reached";
+    case UGDS_INTERRUPTED:                 return "operation interrupted";
+    case UGDS_DEVICE_LOST:                 return "device lost";
+    case UGDS_INVALID_USER_ADDRESS:        return "invalid user address";
+    case UGDS_ASYNC_QUEUE_FULL:            return "async queue full";
+    case UGDS_PIN_LIMIT_EXCEEDED:          return "pin limit exceeded";
+    case UGDS_TIMED_OUT:                   return "operation timed out";
+    case UGDS_STRUCT_VERSION_MISMATCH:     return "struct version mismatch";
     default:                                  return "unknown uGDS error";
     }
 }
@@ -189,6 +211,7 @@ typedef enum uGDSBackend {
     UGDS_BACKEND_DEFAULT = 0,
     UGDS_BACKEND_CUDA    = 1,
     UGDS_BACKEND_HIP     = 2,
+    UGDS_BACKEND_EXTERNAL = 3,
 } uGDSBackend_t;
 
 /* Extended buffer registration with backend selection and export flag */
@@ -243,6 +266,55 @@ uGDSError_t uGDSRDMARegister(const void* bufPtr_base,
 
 uGDSError_t uGDSRDMAUnregister(const void* bufPtr_base,
                                 uGDSRDMARegion_t* region);
+
+/* --- External dma-buf registration ----------------------------------- */
+
+/* Versioned parameter structure for external dma-buf registration.
+ * All reserved fields must be zero. */
+#define UGDS_DMABUF_REG_PARAMS_VERSION_1 1u
+#define UGDS_DMABUF_REQUIRE_P2P          (1u << 0)
+
+typedef struct uGDSDmabufRegParams {
+    uint32_t struct_size;       /* sizeof(uGDSDmabufRegParams_t) */
+    uint16_t version;           /* UGDS_DMABUF_REG_PARAMS_VERSION_1 */
+    uint16_t reserved0;         /* must be zero */
+    int32_t  dmabuf_fd;         /* application-owned dma-buf fd */
+    uint32_t flags;             /* UGDS_DMABUF_* */
+    uint64_t dmabuf_offset;     /* buffer VA - allocation base */
+    uint64_t reserved[4];       /* must be zero */
+} uGDSDmabufRegParams_t;
+
+/* Register an externally exported dma-buf fd for direct NVMe P2P DMA.
+ *
+ * The caller exports GPU memory as a dma-buf fd (e.g. via Intel Level
+ * Zero zeMemGetAllocProperties) and passes it here.  uGDS duplicates
+ * the fd (F_DUPFD_CLOEXEC) so the caller may close the original fd
+ * after this call returns.
+ *
+ * With UGDS_DMABUF_REQUIRE_P2P, the kernel verifies that every mapped
+ * page falls within a single PCI peer device's memory BAR; failure
+ * returns UGDS_DMABUF_NOT_P2P.
+ *
+ * The buffer is tagged UGDS_BACKEND_EXTERNAL: it has no implicit
+ * stream launch backend.  Async stream I/O on an external buffer
+ * requires a stream explicitly registered as CUDA or HIP.
+ *
+ * bufPtr_base is the GPU virtual address of the allocation base.
+ * length is the exact byte count (not page-rounded). */
+uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base, size_t length,
+                                    const uGDSDmabufRegParams_t* params);
+
+/* Capability query for dma-buf support.  Combines compile-time library
+ * support with kernel-side V2/strict-P2P/pin-accounting capabilities.
+ * Zero-initialize the struct before calling. */
+typedef struct uGDSDmabufCaps {
+    bool lib_dmabuf;            /* UGDS_HAVE_DMABUF compiled in */
+    bool kmod_dmabuf_v2;        /* kernel supports V2 ioctl */
+    bool kmod_require_p2p;      /* kernel supports UGDS_DMABUF_REQUIRE_P2P */
+    bool kmod_pin_accounting;   /* kernel enforces pin limits */
+} uGDSDmabufCaps_t;
+
+uGDSError_t uGDSQueryDmabufSupport(uGDSDmabufCaps_t* caps);
 
 /* Synchronous read from the namespace into a registered device buffer.
  * 'bufPtr_base' must have been registered via uGDSBufRegister/

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -140,8 +140,15 @@ void uGDSHandleDeregister(uGDSHandle_t fh);
  * timeout_sec == -1 means infinite wait (equivalent to uGDSHandleDeregister).
  * timeout_sec < -1 means after-reset teardown: release resources retained
  * by timed-out I/O, skip wedged/in-flight checks, and free all resources.
- * The caller must guarantee that no NVMe command is still executing (e.g.
- * after a controller reset). */
+ *
+ * Force contract (timeout_sec < -1): before calling this function the
+ * caller MUST quiesce ALL host API calls and callbacks associated with
+ * this handle -- not only NVMe commands, but every uGDSRead/uGDSWrite,
+ * uGDSReadv/uGDSWritev, batch, and async operation that has passed
+ * handle_lookup, plus every async callback already enqueued on a
+ * stream. No such call may execute or resume concurrently with force
+ * teardown. After force returns, the handle is fully invalid and no
+ * API may use it. The caller must have already reset the controller. */
 uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec);
 
 uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags);

--- a/include/ugds.h
+++ b/include/ugds.h
@@ -259,6 +259,73 @@ uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch, unsigned min_nr,
 
 void uGDSBatchIODestroy(uGDSBatchHandle_t batch);
 
+/* -- Vectored (scatter-gather) IO -- */
+
+/* One scatter-gather segment. 'base' must be a pointer previously
+ * registered via uGDSBufRegister/uGDSBufRegisterEx (exact value).
+ * 'offset' is a byte offset inside that registration and must be a
+ * multiple of the controller page size (MPS).  'size' must be a
+ * multiple of the namespace block size and non-zero.  offset + size
+ * must not exceed the length passed at registration (the exact byte
+ * length, not a page-rounded value). */
+typedef struct uGDSIoSegment {
+    void*   base;
+    off_t   offset;
+    size_t  size;
+} uGDSIoSegment_t;
+
+#define UGDS_IOV_MAX        1024   /* sync/async: POSIX IOV_MAX parity */
+#define UGDS_BATCH_IOV_MAX  128    /* per batch entry (bounds arena) */
+
+/* Vectored read/write.  Segments are consumed in array order:
+ * segs[0] maps to [file_offset, file_offset + segs[0].size), etc.
+ * Returns total bytes transferred, or -errno (same convention as
+ * uGDSRead/uGDSWrite).  The segment array is fully consumed during
+ * the call (synchronous); the caller may free/reuse it on return.
+ * (Implementation in Phase 1.) */
+ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                    unsigned nr_segs, off_t file_offset);
+
+ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                     unsigned nr_segs, off_t file_offset);
+
+/* Vectored batch IO.  Because uGDSIOParams_t has no mode/union/reserved
+ * field, SGL batch entries use this new params struct and submit function;
+ * setup/status/destroy are shared with the existing batch object.
+ * 'segs' is copied at submit, so the caller may free iocb and the arrays
+ * on return -- parity with uGDSBatchIOSubmit.
+ * (Implementation in Phase 2.) */
+typedef struct uGDSIOSegParams {
+    const uGDSIoSegment_t* segs;      /* copied at submit */
+    unsigned               nr_segs;   /* <= UGDS_BATCH_IOV_MAX */
+    off_t                  file_offset;
+    uGDSOpcode_t           opcode;
+    void*                  cookie;
+} uGDSIOSegParams_t;
+
+/* Same semantics as uGDSBatchIOSubmit: entries join the batch created
+ * by uGDSBatchIOSetUp; completions are reaped via uGDSBatchIOGetStatus.
+ * Plain and vectored submits may be mixed on the same batch handle. */
+uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
+                                 uGDSIOSegParams_t* iocb, unsigned flags);
+
+/* Vectored async IO on a CUDA/HIP stream.
+ * Binding contract (mirrors uGDSReadAsync late binding):
+ *   - segs (the array pointer) and nr_segs are fixed at enqueue.
+ *   - segs[i].base is read at enqueue (validation + in-flight refs)
+ *     and MUST NOT change afterwards.
+ *   - segs[i].offset, segs[i].size and *file_offset_p are read in the
+ *     stream callback (late binding).  The segs array must remain
+ *     valid until the callback runs.
+ * (Implementation in Phase 3.) */
+uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                             unsigned nr_segs, off_t* file_offset_p,
+                             ssize_t* bytes_read_p, void* stream);
+
+uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                              unsigned nr_segs, off_t* file_offset_p,
+                              ssize_t* bytes_written_p, void* stream);
+
 /* -- Async Stream IO --
  * Pointer params (size_p, file_offset_p, etc.) must be host-accessible.
  * Use cudaHostAlloc/hipHostMalloc for GPU-writable pinned memory (late binding).

--- a/src/libnvm/dma.cpp
+++ b/src/libnvm/dma.cpp
@@ -40,10 +40,12 @@ struct map
     uint64_t            dmabuf_offset;   /* 0 if not dmabuf */
     size_t              dmabuf_length;   /* 0 if not dmabuf */
 
-    /* Backend origin tag: true if mapping went through the HIP/dmabuf
-     * path (regardless of whether fd was retained). Used by dual-backend
-     * dispatch to select the correct async launch function. */
-    bool                hip_origin;
+    /* Backend origin tag: typed enum identifying whether the mapping
+     * went through the HIP, CUDA, or external fd path (regardless of
+     * whether the fd was retained). Used by dual-backend dispatch to
+     * select the correct async launch function and by uGDSBufRegister
+     * to choose the registration backend. */
+    enum nvm_dmabuf_origin dmabuf_origin;
 };
 
 
@@ -114,7 +116,7 @@ static int create_map(struct map** md, const nvm_ctrl_t* ctrl, struct va_range* 
     m->dmabuf_fd = -1;
     m->dmabuf_offset = 0;
     m->dmabuf_length = 0;
-    m->hip_origin = false;
+    m->dmabuf_origin = NVM_DMABUF_ORIGIN_NONE;
 
     *md = m;
     return 0;
@@ -521,17 +523,17 @@ int nvm_dma_get_dmabuf_info(const nvm_dma_t* handle,
     return 0;
 }
 
-bool nvm_dma_is_hip_origin(const nvm_dma_t* handle)
+enum nvm_dmabuf_origin nvm_dma_origin(const nvm_dma_t* handle)
 {
-    if (handle == NULL) return false;
+    if (handle == NULL) return NVM_DMABUF_ORIGIN_NONE;
     const struct container* c = _nvm_container_of(handle, struct container, handle);
-    return c->map->hip_origin;
+    return c->map->dmabuf_origin;
 }
 
-void _nvm_dma_set_hip_origin(nvm_dma_t* handle)
+void _nvm_dma_set_origin(nvm_dma_t* handle, enum nvm_dmabuf_origin origin)
 {
     if (handle == NULL) return;
     struct container* c = _nvm_container_of(handle, struct container, handle);
-    c->map->hip_origin = true;
+    c->map->dmabuf_origin = origin;
 }
 

--- a/src/libnvm/internal/dma.h
+++ b/src/libnvm/internal/dma.h
@@ -11,6 +11,22 @@
 struct va_range;
 
 
+/*
+ * dma-buf origin tagging.
+ *
+ * Replaces the former bool hip_origin with a typed enum so that
+ * external (application-exported) dma-buf mappings can be
+ * distinguished from HIP and CUDA exports.  The origin is used by
+ * dual-backend dispatch and by uGDSBufRegister to pick the correct
+ * launch backend.
+ */
+enum nvm_dmabuf_origin {
+    NVM_DMABUF_ORIGIN_NONE     = 0,
+    NVM_DMABUF_ORIGIN_HIP      = 1,
+    NVM_DMABUF_ORIGIN_CUDA     = 2,
+    NVM_DMABUF_ORIGIN_EXTERNAL = 3,
+};
+
 
 /*
  * Callback type for freeing an address range descriptor.
@@ -62,11 +78,17 @@ int _nvm_dma_set_dmabuf_info(nvm_dma_t* handle,
                               int fd, uint64_t offset, size_t length);
 
 /*
- * Tag a DMA handle as originating from the HIP/dmabuf path.
- * Called after _nvm_dma_init for HIP mappings, regardless of
- * whether the dmabuf fd was retained or closed.
+ * Set the dma-buf origin on a DMA handle's internal map.
+ * Called after _nvm_dma_init for HIP, CUDA, or external mappings.
  */
-void _nvm_dma_set_hip_origin(nvm_dma_t* handle);
+void _nvm_dma_set_origin(nvm_dma_t* handle, enum nvm_dmabuf_origin origin);
+
+/*
+ * Retrieve the dma-buf origin of a DMA handle.
+ * Used by dual-backend dispatch to select the correct async launch
+ * and by uGDSBufRegister to choose the registration backend.
+ */
+enum nvm_dmabuf_origin nvm_dma_origin(const nvm_dma_t* handle);
 
 /*
  * Retrieve dmabuf metadata from a DMA handle (internal only).
@@ -76,11 +98,20 @@ void _nvm_dma_set_hip_origin(nvm_dma_t* handle);
 int nvm_dma_get_dmabuf_info(const nvm_dma_t* handle,
                              int* out_fd, uint64_t* out_offset, size_t* out_length);
 
-/*
- * Query whether a DMA handle was created through the HIP/dmabuf path.
- * Returns true even if the fd was closed after kernel import.
- * Used by dual-backend dispatch to select the correct async launch.
- */
-bool nvm_dma_is_hip_origin(const nvm_dma_t* handle);
+/* --- Backward-compatibility inline shims -------------------------------
+ *
+ * Existing HIP code calls _nvm_dma_set_hip_origin / nvm_dma_is_hip_origin.
+ * These inline shims forward to the new origin-based API so that
+ * existing callers compile without modification. */
+
+static inline void _nvm_dma_set_hip_origin(nvm_dma_t* handle)
+{
+    _nvm_dma_set_origin(handle, NVM_DMABUF_ORIGIN_HIP);
+}
+
+static inline bool nvm_dma_is_hip_origin(const nvm_dma_t* handle)
+{
+    return nvm_dma_origin(handle) == NVM_DMABUF_ORIGIN_HIP;
+}
 
 #endif /* __NVM_INTERNAL_DMA_H__ */

--- a/src/libnvm/internal/ioctl.h
+++ b/src/libnvm/internal/ioctl.h
@@ -40,6 +40,75 @@ struct nvm_ioctl_irq
 };
 
 
+/* --- V2 dma-buf map ioctl (mirrors drv/ioctl.h) ------------------- */
+
+#define NVM_DMABUF_MAP_VERSION_1      1u
+#define UGDS_DMABUF_REQUIRE_P2P       (1u << 0)
+
+enum nvm_dmabuf_mapping_class {
+    NVM_DMABUF_MAPPING_UNKNOWN  = 0,
+    NVM_DMABUF_MAPPING_SYSTEM   = 1,
+    NVM_DMABUF_MAPPING_PEER_BAR = 2,
+};
+
+enum nvm_dmabuf_failure_reason {
+    NVM_DMABUF_FAIL_NONE          = 0,
+    NVM_DMABUF_FAIL_BAD_FD        = 1,
+    NVM_DMABUF_FAIL_NOT_DMABUF    = 2,
+    NVM_DMABUF_FAIL_RANGE         = 3,
+    NVM_DMABUF_FAIL_PIN           = 4,
+    NVM_DMABUF_FAIL_FENCE         = 5,
+    NVM_DMABUF_FAIL_MAP           = 6,
+    NVM_DMABUF_FAIL_SG_LAYOUT     = 7,
+    NVM_DMABUF_FAIL_NOT_PEER_BAR  = 8,
+    NVM_DMABUF_FAIL_PIN_LIMIT     = 9,
+};
+
+struct nvm_ioctl_dmabuf_v2 {
+    __u32  struct_size;
+    __u16  version;
+    __u16  flags;
+    __u64  gpu_ptr;
+    __s32  dmabuf_fd;
+    __u32  reserved0;
+    __u64  dmabuf_offset;
+    __u64  size;
+    __u64  ioaddrs_capacity;
+    __u64  ioaddrs;
+    __u32  mapping_class;
+    __u32  failure_reason;
+    __u16  peer_domain;
+    __u8   peer_bus;
+    __u8   peer_devfn;
+    __u32  peer_bar;
+    __u64  peer_bar_start;
+    __u64  peer_bar_length;
+    __u64  reserved[4];
+};
+
+/* --- Capability query ioctl (mirrors drv/ioctl.h) ----------------- */
+
+#define NVM_CAPS_VERSION_1            1u
+
+#define NVM_CAP_DMABUF_V1             (1ull << 0)
+#define NVM_CAP_DMABUF_V2             (1ull << 1)
+#define NVM_CAP_DMABUF_REQUIRE_P2P    (1ull << 2)
+#define NVM_CAP_DMABUF_MAPPING_CLASS  (1ull << 3)
+#define NVM_CAP_DMABUF_PIN_ACCOUNTING (1ull << 4)
+
+struct nvm_ioctl_caps {
+    __u32  struct_size;
+    __u16  version;
+    __u16  kernel_uapi_version;
+    __u64  flags;
+    __u64  max_dmabuf_map_bytes;
+    __u64  per_file_pin_limit_bytes;
+    __u64  global_pin_limit_bytes;
+    __u64  current_file_pinned_bytes;
+    __u64  current_global_pinned_bytes;
+    __u64  reserved[4];
+};
+
 
 /* Supported operations */
 enum nvm_ioctl_type
@@ -51,6 +120,8 @@ enum nvm_ioctl_type
     NVM_REGISTER_INTERRUPT      = _IOW(NVM_IOCTL_TYPE, 5, struct nvm_ioctl_irq),
     NVM_UNREGISTER_INTERRUPT    = _IOW(NVM_IOCTL_TYPE, 6, struct nvm_ioctl_irq),
     NVM_GET_NUM_VECTORS         = _IOR(NVM_IOCTL_TYPE, 7, __u32),
+    NVM_GET_CAPS                = _IOWR(NVM_IOCTL_TYPE, 8, struct nvm_ioctl_caps),
+    NVM_MAP_DMABUF_MEMORY_V2    = _IOWR(NVM_IOCTL_TYPE, 9, struct nvm_ioctl_dmabuf_v2),
 };
 
 

--- a/src/libnvm/internal/map.h
+++ b/src/libnvm/internal/map.h
@@ -2,6 +2,7 @@
 #define __NVM_INTERNAL_LINUX_MAP_H__
 #ifdef __linux__
 
+#include <stdint.h>
 #include "internal/ioctl.h"
 #include "internal/dma.h"
 
@@ -15,7 +16,8 @@ enum mapping_type
     MAP_TYPE_HOST        =   0x2,
     MAP_TYPE_API         =   0x4,
     MAP_TYPE_DMABUF      =   0x8,
-    MAP_TYPE_DMABUF_CUDA =   0x10
+    MAP_TYPE_DMABUF_CUDA =   0x10,
+    MAP_TYPE_DMABUF_EXT  =   0x20
 };
 
 typedef int (*dmabuf_close_fn)(int fd);
@@ -36,7 +38,31 @@ struct ioctl_mapping
 
     bool                retain_fd;
     dmabuf_close_fn     close_fn;
+
+    /* V2 dma-buf ioctl parameters (MAP_TYPE_DMABUF_EXT only).
+     * When v2_flags is non-zero, linux_device.cpp issues
+     * NVM_MAP_DMABUF_MEMORY_V2 instead of the V1 ioctl, and
+     * v2_result receives the kernel classification output. */
+    uint16_t                    v2_flags;
+    struct nvm_ioctl_dmabuf_v2* v2_result;
 };
+
+
+/*
+ * Issue the V2 dma-buf map ioctl directly on the controller fd.
+ * Defined in linux_device.cpp; called by linux_dma.cpp for the
+ * external dma-buf import path that needs classification output.
+ * Returns 0 on success or a positive errno.
+ */
+int _nvm_dmabuf_ioctl_v2(const nvm_ctrl_t* ctrl,
+                          struct nvm_ioctl_dmabuf_v2* req);
+
+/*
+ * Issue the NVM_GET_CAPS ioctl directly on the controller fd.
+ * Returns 0 on success or a positive errno.
+ */
+int _nvm_dmabuf_get_caps(const nvm_ctrl_t* ctrl,
+                          struct nvm_ioctl_caps* caps);
 
 
 #endif /* __linux__ */

--- a/src/libnvm/linux_device.cpp
+++ b/src/libnvm/linux_device.cpp
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -69,9 +70,11 @@ static int ioctl_map(const struct device* dev, const struct va_range* va, uint64
         case MAP_TYPE_DMABUF_CUDA:
         case MAP_TYPE_DMABUF_EXT:
         {
-            /* External dmabuf with V2 flags: use the V2 ioctl path
-             * for strict P2P classification. */
-            if (m->type == MAP_TYPE_DMABUF_EXT && m->v2_flags != 0)
+            /* External dmabuf (MAP_TYPE_DMABUF_EXT) always uses the V2
+             * ioctl for pin accounting and mapping classification.
+             * HIP (MAP_TYPE_DMABUF) and CUDA (MAP_TYPE_DMABUF_CUDA)
+             * continue to use the V1 ioctl. */
+            if (m->type == MAP_TYPE_DMABUF_EXT)
             {
                 struct nvm_ioctl_dmabuf_v2 v2req;
                 memset(&v2req, 0, sizeof(v2req));

--- a/src/libnvm/linux_device.cpp
+++ b/src/libnvm/linux_device.cpp
@@ -67,10 +67,45 @@ static int ioctl_map(const struct device* dev, const struct va_range* va, uint64
 #if defined(UGDS_HAVE_DMABUF)
         case MAP_TYPE_DMABUF:
         case MAP_TYPE_DMABUF_CUDA:
+        case MAP_TYPE_DMABUF_EXT:
         {
-            /* DMA-buf path: pass fd + offset + gpu_ptr to kernel.
-             * Both HIP (MAP_TYPE_DMABUF) and CUDA (MAP_TYPE_DMABUF_CUDA)
-             * go through the same NVM_MAP_DMABUF_MEMORY ioctl. */
+            /* External dmabuf with V2 flags: use the V2 ioctl path
+             * for strict P2P classification. */
+            if (m->type == MAP_TYPE_DMABUF_EXT && m->v2_flags != 0)
+            {
+                struct nvm_ioctl_dmabuf_v2 v2req;
+                memset(&v2req, 0, sizeof(v2req));
+                v2req.struct_size      = sizeof(v2req);
+                v2req.version          = NVM_DMABUF_MAP_VERSION_1;
+                v2req.flags            = m->v2_flags;
+                v2req.gpu_ptr          = (uint64_t) m->buffer;
+                v2req.dmabuf_fd        = m->dmabuf_fd;
+                v2req.dmabuf_offset    = m->dmabuf_offset;
+                v2req.size             = (uint64_t)(va->page_size * va->n_pages);
+                v2req.ioaddrs_capacity = (uint64_t)va->n_pages;
+                v2req.ioaddrs          = (uint64_t)(uintptr_t)ioaddrs;
+
+                int v2err = ioctl(dev->fd, NVM_MAP_DMABUF_MEMORY_V2, &v2req);
+                if (v2err < 0)
+                {
+                    dprintf("DMA-buf V2 kernel request failed: %s\n",
+                            strerror(errno));
+                    /* Copy partial classification output so the caller
+                     * can translate the errno precisely. */
+                    if (m->v2_result != NULL)
+                        memcpy(m->v2_result, &v2req, sizeof(v2req));
+                    return errno;
+                }
+                /* Copy classification output to the caller's result */
+                if (m->v2_result != NULL)
+                    memcpy(m->v2_result, &v2req, sizeof(v2req));
+                return 0;
+            }
+
+            /* V1 DMA-buf path: pass fd + offset + gpu_ptr to kernel.
+             * HIP (MAP_TYPE_DMABUF), CUDA (MAP_TYPE_DMABUF_CUDA),
+             * and external without V2 flags (MAP_TYPE_DMABUF_EXT) all
+             * go through NVM_MAP_DMABUF_MEMORY (cmd 4). */
             struct nvm_ioctl_dmabuf request = {
                 .gpu_ptr          = (uint64_t) m->buffer,
                 .dmabuf_fd        = m->dmabuf_fd,
@@ -129,6 +164,61 @@ static void ioctl_unmap(const struct device* dev, const struct va_range* va)
         dprintf("Page unmapping kernel request failed: %s\n", strerror(errno));
     }
 }
+
+
+#if defined(UGDS_HAVE_DMABUF)
+/*
+ * Issue the V2 dma-buf map ioctl directly on the controller's device fd.
+ *
+ * This bypasses the map_range callback because the V2 ioctl uses a
+ * different struct size and produces classification output that the V1
+ * path cannot carry.  The caller (linux_dma.cpp) builds the full V2
+ * request including flags and an output result pointer; this helper
+ * only performs the ioctl on the already-opened fd.
+ *
+ * Returns 0 on success or a positive errno.
+ */
+int _nvm_dmabuf_ioctl_v2(const nvm_ctrl_t* ctrl,
+                          struct nvm_ioctl_dmabuf_v2* req)
+{
+    if (ctrl == NULL || req == NULL)
+        return EINVAL;
+
+    struct controller* c = _nvm_container_of(ctrl, struct controller, handle);
+    struct device* dev = c->device;
+
+    int err = ioctl(dev->fd, NVM_MAP_DMABUF_MEMORY_V2, req);
+    if (err < 0)
+    {
+        dprintf("DMA-buf V2 kernel request failed: %s\n", strerror(errno));
+        return errno;
+    }
+    return 0;
+}
+
+
+/*
+ * Issue the NVM_GET_CAPS ioctl directly on the controller's device fd.
+ * Returns 0 on success or a positive errno.
+ */
+int _nvm_dmabuf_get_caps(const nvm_ctrl_t* ctrl,
+                          struct nvm_ioctl_caps* caps)
+{
+    if (ctrl == NULL || caps == NULL)
+        return EINVAL;
+
+    struct controller* c = _nvm_container_of(ctrl, struct controller, handle);
+    struct device* dev = c->device;
+
+    int err = ioctl(dev->fd, NVM_GET_CAPS, caps);
+    if (err < 0)
+    {
+        dprintf("GET_CAPS kernel request failed: %s\n", strerror(errno));
+        return errno;
+    }
+    return 0;
+}
+#endif /* UGDS_HAVE_DMABUF */
 
 
 

--- a/src/libnvm/linux_dma.cpp
+++ b/src/libnvm/linux_dma.cpp
@@ -88,6 +88,8 @@ static int create_mapping_descriptor(struct ioctl_mapping** handle, size_t page_
     md->dmabuf_offset = 0;
     md->retain_fd = false;
     md->close_fn = NULL;
+    md->v2_flags = 0;
+    md->v2_result = NULL;
 
     *handle = md;
     return 0;
@@ -651,3 +653,244 @@ int nvm_dma_map_device(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devptr,
 {
     return nvm_dma_map_device_ex(handle, ctrl, devptr, size, 0);
 }
+
+
+#if defined(UGDS_HAVE_DMABUF)
+/*
+ * Map an external application-exported dma-buf fd for the controller.
+ *
+ * The caller passes a dma-buf fd obtained from a GPU runtime export
+ * (e.g. Intel Level Zero zeMemGetAllocProperties, or any producer that
+ * exposes dma_buf).  This function duplicates the fd with
+ * F_DUPFD_CLOEXEC so that uGDS owns the duplicate independently of the
+ * caller's fd lifetime.  The mapping descriptor retains the fd and
+ * closes it via posix_close_adapter at teardown.
+ *
+ * Parameters:
+ *   handle        - output DMA handle
+ *   ctrl          - controller handle
+ *   devptr        - the GPU virtual address (base of the export)
+ *   size          - buffer size in bytes
+ *   dmabuf_fd     - application-owned dma-buf fd (not consumed; uGDS dups it)
+ *   dmabuf_offset - offset within the dma-buf allocation
+ *
+ * Returns 0 on success, or a positive errno on failure.
+ */
+int nvm_dma_map_dmabuf_fd(nvm_dma_t** handle, const nvm_ctrl_t* ctrl,
+                           void* devptr, size_t size,
+                           int dmabuf_fd, uint64_t dmabuf_offset)
+{
+    struct ioctl_mapping* md = NULL;
+    *handle = NULL;
+
+    if (_nvm_ctrl_type(ctrl) != DEVICE_TYPE_IOCTL)
+    {
+        return EBADF;
+    }
+
+    /* Validate arguments */
+    if (size == 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: size must be non-zero\n");
+        return EINVAL;
+    }
+    if (dmabuf_fd < 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: invalid dmabuf_fd %d\n", dmabuf_fd);
+        return EBADF;
+    }
+
+    /* Use host page size for alignment validation and mapping */
+    long hps = sysconf(_SC_PAGESIZE);
+    if (hps <= 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: sysconf(_SC_PAGESIZE) failed\n");
+        return EINVAL;
+    }
+
+    /* Validate page alignment of devptr */
+    if (((uintptr_t)devptr % (size_t)hps) != 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: devptr %p not page-aligned (%ld)\n",
+                devptr, hps);
+        return EINVAL;
+    }
+
+    /* Validate page alignment of dmabuf_offset */
+    if ((dmabuf_offset % (uint64_t)hps) != 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: dmabuf_offset %llu not page-aligned\n",
+                (unsigned long long)dmabuf_offset);
+        return EINVAL;
+    }
+
+    /* Duplicate the fd so uGDS owns it independently of the caller.
+     * F_DUPFD_CLOEXEC prevents the duplicate from leaking across exec. */
+    int dup_fd = fcntl(dmabuf_fd, F_DUPFD_CLOEXEC, 0);
+    if (dup_fd < 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_fd: F_DUPFD_CLOEXEC failed: %s\n",
+                strerror(errno));
+        return errno;
+    }
+
+    /* Create the external dmabuf mapping descriptor.
+     * The fd is retained and closed via posix_close_adapter at teardown. */
+    int err = create_mapping_descriptor(&md, (size_t)hps,
+                                         MAP_TYPE_DMABUF_EXT, devptr, size);
+    if (err != 0)
+    {
+        close(dup_fd);
+        return err;
+    }
+
+    md->dmabuf_fd = dup_fd;
+    md->dmabuf_offset = dmabuf_offset;
+    md->retain_fd = true;
+    md->close_fn = posix_close_adapter;
+
+    /* Initialize the DMA handle via the standard path.
+     * This calls map_range -> ioctl_map which issues the V1
+     * NVM_MAP_DMABUF_MEMORY ioctl. */
+    err = _nvm_dma_init(handle, ctrl, &md->range, &release_mapping_descriptor);
+    if (err != 0)
+    {
+        /* _nvm_dma_init failure: remove_mapping_descriptor will close
+         * the retained dup_fd via posix_close_adapter. */
+        remove_mapping_descriptor(md);
+        return err;
+    }
+
+    /* Tag as external origin for dual-backend dispatch */
+    _nvm_dma_set_origin(*handle, NVM_DMABUF_ORIGIN_EXTERNAL);
+
+    /* Set dmabuf metadata for re-export (RDMA path) */
+    _nvm_dma_set_dmabuf_info(*handle, dup_fd, dmabuf_offset, size);
+
+    return 0;
+}
+
+
+/*
+ * Map an external dma-buf fd using the V2 ioctl with classification.
+ *
+ * This variant issues NVM_MAP_DMABUF_MEMORY_V2 (cmd 9) instead of the
+ * V1 ioctl (cmd 4).  The V2 ioctl accepts a flags field (currently
+ * UGDS_DMABUF_REQUIRE_P2P for strict PCIe peer-BAR verification) and
+ * returns mapping classification output in *result.
+ *
+ * The strict no-fallback rule: when UGDS_DMABUF_REQUIRE_P2P is set and
+ * the kernel reports that the mapping is not a peer BAR, this function
+ * fails and does not fall back to V1.
+ *
+ * Parameters:
+ *   handle        - output DMA handle
+ *   ctrl          - controller handle
+ *   devptr        - the GPU virtual address (base of the export)
+ *   size          - buffer size in bytes
+ *   dmabuf_fd     - application-owned dma-buf fd (uGDS dups it)
+ *   dmabuf_offset - offset within the dma-buf allocation
+ *   flags         - V2 flags (e.g. UGDS_DMABUF_REQUIRE_P2P)
+ *   result        - output: kernel classification (mapping_class,
+ *                   failure_reason, peer BAR info)
+ *
+ * Returns 0 on success, or a positive errno on failure.
+ */
+int nvm_dma_map_dmabuf_v2(nvm_dma_t** handle, const nvm_ctrl_t* ctrl,
+                           void* devptr, size_t size,
+                           int dmabuf_fd, uint64_t dmabuf_offset,
+                           uint16_t flags,
+                           struct nvm_ioctl_dmabuf_v2* result)
+{
+    struct ioctl_mapping* md = NULL;
+    *handle = NULL;
+
+    if (_nvm_ctrl_type(ctrl) != DEVICE_TYPE_IOCTL)
+    {
+        return EBADF;
+    }
+
+    if (size == 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: size must be non-zero\n");
+        return EINVAL;
+    }
+    if (dmabuf_fd < 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: invalid dmabuf_fd %d\n", dmabuf_fd);
+        return EBADF;
+    }
+    if (result == NULL)
+    {
+        return EINVAL;
+    }
+
+    long hps = sysconf(_SC_PAGESIZE);
+    if (hps <= 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: sysconf(_SC_PAGESIZE) failed\n");
+        return EINVAL;
+    }
+
+    if (((uintptr_t)devptr % (size_t)hps) != 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: devptr %p not page-aligned\n", devptr);
+        return EINVAL;
+    }
+    if ((dmabuf_offset % (uint64_t)hps) != 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: dmabuf_offset not page-aligned\n");
+        return EINVAL;
+    }
+
+    /* Duplicate the fd so uGDS owns it independently of the caller. */
+    int dup_fd = fcntl(dmabuf_fd, F_DUPFD_CLOEXEC, 0);
+    if (dup_fd < 0)
+    {
+        dprintf("nvm_dma_map_dmabuf_v2: F_DUPFD_CLOEXEC failed: %s\n",
+                strerror(errno));
+        return errno;
+    }
+
+    /* Create the external dmabuf mapping descriptor with V2 flags.
+     * The map_range callback (ioctl_map) checks v2_flags and issues
+     * NVM_MAP_DMABUF_MEMORY_V2 instead of V1 when flags are set.
+     * The v2_result pointer lets ioctl_map copy classification output
+     * back to the caller. */
+    int err = create_mapping_descriptor(&md, (size_t)hps,
+                                         MAP_TYPE_DMABUF_EXT, devptr, size);
+    if (err != 0)
+    {
+        close(dup_fd);
+        return err;
+    }
+
+    md->dmabuf_fd = dup_fd;
+    md->dmabuf_offset = dmabuf_offset;
+    md->retain_fd = true;
+    md->close_fn = posix_close_adapter;
+    md->v2_flags = flags;
+    md->v2_result = result;
+
+    /* Initialize via the standard path.  _nvm_dma_init calls map_range
+     * -> ioctl_map, which detects v2_flags and issues the V2 ioctl.
+     * On failure the kernel mapping is never created, and
+     * remove_mapping_descriptor closes the retained dup_fd.
+     * On success the unmap callback is set, so teardown calls
+     * NVM_UNMAP_MEMORY correctly. */
+    err = _nvm_dma_init(handle, ctrl, &md->range, &release_mapping_descriptor);
+    if (err != 0)
+    {
+        remove_mapping_descriptor(md);
+        return err;
+    }
+
+    /* Tag as external origin for dual-backend dispatch */
+    _nvm_dma_set_origin(*handle, NVM_DMABUF_ORIGIN_EXTERNAL);
+
+    /* Set dmabuf metadata for re-export (RDMA path) */
+    _nvm_dma_set_dmabuf_info(*handle, dup_fd, dmabuf_offset, size);
+
+    return 0;
+}
+#endif /* UGDS_HAVE_DMABUF */

--- a/src/libnvm/linux_dma.cpp
+++ b/src/libnvm/linux_dma.cpp
@@ -561,7 +561,17 @@ int nvm_dma_map_device_ex(nvm_dma_t** handle, const nvm_ctrl_t* ctrl, void* devp
         }
         else
         {
-            /* Standard NVIDIA CUDA path via kernel P2P */
+            /* Standard NVIDIA CUDA path via kernel P2P.
+             * Reject non-64KiB-aligned devptr: the kernel maps
+             * vaddr & GPU_PAGE_MASK (drv/map.c), so a misaligned
+             * base silently addresses the containing 64KiB page and
+             * ioaddrs[0] does not correspond to devptr. This is silent
+             * data corruption. */
+            if ((uintptr_t)devptr % ((size_t)1 << 16) != 0)
+            {
+                dprintf("CUDA P2P devptr %p not 64KiB-aligned\n", devptr);
+                return EINVAL;
+            }
             err = create_mapping_descriptor(&md, 1ULL << 16, MAP_TYPE_CUDA, devptr, size);
             if (err != 0)
             {

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -14,6 +14,12 @@ typedef hipStream_t cudaStream_t;
 #include <cuda_runtime.h>
 #endif
 #include <mutex>
+#include <cerrno>
+#include <new>
+
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
 
 /* Forward declaration for dual-backend stream validation */
 #if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
@@ -440,3 +446,446 @@ extern "C" uGDSError_t uGDSStreamDeregister(void* stream)
 }
 #undef UGDS_ACTIVE_BACKEND
 #endif
+
+/* ======================================================================== */
+/* Vectored async (uGDSReadvAsync / uGDSWritevAsync)                       */
+/* Async path + timeout ownership handling.                                */
+/* ======================================================================== */
+
+/* ---- Dual-backend stream-backend lookup helper ----
+ * Reads the registered backend of a stream exactly once under
+ * s_stream_map_lock.  Returns UGDS_BACKEND_DEFAULT for unregistered or
+ * NULL streams.  Single-backend builds collapse to a compile-time active
+ * backend.  This helper is separate from async_check_stream_backend so
+ * that the async-vectored launch decision can read the stream backend
+ * exactly once (atomic snapshot). */
+static uGDSBackend_t iov_stream_backend_lookup(void* stream)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    if (stream == nullptr)
+        return UGDS_BACKEND_DEFAULT;
+    std::lock_guard<std::mutex> g(s_stream_map_lock);
+    auto it = s_stream_backends.find(stream);
+    if (it == s_stream_backends.end())
+        return UGDS_BACKEND_DEFAULT;
+    return it->second;
+#else
+    (void)stream;
+#if defined(__HIP_PLATFORM_AMD__)
+    return UGDS_BACKEND_HIP;
+#else
+    return UGDS_BACKEND_CUDA;
+#endif
+#endif
+}
+
+/* ---- launch_backend decision ----
+ * A is the buffer backend when the list is homogeneous (the single
+ * backend that every segment shares).  Single-backend builds reduce to
+ * A == active backend and the "mixed" branches become unreachable at
+ * compile time (the other backend cannot register buffers). */
+static uGDSError_t iov_compute_launch_backend(uGDSBackend_t list_a,
+                                              bool         mixed,
+                                              uGDSBackend_t stream_backend,
+                                              uGDSBackend_t* out)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    if (!mixed) {
+        /* Homogeneous list: every segment is on backend A. */
+        if (stream_backend == UGDS_BACKEND_DEFAULT) {
+            /* NULL/unregistered/registered-DEFAULT: launch on A. */
+            *out = list_a;
+            return UGDS_OK;
+        }
+        if (stream_backend == list_a) {
+            *out = list_a;
+            return UGDS_OK;
+        }
+        /* Registered on a backend that is not A: scalar-mismatch parity. */
+        return make_error(UGDS_INVALID_VALUE);
+    }
+    /* Mixed list: accepted iff the stream has an explicit registered
+     * backend; launch on that backend. */
+    if (stream_backend == UGDS_BACKEND_DEFAULT)
+        return make_error(UGDS_INVALID_VALUE);
+    *out = stream_backend;
+    return UGDS_OK;
+#else
+    /* Single-backend: mixed is unrepresentable, the active backend is
+     * the only one.  Any non-DEFAULT stream registration was already
+     * validated against the active backend at StreamRegisterEx. */
+    (void)stream_backend;
+    (void)mixed;
+    *out = list_a;
+    return UGDS_OK;
+#endif
+}
+
+/* ---- async_validate_v ----
+ * Under a single g_driver.lock hold:
+ *  - resolve every segment in the registry (identity-only: dma/base/
+ *    registered_length/backend), controller affinity check;
+ *  - acquire in-flight refs all-or-nothing into req->owner via
+ *    acquire_identity_only (registered-only);
+ *  - capture a list_backend snapshot for the launch decision;
+ *  - take a handle-operation reference via handle_lookup_locked.
+ * Geometry (offset/size) is NOT validated here -- late binding.
+ *
+ * On success, fills req->resolved (identity-only SegView[]), req->owner,
+ * req->hs_sp, and *out_list_backend / *out_mixed.  On failure, owner is
+ * untouched (no refs acquired) and the caller frees req->resolved.  The
+ * handle-operation ref is released on any failure path after lookup
+ * succeeds. */
+static uGDSError_t async_validate_v(uGDSHandle_t fh,
+                                    uGDSIoSegment_t* segs,
+                                    unsigned nr_segs,
+                                    SegView* resolved,
+                                    SglRefOwner* owner,
+                                    std::shared_ptr<HandleState>* hs_sp_out,
+                                    uGDSBackend_t* out_list_backend,
+                                    bool* out_mixed)
+{
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (fh == nullptr || segs == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+    if (nr_segs == 0 || nr_segs > UGDS_IOV_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* No per-segment value validation here (late binding).  Only base != NULL
+     * is checked so that registry lookup is well-defined. */
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr)
+            return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Take a single g_driver.lock to do: handle lookup + identity-only
+     * reference acquisition.  The handle ref is needed so that
+     * handle_in_flight prevents Deregister from tearing down the QPs
+     * while the request is queued.  owner->acquire_identity_only takes
+     * the same lock internally; the lock is not held across the acquire
+     * call. */
+    HandleState* hs = nullptr;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        hs = handle_lookup_locked(fh, hs_sp_out);
+    }
+    if (!hs)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Controller affinity check + ref acquisition.  handle_lookup_locked succeeded,
+     * so hs is valid for the lifetime of *hs_sp_out. */
+    int rc = owner->acquire_identity_only(
+        segs, static_cast<uint32_t>(nr_segs),
+        hs->ctrl, resolved);
+    if (rc != 0) {
+        handle_release(hs);
+        hs_sp_out->reset();
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Snapshot segment backends from resolved[] (read under no lock; the
+     * registry entries are pinned by owner for the lifetime of this
+     * request).  mixed == true iff backends span more than one value;
+     * list_a is the first non-DEFAULT backend, or DEFAULT if all are
+     * DEFAULT (homogeneous-DEFAULT). */
+    uGDSBackend_t a = UGDS_BACKEND_DEFAULT;
+    bool mixed = false;
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        uGDSBackend_t b = resolved[i].backend;
+        if (i == 0) {
+            a = b;
+        } else if (b != a) {
+            mixed = true;
+            /* Keep a as the first-segment backend; for a mixed list the
+             * launch decision ignores a and uses the stream backend. */
+        }
+    }
+    /* If a == DEFAULT the list is homogeneous-DEFAULT; treat A as the
+     * build's active backend for the decision (parity with the scalar
+     * buffer-backend dispatch). */
+#if defined(__HIP_PLATFORM_AMD__) && !defined(_CUDA)
+    if (a == UGDS_BACKEND_DEFAULT) a = UGDS_BACKEND_HIP;
+#elif !defined(__HIP_PLATFORM_AMD__)
+    if (a == UGDS_BACKEND_DEFAULT) a = UGDS_BACKEND_CUDA;
+#else
+    /* Dual build: leave DEFAULT; iov_compute_launch_backend treats the
+     * single buffer-backend snapshot path as DEFAULT => launch on A.  In
+     * dual builds, homogeneous-DEFAULT means all segments are DEFAULT --
+     * that means none were registered via uGDSBufRegisterEx with an
+     * explicit backend, so the buffer backend parity is the CUDA (A)
+     * side; iov_compute_launch_backend uses list_a as-is. */
+#endif
+
+    *out_list_backend = a;
+    *out_mixed = mixed;
+    return UGDS_OK;
+}
+
+/* ---- async_iov_execute (section 6.3, callback body) ----
+ * Must be effectively noexcept: the caller (async_iov_callback) is a
+ * full exception boundary.  All work here is infallible except for
+ * do_iov_engine, which is noexcept-by-contract (the engine's only
+ * allocation-free path is the streaming cursor). */
+static void async_iov_execute(AsyncRequest* req) noexcept
+{
+    /* 1. Late-bind offset/size from user_segs and file_offset_p.  These
+     *    reads race with the producer only if the caller violates the
+     *    binding contract (documented in include/ugds.h); under that
+     *    contract the values are stable from enqueue until the callback
+     *    runs.  No registry access is needed: identity is already
+     *    snapshotted in resolved[]. */
+    const off_t file_offset = *req->file_offset_p;
+
+    /* 2. Complete resolved[] geometry and run the same per-segment value
+     *    checks as sync do_readv_writev, but using the snapshotted
+     *    registered_length.  This closes the late-binding window. */
+    HandleState* hs = req->hs_sp.get();
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    ssize_t err_ret = 0;
+    uint64_t total_size = 0;
+
+    for (unsigned i = 0; i < req->nr_segs; ++i) {
+        const uGDSIoSegment_t& us = req->user_segs[i];
+        SegView& sv = req->resolved[i];
+
+        if (us.size == 0) { err_ret = -EINVAL; break; }
+        if (us.offset < 0) { err_ret = -EINVAL; break; }
+        if ((static_cast<size_t>(us.offset) % page_size) != 0) {
+            err_ret = -EINVAL; break;
+        }
+        if ((us.size % block_size) != 0) { err_ret = -EINVAL; break; }
+
+        /* Exact-length bound against the snapshotted registered_length. */
+        const uint64_t off = static_cast<uint64_t>(us.offset);
+        const uint64_t sz  = static_cast<uint64_t>(us.size);
+        if (off > sv.registered_length ||
+            sz > (sv.registered_length - off)) {
+            err_ret = -EINVAL; break;
+        }
+
+        if (sz > static_cast<uint64_t>(SSIZE_MAX) - total_size) {
+            err_ret = -EINVAL; break;
+        }
+        total_size += sz;
+
+        sv.page_start = off / page_size;
+        sv.size       = us.size;
+    }
+
+    if (err_ret == 0) {
+        if (file_offset < 0 ||
+            (static_cast<size_t>(file_offset) % block_size) != 0)
+            err_ret = -EINVAL;
+    }
+
+    if (err_ret != 0) {
+        /* Validation failure: release handle ref, write -errno, and
+         * delete req.  owner destructor releases the in-flight refs
+         * (none parked -- the engine never ran). */
+        *req->bytes_done_p = err_ret;
+        handle_release(hs);
+        delete req;
+        return;
+    }
+
+    /* 3. Engine dispatch.  Pass our owner; on timeout the engine
+     *    move-assigns it into qp.timeout_refs and we must NOT release. */
+    IovEngineResult result = do_iov_engine(hs, req->resolved,
+                                           static_cast<uint32_t>(req->nr_segs),
+                                           file_offset, req->opcode,
+                                           &req->owner, nullptr);
+
+    /* 4. Publish the result. */
+    *req->bytes_done_p = result.ret;
+
+    /* 5. Release the handle-operation reference taken at enqueue. */
+    handle_release(hs);
+
+    /* 6. delete req: the owner destructor releases the in-flight refs
+     *    unless the engine parked them on timeout (in which case
+     *    req->owner was moved-from and is empty). */
+    delete req;
+}
+
+/* ---- async_iov_callback (exception boundary) ----
+ * Declared noexcept-equivalent: any exception is caught and translated
+ * to -EIO so nothing propagates into the CUDA/HIP runtime. */
+static void async_iov_callback(void* userData) noexcept
+{
+    AsyncRequest* req = static_cast<AsyncRequest*>(userData);
+    try {
+        async_iov_execute(req);
+    } catch (...) {
+        /* Last-resort guard: async_iov_execute is noexcept-by-contract
+         * but the language does not enforce it.  Park the failure and
+         * free the request so the caller's bytes_done_p is writable
+         * exactly once. */
+        if (req->bytes_done_p != nullptr)
+            *req->bytes_done_p = -EIO;
+        if (req->hs_sp)
+            handle_release(req->hs_sp.get());
+        delete req;
+    }
+}
+
+/* ---- vectored launch dispatch ----
+ * Selects cudaLaunchHostFunc vs hipLaunchHostFunc in dual builds based
+ * on the enqueue-time launch_backend decision.  Single-backend builds
+ * use the active runtime. */
+static uGDSError_t iov_launch_host_func(void* stream, AsyncRequest* req)
+{
+#if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
+    int err;
+    if (req->launch_backend == UGDS_BACKEND_HIP) {
+        err = hipLaunchHostFunc(stream, async_iov_callback, req);
+    } else {
+        err = cudaLaunchHostFunc(stream, async_iov_callback, req);
+    }
+    if (err != 0) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = err;
+        return e;
+    }
+    return UGDS_OK;
+#elif defined(__HIP_PLATFORM_AMD__)
+    hipError_t err = hipLaunchHostFunc((hipStream_t)stream,
+                                       async_iov_callback, req);
+    if (err != hipSuccess) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+#else
+    cudaError_t err = cudaLaunchHostFunc((cudaStream_t)(uintptr_t)stream,
+                                         async_iov_callback, req);
+    if (err != cudaSuccess) {
+        uGDSError_t e;
+        e.err = UGDS_CUDA_DRIVER_ERROR;
+        e.cu_err = static_cast<int>(err);
+        return e;
+    }
+    return UGDS_OK;
+#endif
+}
+
+/* ---- common enqueue + launch for uGDSReadvAsync / uGDSWritevAsync ---- */
+static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
+                                         uGDSIoSegment_t* segs,
+                                         unsigned nr_segs,
+                                         off_t* file_offset_p,
+                                         ssize_t* bytes_done_p,
+                                         void* stream,
+                                         uint8_t opcode)
+{
+    /* Malformed-call checks.  These do not need the registry and
+     * cannot race with Deregister. */
+    if (!g_driver.initialized)
+        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+    if (fh == nullptr || segs == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+    if (nr_segs == 0 || nr_segs > UGDS_IOV_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+    if (file_offset_p == nullptr || bytes_done_p == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* Pre-zero bytes_done_p so a late callback-failure still reports a
+     * deterministic value to the caller. */
+    *bytes_done_p = 0;
+
+    /* Allocate the request and its resolved[] storage BEFORE acquiring
+     * any reference, so that allocation failure cannot strand an
+     * in_flight or handle_in_flight counter.  resolved[] uses the
+     * inline slot for nr <= 4. */
+    AsyncRequest* req = new (std::nothrow) AsyncRequest;
+    if (req == nullptr)
+        return make_error(UGDS_OUT_OF_MEMORY);
+    req->fh            = fh;
+    req->file_offset_p = file_offset_p;
+    req->bytes_done_p  = bytes_done_p;
+    req->opcode        = opcode;
+    req->user_segs     = segs;
+    req->nr_segs       = nr_segs;
+    /* bufPtr_base/size_p/bufPtr_offset_p are unused for the vectored path. */
+
+    if (nr_segs <= 4) {
+        req->resolved = req->inline_resolved;
+    } else {
+        SegView* heap = new (std::nothrow) SegView[nr_segs];
+        if (heap == nullptr) {
+            delete req;
+            return make_error(UGDS_OUT_OF_MEMORY);
+        }
+        req->resolved = heap;
+    }
+
+    /* async_validate_v acquires in-flight refs + handle ref, fills
+     * resolved (identity-only), and snapshots list backend + mixed. */
+    uGDSBackend_t list_backend = UGDS_BACKEND_DEFAULT;
+    bool mixed = false;
+    uGDSError_t st = async_validate_v(fh, segs, nr_segs, req->resolved,
+                                      &req->owner, &req->hs_sp,
+                                      &list_backend, &mixed);
+    if (st.err != UGDS_SUCCESS) {
+        /* No refs acquired, no handle ref held.  Free the request and
+         * its heap storage (if any). */
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return st;
+    }
+
+    /* Compute launch_backend ONCE from the snapshot list_backend and
+     * a single read of the stream backend. */
+    uGDSBackend_t stream_backend = iov_stream_backend_lookup(stream);
+    uGDSBackend_t launch_backend = UGDS_BACKEND_DEFAULT;
+    uGDSError_t lberr = iov_compute_launch_backend(list_backend, mixed,
+                                                    stream_backend,
+                                                    &launch_backend);
+    if (lberr.err != UGDS_SUCCESS) {
+        /* Reject at enqueue: release refs + handle ref, then free. */
+        req->owner.release();  /* idempotent: decrements in_flight */
+        handle_release(req->hs_sp.get());
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return lberr;
+    }
+    req->launch_backend = launch_backend;
+
+    /* Launch the callback on the selected backend's stream.  On failure
+     * the caller can retry, so we must roll back every reference we
+     * acquired and free the request. */
+    uGDSError_t lc = iov_launch_host_func(stream, req);
+    if (lc.err != UGDS_SUCCESS) {
+        req->owner.release();
+        handle_release(req->hs_sp.get());
+        if (req->resolved != req->inline_resolved)
+            delete[] req->resolved;
+        delete req;
+        return lc;
+    }
+
+    return UGDS_OK;
+}
+
+extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                                        unsigned nr_segs, off_t* file_offset_p,
+                                        ssize_t* bytes_read_p, void* stream)
+{
+    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                 bytes_read_p, stream, NVM_IO_READ);
+}
+
+extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
+                                         unsigned nr_segs, off_t* file_offset_p,
+                                         ssize_t* bytes_written_p, void* stream)
+{
+    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                 bytes_written_p, stream, NVM_IO_WRITE);
+}

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -813,7 +813,8 @@ static uGDSError_t iov_launch_host_func(void* stream, AsyncRequest* req)
         return e;
     }
     return UGDS_OK;
-#else
+#elif defined(_CUDA) || defined(__CUDACC__)
+    /* CUDA-only build */
     cudaError_t err = cudaLaunchHostFunc((cudaStream_t)(uintptr_t)stream,
                                          async_iov_callback, req);
     if (err != cudaSuccess) {
@@ -823,6 +824,11 @@ static uGDSError_t iov_launch_host_func(void* stream, AsyncRequest* req)
         return e;
     }
     return UGDS_OK;
+#else
+    /* No GPU backend: async IO not available */
+    (void)stream;
+    delete req;
+    return make_error(UGDS_IO_NOT_SUPPORTED);
 #endif
 }
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -830,17 +830,24 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     }
 
     /* async_validate_v acquires in-flight refs + handle ref, fills
-     * resolved (identity-only), and snapshots list backend + mixed. */
+     * resolved (identity-only), and snapshots list backend + mixed.
+     * The handle ref guard ensures handle_release is called on
+     * exception between validation and successful launch. */
     uGDSBackend_t list_backend = UGDS_BACKEND_DEFAULT;
     bool mixed = false;
     uGDSError_t st = async_validate_v(fh, segs, nr_segs, req->resolved,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held. req_guard frees req +
-         * heap resolved[] via destructor. */
         return st;
     }
+
+    /* RAII: release handle ref if we leave scope without launching. */
+    struct HandleRefGuard {
+        HandleState* hs;
+        bool armed;
+        ~HandleRefGuard() { if (armed && hs) handle_release(hs); }
+    } hguard{req->hs_sp.get(), true};
 
     /* Compute launch_backend ONCE from the snapshot list_backend and
      * a single read of the stream backend. */
@@ -851,7 +858,7 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
         req->owner.release();
-        handle_release(req->hs_sp.get());
+        /* hguard releases handle ref */
         return lberr;
     }
     req->launch_backend = launch_backend;
@@ -862,11 +869,12 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
         req->owner.release();
-        handle_release(req->hs_sp.get());
+        /* hguard releases handle ref */
         return lc;
     }
 
-    /* Launch succeeded: release ownership to the callback. */
+    /* Launch succeeded: disarm guards, release ownership to callback. */
+    hguard.armed = false;
     (void)req_guard.release();
     return UGDS_OK;
 }

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -41,8 +41,15 @@
 #define cudaError_t hipError_t
 #define cudaSuccess hipSuccess
 typedef hipStream_t cudaStream_t;
-#else
+#elif defined(_CUDA) || defined(__CUDACC__)
 #include <cuda_runtime.h>
+#else
+/* No GPU backend: async launch is not available. Stub definitions
+ * so the TU compiles for standalone dmabuf-only builds. */
+#define CUDART_CB
+typedef void* cudaStream_t;
+typedef int cudaError_t;
+#define cudaSuccess 0
 #endif
 #include <mutex>
 #include <cerrno>

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -825,9 +825,10 @@ static uGDSError_t iov_launch_host_func(void* stream, AsyncRequest* req)
     }
     return UGDS_OK;
 #else
-    /* No GPU backend: async IO not available */
+    /* No GPU backend: async IO not available.
+     * The caller owns req through its unique_ptr and releases it on
+     * every failure return; do not delete it here. */
     (void)stream;
-    delete req;
     return make_error(UGDS_IO_NOT_SUPPORTED);
 #endif
 }

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -805,10 +805,11 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
     /* Allocate the request and its resolved[] storage BEFORE acquiring
      * any reference, so that allocation failure cannot strand an
      * in_flight or handle_in_flight counter.  resolved[] uses the
-     * inline slot for nr <= 4. */
-    AsyncRequest* req = new (std::nothrow) AsyncRequest;
-    if (req == nullptr)
-        return make_error(UGDS_OUT_OF_MEMORY);
+     * inline slot for nr <= 4.
+     * unique_ptr owns req until successful launch; on any exception or
+     * early return it is automatically freed. */
+    auto req_guard = std::make_unique<AsyncRequest>();
+    AsyncRequest* req = req_guard.get();
     req->fh            = fh;
     req->file_offset_p = file_offset_p;
     req->bytes_done_p  = bytes_done_p;
@@ -822,10 +823,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
         /* resolved_owns_heap stays false (default). */
     } else {
         SegView* heap = new (std::nothrow) SegView[nr_segs];
-        if (heap == nullptr) {
-            delete req;  /* ~AsyncRequest frees heap[] if owned */
+        if (heap == nullptr)
             return make_error(UGDS_OUT_OF_MEMORY);
-        }
         req->resolved = heap;
         req->resolved_owns_heap = true;  /* destructor owns it */
     }
@@ -838,9 +837,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held.  Free the request; the
-         * destructor frees heap resolved[] if any. */
-        delete req;
+        /* No refs acquired, no handle ref held. req_guard frees req +
+         * heap resolved[] via destructor. */
         return st;
     }
 
@@ -852,11 +850,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     stream_backend,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
-        /* Reject at enqueue: release refs + handle ref, then free.
-         * The destructor frees heap resolved[] if owned. */
-        req->owner.release();  /* idempotent: decrements in_flight */
+        req->owner.release();
         handle_release(req->hs_sp.get());
-        delete req;
         return lberr;
     }
     req->launch_backend = launch_backend;
@@ -866,13 +861,13 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * acquired and free the request. */
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
-        /* The destructor frees heap resolved[] if owned. */
         req->owner.release();
         handle_release(req->hs_sp.get());
-        delete req;
         return lc;
     }
 
+    /* Launch succeeded: release ownership to the callback. */
+    (void)req_guard.release();
     return UGDS_OK;
 }
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -70,6 +70,11 @@ static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
     if (it == g_driver.buf_registry.end())
         return make_error(UGDS_INVALID_VALUE);
 
+    /* Controller affinity check: validate against the submitting
+     * handle's controller. */
+    if (it->second.map_ctrl == nullptr)
+        return make_error(UGDS_INVALID_VALUE);
+
     /* Hold in-flight reference from enqueue until callback completes.
      * This prevents uGDSBufDeregister from unmapping the buffer
      * while the async request is queued but not yet executed. */
@@ -83,6 +88,15 @@ static uGDSError_t async_validate(uGDSHandle_t fh, void* bufPtr_base,
     if (!hs) {
         /* Roll back buffer in_flight ref on handle acquire failure */
         it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Controller affinity check: controller at registration must match
+     * the submitting handle's controller. */
+    if (it->second.map_ctrl != hs->ctrl) {
+        it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        handle_release(hs);
+        hs_sp_out->reset();
         return make_error(UGDS_INVALID_VALUE);
     }
 

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -622,12 +622,10 @@ static uGDSError_t async_validate_v(uGDSHandle_t fh,
     return UGDS_OK;
 }
 
-/* ---- async_iov_execute (section 6.3, callback body) ----
- * Must be effectively noexcept: the caller (async_iov_callback) is a
- * full exception boundary.  All work here is infallible except for
- * do_iov_engine, which is noexcept-by-contract (the engine's only
- * allocation-free path is the streaming cursor). */
-static void async_iov_execute(AsyncRequest* req) noexcept
+/* ---- async_iov_execute (callback body) ----
+ * Potentially throwing: do_iov_engine acquires std::mutex and may throw.
+ * The caller (async_iov_callback) is the noexcept exception boundary. */
+static void async_iov_execute(AsyncRequest* req)
 {
     /* 1. Late-bind offset/size from user_segs and file_offset_p.  These
      *    reads race with the producer only if the caller violates the
@@ -719,10 +717,10 @@ static void async_iov_callback(void* userData) noexcept
     try {
         async_iov_execute(req);
     } catch (...) {
-        /* Last-resort guard: async_iov_execute is noexcept-by-contract
-         * but the language does not enforce it.  Park the failure and
-         * free the request so the caller's bytes_done_p is writable
-         * exactly once. */
+        /* Real catch boundary: async_iov_execute is NOT noexcept,
+         * so exceptions from do_iov_engine or mutex acquisition
+         * arrive here. Park the failure and free the request so
+         * the caller's bytes_done_p is writable exactly once. */
         if (req->bytes_done_p != nullptr)
             *req->bytes_done_p = -EIO;
         if (req->hs_sp)
@@ -798,6 +796,12 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * deterministic value to the caller. */
     *bytes_done_p = 0;
 
+    /* Validate base pointers before any allocation. */
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr)
+            return make_error(UGDS_INVALID_VALUE);
+    }
+
     /* Allocate the request and its resolved[] storage BEFORE acquiring
      * any reference, so that allocation failure cannot strand an
      * in_flight or handle_in_flight counter.  resolved[] uses the
@@ -815,13 +819,15 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
 
     if (nr_segs <= 4) {
         req->resolved = req->inline_resolved;
+        /* resolved_owns_heap stays false (default). */
     } else {
         SegView* heap = new (std::nothrow) SegView[nr_segs];
         if (heap == nullptr) {
-            delete req;
+            delete req;  /* ~AsyncRequest frees heap[] if owned */
             return make_error(UGDS_OUT_OF_MEMORY);
         }
         req->resolved = heap;
+        req->resolved_owns_heap = true;  /* destructor owns it */
     }
 
     /* async_validate_v acquires in-flight refs + handle ref, fills
@@ -832,10 +838,8 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                       &req->owner, &req->hs_sp,
                                       &list_backend, &mixed);
     if (st.err != UGDS_SUCCESS) {
-        /* No refs acquired, no handle ref held.  Free the request and
-         * its heap storage (if any). */
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
+        /* No refs acquired, no handle ref held.  Free the request; the
+         * destructor frees heap resolved[] if any. */
         delete req;
         return st;
     }
@@ -848,11 +852,10 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
                                                     stream_backend,
                                                     &launch_backend);
     if (lberr.err != UGDS_SUCCESS) {
-        /* Reject at enqueue: release refs + handle ref, then free. */
+        /* Reject at enqueue: release refs + handle ref, then free.
+         * The destructor frees heap resolved[] if owned. */
         req->owner.release();  /* idempotent: decrements in_flight */
         handle_release(req->hs_sp.get());
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
         delete req;
         return lberr;
     }
@@ -863,10 +866,9 @@ static uGDSError_t do_readv_writev_async(uGDSHandle_t fh,
      * acquired and free the request. */
     uGDSError_t lc = iov_launch_host_func(stream, req);
     if (lc.err != UGDS_SUCCESS) {
+        /* The destructor frees heap resolved[] if owned. */
         req->owner.release();
         handle_release(req->hs_sp.get());
-        if (req->resolved != req->inline_resolved)
-            delete[] req->resolved;
         delete req;
         return lc;
     }
@@ -878,14 +880,26 @@ extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                                         unsigned nr_segs, off_t* file_offset_p,
                                         ssize_t* bytes_read_p, void* stream)
 {
-    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
-                                 bytes_read_p, stream, NVM_IO_READ);
+    try {
+        return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                     bytes_read_p, stream, NVM_IO_READ);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t fh, uGDSIoSegment_t* segs,
                                          unsigned nr_segs, off_t* file_offset_p,
                                          ssize_t* bytes_written_p, void* stream)
 {
-    return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
-                                 bytes_written_p, stream, NVM_IO_WRITE);
+    try {
+        return do_readv_writev_async(fh, segs, nr_segs, file_offset_p,
+                                     bytes_written_p, stream, NVM_IO_WRITE);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -573,16 +573,32 @@ static uGDSError_t async_validate_v(uGDSHandle_t fh,
     if (!hs)
         return make_error(UGDS_INVALID_VALUE);
 
-    /* Controller affinity check + ref acquisition.  handle_lookup_locked succeeded,
-     * so hs is valid for the lifetime of *hs_sp_out. */
+    /* RAII: ensure handle_release runs even if acquire_identity_only
+     * throws (e.g., from its internal mutex acquisition). */
+    struct HandleReleaseGuard {
+        HandleState* hs;
+        std::shared_ptr<HandleState>* sp;
+        bool armed;
+        ~HandleReleaseGuard() {
+            if (armed) {
+                handle_release(hs);
+                sp->reset();
+            }
+        }
+    } hguard{hs, hs_sp_out, true};
+
+    /* Controller affinity check + ref acquisition.  handle_lookup_locked
+     * succeeded, so hs is valid for the lifetime of *hs_sp_out. */
     int rc = owner->acquire_identity_only(
         segs, static_cast<uint32_t>(nr_segs),
         hs->ctrl, resolved);
     if (rc != 0) {
-        handle_release(hs);
-        hs_sp_out->reset();
+        /* hguard releases handle ref */
         return make_error(UGDS_INVALID_VALUE);
     }
+
+    /* Success: disarm the guard. Caller owns the handle ref now. */
+    hguard.armed = false;
 
     /* Snapshot segment backends from resolved[] (read under no lock; the
      * registry entries are pinned by owner for the lifetime of this

--- a/src/ugds_async.cpp
+++ b/src/ugds_async.cpp
@@ -1,3 +1,34 @@
+/* ugds_async.cpp -- Asynchronous vectored IO on CUDA/HIP streams.
+ *
+ * Public APIs implemented here:
+ *   - uGDSReadvAsync  / uGDSWritevAsync   (vectored async IO)
+ *
+ * Internal functions:
+ *   - async_validate_v       (handle lookup + identity-only ref acquisition)
+ *   - do_readv_writev_async   (request allocation, validation, launch)
+ *   - async_iov_execute       (callback body: late binding + engine dispatch)
+ *   - async_iov_callback      (noexcept exception boundary around execute)
+ *
+ * Late binding contract:
+ *   - segs[i].base is read at enqueue (validation + in-flight refs) and
+ *     MUST NOT change afterwards.
+ *   - segs[i].offset, segs[i].size, and *file_offset_p are read in the
+ *     stream callback (late binding).  The segs array must remain valid
+ *     until the callback runs.
+ *
+ * Callback lifecycle:
+ *   1. Enqueue: uGDSReadvAsync/uGDSWritevAsync allocates AsyncRequest,
+ *      acquires identity-only refs + handle ref under g_driver.lock,
+ *      computes launch_backend, and launches async_iov_callback on the
+ *      stream.  unique_ptr owns the request until successful launch;
+ *      HandleRefGuard owns the handle ref from validation through launch.
+ *   2. Callback: async_iov_callback (noexcept) wraps async_iov_execute
+ *      in try/catch(...).  On success, writes bytes_done_p and releases
+ *      refs.  On exception, writes -EIO to bytes_done_p and releases.
+ *   3. Cleanup: ~AsyncRequest frees heap resolved[] (if owned); owner
+ *      releases in-flight buffer refs; handle_release decrements
+ *      handle_in_flight.
+ */
 #include "ugds_internal.h"
 #if defined(_CUDA) && defined(__HIP_PLATFORM_AMD__)
 /* Dual-backend: avoid both cuda_runtime.h and hip_runtime.h in this TU

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -39,27 +39,51 @@ static inline void queue_entry_release(BatchState* bs, unsigned idx)
     bs->release_scratch[bs->n_release_pending++] = idx;
 }
 
-/* Drain all pending deferred releases in one g_driver.lock hold.
+/* Release the in-flight reference(s) held by a batch entry.
+ * Kind-aware release.
+ * - BATCH_ENTRY_PLAIN: one ref at entry.devPtr_base (legacy path).
+ * - BATCH_ENTRY_VECTORED: one ref per base in
+ *   bs->seg_arena[entry.seg_begin .. seg_begin + seg_count).
+ *   Duplicate bases are released per occurrence, matching acquire().
+ * Must be called WITHOUT holding g_driver.lock. */
+void release_entry_refs(BatchState* bs, BatchIOEntry& entry)
+{
+    if (!entry.refs_held)
+        return;
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    if (entry.kind == BATCH_ENTRY_VECTORED) {
+        for (uint32_t k = 0; k < entry.seg_count; ++k) {
+            uint32_t ai = entry.seg_begin + k;
+            if (ai >= bs->seg_arena.size())
+                break;
+            const void* base = bs->seg_arena[ai].base;
+            auto it = g_driver.buf_registry.find(base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    } else {
+        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    entry.refs_held = false;
+    entry.release_queued = false;
+}
+
+/* Drain all pending deferred releases in one pass.
  * Must be called under bs->lock but NOT under qp.lock and NOT under
- * g_driver.lock (the old version called
- * async_release_inflight_batch which re-locked g_driver.lock, causing
- * a deadlock on a non-recursive mutex). */
+ * g_driver.lock (the old version called async_release_inflight_batch
+ * which re-locked g_driver.lock, causing a deadlock on a non-recursive
+ * mutex). */
 static void drain_release_scratch(BatchState* bs)
 {
     if (bs->n_release_pending == 0) return;
-    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
     for (uint32_t i = 0; i < bs->n_release_pending; ++i) {
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        /* Inline the decrement instead of calling
-         * async_release_inflight_batch to avoid re-locking
-         * g_driver.lock (nested-lock bug fix). */
-        auto it = g_driver.buf_registry.find(entry.devPtr_base);
-        if (it != g_driver.buf_registry.end())
-            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-        entry.refs_held = false;
-        entry.release_queued = false;
+        /* C1: release_entry_refs handles both PLAIN and VECTORED. */
+        release_entry_refs(bs, entry);
     }
     bs->n_release_pending = 0;
 }
@@ -1181,8 +1205,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
             continue;
         }
 
-        /* refs are now held by the arena; mark for deferred release. */
+        /* refs are now held by the batch (the in_flight counter was
+         * incremented by acquire).  Transfer ownership to the batch by
+         * disarming the local owner so its destructor does not release.
+         * drain_release_scratch will decrement each base in entry's
+         * arena range, selected by entry.kind. */
         entry.refs_held = true;
+        owner.disarm();
 
         /* Stream windows into the work array. */
         SglWindowCursor cursor;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -195,7 +195,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
 
     (void)flags;
 
-    // Phase 1: validate and populate entries
+    // Validate and populate entries
     unsigned base = bs->n_entries;
     for (unsigned i = 0; i < nr; ++i) {
         const uGDSIOParams_t& p = iocb[i];
@@ -234,7 +234,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.n_cmds = static_cast<uint16_t>(n_cmds);
     }
 
-    // Phase 2: build sub-command list
+    // Build sub-command list
     struct SubCmd {
         unsigned io_idx;
         uint64_t lba;
@@ -318,7 +318,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         }
     }
 
-    // Phase 3: enqueue all NVMe commands to the single batch QP
+    // Enqueue all NVMe commands to the single batch QP
     {
         std::lock_guard<std::mutex> qp_lock(qp.lock);
 

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,13 +212,15 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that owns ALL five items by value.
-     * Declared before bs_sp so its destructor runs first on unwind.
+    /* BatchSetupTxn - RAII scope guard that owns ALL five items by value.
      * Pool resources are owned by value (not pointer to bs_sp members)
      * so destruction order does not cause dangling dereferences.
      * On commit, pool resources are transferred to bs_sp->prp_pool
      * and txn.armed is cleared.
-     * Destructor uses try_lock to remain noexcept-safe. */
+     * Destructor uses a blocking lock_guard because gate-state transitions
+     * must be atomic under g_driver.lock. If the lock throws (system_error),
+     * std::terminate is the correct outcome: the process state is
+     * unrecoverable. try_to_lock would silently skip the mutex and race. */
     struct BatchSetupTxn {
         HandleState* hs;
         void* pool_buf;
@@ -229,8 +231,8 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
             /* Rollback items 5, 4 (owned by value) */
             if (pool_dma) { nvm_dma_unmap(pool_dma); }
             if (pool_buf) { free(pool_buf); }
-            /* Rollback items 3, 2, 1 (gate state, best-effort lock) */
-            std::unique_lock<std::mutex> lk(g_driver.lock, std::try_to_lock);
+            /* Rollback items 3, 2, 1 (gate state under g_driver.lock) */
+            std::lock_guard<std::mutex> g(g_driver.lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
@@ -306,10 +308,10 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     return UGDS_OK;
 
 setup_rollback:
-    /* Pool resources are owned by txn; txn.armed=false below prevents
-     * the destructor from double-freeing. Gate state is also unwound
-     * explicitly. bs_sp is reset for its own cleanup. */
-    txn.armed = false;  /* prevent double-run: we clean up explicitly */
+    /* Clean up pool resources first, then gate state. txn stays armed
+     * so its destructor handles gate rollback if the lock_guard below
+     * throws (the destructor will block on the same lock, which is fine
+     * since the throwing lock_guard's exception unwinds this frame). */
     {
         if (txn.pool_dma) { nvm_dma_unmap(txn.pool_dma); txn.pool_dma = nullptr; }
         if (txn.pool_buf) { free(txn.pool_buf); txn.pool_buf = nullptr; }
@@ -321,6 +323,7 @@ setup_rollback:
         handle_release(hs);
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
+    txn.armed = false;  /* gate cleanup done; disarm to prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -7,6 +7,9 @@
 #include <atomic>
 #include <time.h>
 #include <cstdio>
+#include <cassert>
+#include <new>
+#include <memory>
 
 /* Release in-flight reference held by batch submit.
  * Called on validation failure or when batch entry completes. */
@@ -16,6 +19,61 @@ static void async_release_inflight_batch(void* devPtr_base)
     auto it = g_driver.buf_registry.find(devPtr_base);
     if (it != g_driver.buf_registry.end())
         it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+/* Append an entry index to the deferred-release scratch.
+ * Must be called under bs->lock; the actual registry decrement is
+ * deferred until after qp.lock is released. */
+static inline void queue_entry_release(BatchState* bs, unsigned idx)
+{
+    BatchIOEntry& entry = bs->entries[idx];
+    if (!entry.refs_held) return;
+    if (entry.release_queued) return;  /* already queued */
+    assert(bs->n_release_pending < bs->release_scratch.size());
+    entry.release_queued = true;
+    bs->release_scratch[bs->n_release_pending++] = idx;
+}
+
+/* Drain all pending deferred releases in one g_driver.lock hold.
+ * Must be called under bs->lock but NOT under qp.lock.
+ * Clears refs_held and release_queued for each drained index, then
+ * resets n_release_pending. */
+static void drain_release_scratch(BatchState* bs)
+{
+    if (bs->n_release_pending == 0) return;
+    std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+    for (uint32_t i = 0; i < bs->n_release_pending; ++i) {
+        uint32_t idx = bs->release_scratch[i];
+        BatchIOEntry& entry = bs->entries[idx];
+        if (!entry.refs_held) continue;  /* already released */
+        async_release_inflight_batch(entry.devPtr_base);
+        entry.refs_held = false;
+        entry.release_queued = false;
+    }
+    bs->n_release_pending = 0;
+}
+
+/* Abort a Phase-3 entry that is WAITING or PENDING.
+ * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
+ * -ECANCELED, and queues the entry for deferred release if all its
+ * submitted commands have already completed.  Must be called
+ * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1). */
+static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
+{
+    BatchIOEntry& entry = bs->entries[idx];
+    if (entry.status != UGDS_BATCH_WAITING &&
+        entry.status != UGDS_BATCH_PENDING)
+        return;
+    entry.error_code = -ECANCELED;
+    entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */
+    if (entry.n_cmds_done == entry.n_cmds) {
+        /* All submitted commands already drained: terminalize now. */
+        entry.status = UGDS_BATCH_FAILED;
+        bs->n_completed++;
+        queue_entry_release(bs, idx);
+    }
+    /* else: submitted prefix still draining; drain_one_completion will
+     * terminalize when n_cmds_done == n_cmds. */
 }
 
 static void cleanup_prp_pool(BatchState* bs)
@@ -69,14 +127,25 @@ static bool drain_one_completion(IOQueuePair& qp, BatchState* bs)
 
     entry.n_cmds_done++;
 
-    if (entry.n_cmds_done == entry.n_cmds) {
+    if (entry.error_code == -ECANCELED) {
+        /* Abort has terminal-result precedence: do not overwrite with
+         * bytes or device status.  Terminalize when the submitted prefix
+         * has fully drained. */
+        if (entry.n_cmds_done == entry.n_cmds) {
+            entry.status = UGDS_BATCH_FAILED;
+            bs->n_completed++;
+            queue_entry_release(bs, slot.io_idx);
+        }
+    } else if (entry.n_cmds_done == entry.n_cmds) {
         if (entry.status != UGDS_BATCH_FAILED) {
             entry.status = UGDS_BATCH_COMPLETE;
         }
         entry.error_code = entry.bytes_done;
         bs->n_completed++;
-        /* Release in-flight reference when all sub-commands complete */
-        async_release_inflight_batch(entry.devPtr_base);
+        /* Queue deferred release of in-flight reference:
+         * the actual registry decrement runs after qp.lock drops via
+         * drain_release_scratch, restoring the stated lock order. */
+        queue_entry_release(bs, slot.io_idx);
     }
 
     return true;
@@ -105,65 +174,117 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
         return make_error(UGDS_INVALID_VALUE);
 
-    /* Look up handle via global registry to safely acquire a shared_ptr.
-     * This prevents UAF if HandleDeregister races with us. */
+    /* --- Setup gate: one g_driver.lock critical section ---
+     * The closing check, batch_active claim, and batch_setting_up
+     * publication are indivisible with respect to force teardown's
+     * closing claim, which runs under the same lock. */
     std::shared_ptr<HandleState> hs_sp;
-    HandleState* hs = handle_lookup(fh, &hs_sp);
-    if (!hs)
-        return make_error(UGDS_INVALID_VALUE);
+    HandleState* hs = nullptr;
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        auto it = g_driver.handle_registry.find(static_cast<HandleState*>(fh));
+        if (it == g_driver.handle_registry.end())
+            return make_error(UGDS_INVALID_VALUE);
+        if (it->second->closing.load(std::memory_order_acquire))
+            return make_error(UGDS_INVALID_VALUE);
+        if (it->second->wedged.load(std::memory_order_acquire))
+            return make_error(UGDS_INVALID_VALUE);
+        if (!it->second->batch_qp)
+            return make_error(UGDS_INTERNAL_ERROR);
 
-    if (!hs->batch_qp) {
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+        bool expected = false;
+        if (!it->second->batch_active.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel))
+            return make_error(UGDS_INVALID_VALUE);
+
+        /* Gate won: acquire handle reference + set batch_setting_up */
+        hs_sp = it->second;
+        it->second->handle_in_flight.fetch_add(1, std::memory_order_acq_rel);
+        hs = hs_sp.get();
+        hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    bool expected = false;
-    if (!hs->batch_active.compare_exchange_strong(expected, true)) {
-        handle_release(hs);
-        return make_error(UGDS_INVALID_VALUE);
-    }
-
-    auto bs = new (std::nothrow) BatchState();
-    if (!bs) {
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
-    }
-
-    bs->capacity = nr;
-    bs->hs = hs;
-    bs->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
-    bs->entries.resize(nr);
-    bs->cmd_map.resize(hs->batch_queue_depth);
+    /* --- Private, fallible phase --- */
+    auto bs_sp = std::make_shared<BatchState>();
+    bs_sp->capacity = nr;
+    bs_sp->hs = hs;
+    bs_sp->hs_sp = std::move(hs_sp);  /* keep handle alive for batch lifetime */
+    bs_sp->entries.resize(nr);
+    bs_sp->cmd_map.resize(hs->batch_queue_depth);
+    /* release_scratch is sized from capacity (the immutable SetUp
+     * bound), NOT n_entries (the current round's consumed count). */
+    bs_sp->release_scratch.resize(nr);
 
     const size_t page_size = hs->ctrl->page_size;
-    PRPPool& pool = bs->prp_pool;
+    PRPPool& pool = bs_sp->prp_pool;
     size_t pool_bytes = UGDS_PRP_POOL_PAGES * page_size;
 
+    uGDSError_t setup_err = UGDS_OK;
     if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
-        delete bs;
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+        setup_err = make_error(UGDS_OUT_OF_MEMORY);
+        goto setup_rollback;
     }
     std::memset(pool.buf, 0, pool_bytes);
 
-    int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
-    if (!nvm_ok(rc)) {
-        free(pool.buf);
-        pool.buf = nullptr;
-        delete bs;
-        hs->batch_active.store(false);
-        handle_release(hs);
-        return make_error(UGDS_INTERNAL_ERROR);
+    {
+        int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
+        if (!nvm_ok(rc)) {
+            free(pool.buf);
+            pool.buf = nullptr;
+            setup_err = (rc == ENOMEM)
+                ? make_error(UGDS_OUT_OF_MEMORY)
+                : make_error(UGDS_INTERNAL_ERROR);
+            goto setup_rollback;
+        }
     }
     pool.n_pages = UGDS_PRP_POOL_PAGES;
     pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
-    *batch = static_cast<uGDSBatchHandle_t>(bs);
+    /* --- Publication: one g_driver.lock critical section --- */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        if (hs->closing.load(std::memory_order_acquire)) {
+            /* Deregister/force arrived mid-setup; roll back.
+             * batch_setting_up is cleared as the LAST rollback action. */
+            setup_err = make_error(UGDS_INVALID_VALUE);
+            goto setup_rollback;
+        }
+        /* active_batch must be null: the CAS above ensures no other setup
+         * claimed batch_active, and no destroy can have run yet. */
+        if (hs->active_batch != nullptr) {
+            setup_err = make_error(UGDS_INTERNAL_ERROR);
+            goto setup_rollback;
+        }
+        bs_sp->self = bs_sp;            /* public-handle ownership */
+        hs->active_batch = bs_sp;       /* owning recovery link */
+        hs->batch_setting_up.store(false, std::memory_order_release);
+    }
 
+    *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
     return UGDS_OK;
+
+setup_rollback:
+    /* Rollback in reverse acquisition order:
+     * 5 (pool DMA) -> 4 (pool buf) -> 3 (BatchState shared_ptr)
+     * -> 2 (batch_active) -> 1 (handle ref + batch_setting_up LAST).
+     * pool.dma and pool.buf are cleaned up above or here; the shared_ptr
+     * reset handles item 3. */
+    {
+        if (pool.dma) { nvm_dma_unmap(pool.dma); pool.dma = nullptr; }
+        if (pool.buf) { free(pool.buf); pool.buf = nullptr; }
+    }
+    bs_sp.reset();  /* RAII: releases BatchState if last owner */
+    {
+        std::lock_guard<std::mutex> g(g_driver.lock);
+        hs->batch_active.store(false, std::memory_order_release);
+        handle_release(hs);
+        /* batch_setting_up cleared LAST so a waiting force teardown
+         * proceeds only after every other side effect (including the
+         * DMA unmap, which needs hs->ctrl alive) has been undone. */
+        hs->batch_setting_up.store(false, std::memory_order_release);
+    }
+    return setup_err;
 }
 
 extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
@@ -225,6 +346,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         entry.error_code = 0;
         entry.n_cmds_done = 0;
         entry.event_returned = false;
+        /* SGL/lifecycle fields */
+        entry.kind = BATCH_ENTRY_PLAIN;
+        entry.seg_begin = 0;
+        entry.seg_count = 0;
+        entry.refs_held = false;
+        entry.release_queued = false;
+        entry.n_cmds_submitted = 0;
 
         /* Overflow-safe ceil division for n_cmds */
         size_t n_cmds = (p.size - 1) / max_xfer + 1;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,13 +212,25 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn scope guard. The five named rollback items
-     * are armed in acquisition order. Rollback runs in reverse order.
-     * Item 1: gate refs/flags. Item 2: batch_active claim.
-     * Items 3-5 are handled by the explicit rollback below for the
-     * private phase allocations. The gate (items 1+2) is rolled back
-     * by the explicit cleanup at setup_rollback. */
-    bool txn_gate_armed = true;   /* items 1+2 armed */
+    /* M3: BatchSetupTxn - RAII scope guard that rolls back gate state
+     * if the function exits via exception or early return before commit.
+     * Five items (acquired in order, rolled back in reverse):
+     *   1. handle_in_flight reference
+     *   2. batch_active claim
+     *   3. batch_setting_up flag (cleared LAST, under g_driver.lock)
+     * Items 4-5 (pool DMA, pool buf) are handled by the explicit
+     * setup_rollback label for non-throwing failures. */
+    struct BatchSetupTxn {
+        HandleState* hs;
+        bool armed;
+        ~BatchSetupTxn() {
+            if (!armed) return;
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            hs->batch_active.store(false, std::memory_order_release);
+            handle_release(hs);
+            hs->batch_setting_up.store(false, std::memory_order_release);
+        }
+    } txn{hs, true};
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -275,7 +287,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
-        txn_gate_armed = false;         /* commit: gate items disarmed */
+        txn.armed = false;           /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
@@ -301,6 +313,7 @@ setup_rollback:
          * DMA unmap, which needs hs->ctrl alive) has been undone. */
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
+    txn.armed = false;  /* explicit rollback done; prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,25 +212,31 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that rolls back gate state
+    /* M3: BatchSetupTxn - RAII scope guard that rolls back ALL five items
      * if the function exits via exception or early return before commit.
-     * Five items (acquired in order, rolled back in reverse):
-     *   1. handle_in_flight reference
-     *   2. batch_active claim
-     *   3. batch_setting_up flag (cleared LAST, under g_driver.lock)
-     * Items 4-5 (pool DMA, pool buf) are handled by the explicit
-     * setup_rollback label for non-throwing failures. */
+     * Items (acquired in order, rolled back in reverse):
+     *   5. pool DMA mapping
+     *   4. pool host buffer
+     *   3. batch_active claim
+     *   2. handle_in_flight reference
+     *   1. batch_setting_up flag (cleared LAST, under g_driver.lock) */
     struct BatchSetupTxn {
         HandleState* hs;
+        void** pool_buf;
+        nvm_dma_t** pool_dma;
         bool armed;
         ~BatchSetupTxn() {
             if (!armed) return;
+            /* Rollback items 5, 4 (raw resources) */
+            if (pool_dma && *pool_dma) { nvm_dma_unmap(*pool_dma); *pool_dma = nullptr; }
+            if (pool_buf && *pool_buf) { free(*pool_buf); *pool_buf = nullptr; }
+            /* Rollback items 3, 2, 1 (gate state) */
             std::lock_guard<std::mutex> g(g_driver.lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
         }
-    } txn{hs, true};
+    } txn{hs, nullptr, nullptr, true};
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -253,18 +259,21 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         goto setup_rollback;
     }
     std::memset(pool.buf, 0, pool_bytes);
+    txn.pool_buf = &pool.buf;  /* arm item 4 */
 
     {
         int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
         if (!nvm_ok(rc)) {
             free(pool.buf);
             pool.buf = nullptr;
+            txn.pool_buf = nullptr;  /* already freed */
             setup_err = (rc == ENOMEM)
                 ? make_error(UGDS_OUT_OF_MEMORY)
                 : make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
     }
+    txn.pool_dma = &pool.dma;  /* arm item 5 */
     pool.n_pages = UGDS_PRP_POOL_PAGES;
     pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
@@ -654,6 +663,7 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
                                               uGDSIOEvents_t* events,
                                               struct timespec* timeout)
 {
+    try {
     if (batch == nullptr || nr == nullptr || events == nullptr)
         return make_error(UGDS_INVALID_VALUE);
 
@@ -720,12 +730,15 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
 
         __builtin_ia32_pause();
     }
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 {
     if (batch == nullptr) return;
-
+    try {
     BatchState* bs = static_cast<BatchState*>(batch);
     HandleState* hs = bs->hs;
 
@@ -819,4 +832,9 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 
     /* link_pin then last_pin drop here; whichever is the final reference
      * runs ~BatchState with no guard addressing its members. */
+    } catch (...) {
+        /* Destroy is void; swallow to prevent crossing C ABI.
+         * The BatchState may be partially cleaned up but shared_ptr
+         * ref counts prevent double-free. */
+    }
 }

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -82,28 +82,39 @@ static void drain_release_scratch(BatchState* bs)
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        /* C1: release_entry_refs handles both PLAIN and VECTORED. */
+        /* release_entry_refs handles both PLAIN and VECTORED. */
         release_entry_refs(bs, entry);
     }
     bs->n_release_pending = 0;
 }
 
-/* Abort a Phase-3 entry that is WAITING, PENDING, or FAILED.
+/* Abort an entry that is WAITING or PENDING (not yet terminal).
+ *
  * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
  * -ECANCELED, and queues the entry for deferred release if all its
- * submitted commands have already completed.  Must be called
- * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1).
+ * submitted commands have already completed.  Must be called under
+ * bs->lock + qp.lock; does NOT touch g_driver.lock.
  *
- * C4 (review R1): abort also accepts the FAILED state so a device
- * error latched by drain_one_completion is not stranded: the submitted
- * prefix still drains exactly once and refs are released.  A COMPLETE
- * or TORN_DOWN entry is left untouched. */
+ * Entries already terminalized by drain_one_completion (device error
+ * latched as FAILED while the submitted prefix continues to drain)
+ * are still eligible: their remaining commands will drain, and the
+ * ECANCELED precedence in drain ensures consistent terminalization.
+ *
+ * Entries that were never submitted (preflight/resolve failures with
+ * n_cmds == 0 and n_completed already incremented) must be skipped to
+ * avoid double-counting.  We detect this with n_cmds == 0: such
+ * entries have no command-level lifecycle to abort. */
 static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
 {
     BatchIOEntry& entry = bs->entries[idx];
     if (entry.status != UGDS_BATCH_WAITING &&
         entry.status != UGDS_BATCH_PENDING &&
         entry.status != UGDS_BATCH_FAILED)
+        return;
+    /* Skip entries that were terminalized before any submission
+     * (preflight or resolve failure).  These already incremented
+     * n_completed and have no command lifecycle to abort. */
+    if (entry.n_cmds == 0)
         return;
     entry.error_code = -ECANCELED;
     entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -850,3 +850,470 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
          * ref counts prevent double-free. */
     }
 }
+
+/* ======================================================================== */
+/* uGDSBatchIOSubmitv: vectored batch submit                              */
+/* ======================================================================== */
+
+/* Registry preflight result: a stack record filled under g_driver.lock
+ * without taking refs.  Classifies each entry so the caller can size
+ * the work array before any ref acquisition or allocation. */
+struct PreflightResult {
+    bool        valid;
+};
+
+/* Pure value validation for one vectored entry.
+ * Performs the value-matrix checks and computes the analytic window
+ * count via sgl_count_windows_analytic.  Writes nothing to bs.
+ * Returns true on success (out_n_cmds set), false on value error. */
+static bool submitv_validate_entry(const uGDSIOSegParams_t& p,
+                                   size_t page_size, size_t block_size,
+                                   size_t window_cap, size_t SU,
+                                   uint32_t* out_n_cmds)
+{
+    if (p.segs == nullptr || p.nr_segs == 0)
+        return false;
+    if (p.nr_segs > UGDS_BATCH_IOV_MAX)
+        return false;
+    if (p.file_offset < 0)
+        return false;
+    if ((static_cast<size_t>(p.file_offset) % block_size) != 0)
+        return false;
+
+    /* opcode check */
+    if (p.opcode != UGDS_READ && p.opcode != UGDS_WRITE)
+        return false;
+
+    uint64_t total_size = 0;
+    for (unsigned k = 0; k < p.nr_segs; ++k) {
+        if (p.segs[k].base == nullptr || p.segs[k].size == 0)
+            return false;
+        if (p.segs[k].offset < 0)
+            return false;
+        if ((static_cast<size_t>(p.segs[k].offset) % page_size) != 0)
+            return false;
+        if ((p.segs[k].size % block_size) != 0)
+            return false;
+
+        uint64_t seg_size = static_cast<uint64_t>(p.segs[k].size);
+        if (seg_size > static_cast<uint64_t>(SSIZE_MAX) - total_size)
+            return false;  /* total overflow */
+        total_size += seg_size;
+    }
+
+    /* Analytic window count over the segment array.  O(nr_segs). */
+    uint32_t n_cmds = 0;
+    if (!sgl_count_windows_analytic(p.segs, p.nr_segs,
+                                    window_cap, page_size, block_size,
+                                    &n_cmds))
+        return false;
+
+    if (n_cmds == 0)
+        return false;
+
+    (void)SU;  /* window_cap already incorporates SU rounding */
+    *out_n_cmds = n_cmds;
+    return true;
+}
+
+extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
+                                            uGDSIOSegParams_t* iocb,
+                                            unsigned flags)
+{
+    try {
+    /* ==================================================================
+     * Basic call/batch checks (no state mutation)
+     * ================================================================== */
+    if (batch == nullptr || iocb == nullptr || nr == 0)
+        return make_error(UGDS_INVALID_VALUE);
+
+    BatchState* bs = static_cast<BatchState*>(batch);
+    std::lock_guard<std::mutex> batch_lock(bs->lock);
+
+    if (bs->hs->wedged.load(std::memory_order_acquire) ||
+        bs->hs->closing.load(std::memory_order_acquire))
+        return make_error(UGDS_BUSY);
+
+    if (bs->lifecycle != BATCH_LIFECYCLE_ACTIVE)
+        return make_error(UGDS_INVALID_VALUE);
+
+    if (bs->n_entries + nr > bs->capacity)
+        return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
+
+    (void)flags;
+
+    /* recycle: same path as plain submit, plus arena_used reset. */
+    if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
+        bs->n_entries = 0;
+        bs->n_completed = 0;
+        bs->n_events_read = 0;
+        bs->arena_used = 0;
+    }
+
+    HandleState* hs = bs->hs;
+    IOQueuePair& qp = hs->batch_qp->qp;
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+    const size_t max_xfer   = compute_max_xfer(hs);
+
+    /* Compute SU and window_cap (parity with sync vectored path). */
+    const size_t SU = (page_size > block_size &&
+                       (page_size & (page_size - 1)) == 0 &&
+                       (block_size & (block_size - 1)) == 0)
+                      ? std::max(page_size, block_size)
+                      : [&]() {
+                          size_t a = page_size, b = block_size;
+                          while (b != 0) { size_t t = a % b; a = b; b = t; }
+                          return (page_size / a) * block_size;
+                      }();
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* ==================================================================
+     * Validate -> preflight -> allocate -> commit-copy
+     * ================================================================== */
+
+    /* --- Step 1: Pure value validation (all entries, no state write) --- */
+    unsigned base = bs->n_entries;
+
+    uint32_t per_entry_n_cmds[UGDS_MAX_BATCH_IO_SIZE];
+    uint64_t total_cmds = 0;
+    for (unsigned i = 0; i < nr; ++i) {
+        uint32_t n_cmds_i = 0;
+        if (!submitv_validate_entry(iocb[i], page_size, block_size,
+                                    window_cap, SU, &n_cmds_i))
+            return make_error(UGDS_INVALID_VALUE);
+
+        /* checked addition for total_cmds */
+        if (total_cmds > UINT64_MAX - n_cmds_i)
+            return make_error(UGDS_INVALID_VALUE);
+        total_cmds += n_cmds_i;
+        per_entry_n_cmds[i] = n_cmds_i;
+    }
+
+    if (total_cmds > UINT32_MAX)
+        return make_error(UGDS_INVALID_VALUE);
+
+    /* --- Step 2: Registry preflight (read-only, no refs) ---
+     * Classifies each entry; failures become terminal FAILED -EINVAL
+     * and contribute zero to alloc_cmds. */
+    PreflightResult preflight[UGDS_MAX_BATCH_IO_SIZE];
+    uint64_t alloc_cmds = 0;
+    {
+        std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+        for (unsigned i = 0; i < nr; ++i) {
+            const uGDSIOSegParams_t& p = iocb[i];
+            bool ok = true;
+
+            /* Check every segment: registration, exact-length, affinity. */
+            for (unsigned k = 0; k < p.nr_segs && ok; ++k) {
+                auto it = g_driver.buf_registry.find(p.segs[k].base);
+                if (it == g_driver.buf_registry.end()) {
+                    ok = false;
+                    break;
+                }
+                DriverState::BufEntry& be = it->second;
+                /* Controller affinity check */
+                if (be.map_ctrl != hs->ctrl) { ok = false; break; }
+                /* Exact-length bounds */
+                const uint64_t off = static_cast<uint64_t>(p.segs[k].offset);
+                const uint64_t sz  = static_cast<uint64_t>(p.segs[k].size);
+                if (off > be.length || sz > be.length - off) {
+                    ok = false;
+                    break;
+                }
+            }
+
+            preflight[i].valid = ok;
+            if (ok) {
+                alloc_cmds += per_entry_n_cmds[i];
+            }
+        }
+    }
+
+    /* --- Step 3: Allocate (fallible, still no entry/watermark mutation) ---
+     * First the local work array, then the one-time arena resize.
+     * The arena resize is the final fallible operation before commit. */
+    std::vector<SubCmdV> work;
+    if (alloc_cmds > 0)
+        work.resize(static_cast<size_t>(alloc_cmds));
+
+    if (bs->seg_arena.empty()) {
+        /* One lifetime allocation: capacity * UGDS_BATCH_IOV_MAX.
+         * capacity <= 128, UGDS_BATCH_IOV_MAX = 128, so <= 16384
+         * SegView elements (~48 B each = ~768 KiB). */
+        size_t arena_elems = static_cast<size_t>(bs->capacity) *
+                             static_cast<size_t>(UGDS_BATCH_IOV_MAX);
+        bs->seg_arena.resize(arena_elems);
+    }
+
+    /* --- Step 4: Commit-copy (infallible) ---
+     * From here, no allocation or throw is possible.  Capture the
+     * watermark for rollback safety; populate entries and arena.
+     * The watermark is the 8.4 rollback anchor: it is never restored
+     * in this path because no operation after this point can fail, but
+     * it documents the invariant and serves as the audit point for the
+     * fixed-size arena model. */
+    const uint32_t watermark = bs->arena_used;
+    (void)watermark;  /* documented rollback anchor; no post-commit failure */
+    uint32_t work_used = 0;
+
+    for (unsigned i = 0; i < nr; ++i) {
+        unsigned idx = base + i;
+        BatchIOEntry& entry = bs->entries[idx];
+        const uGDSIOSegParams_t& p = iocb[i];
+
+        /* Clear entry fields for both success and failure paths. */
+        entry.cookie = p.cookie;
+        entry.devPtr_base = nullptr;   /* not used for vectored */
+        entry.file_offset = p.file_offset;
+        entry.devPtr_offset = 0;
+        entry.size = 0;
+        entry.opcode = (p.opcode == UGDS_READ) ? NVM_IO_READ : NVM_IO_WRITE;
+        entry.status = UGDS_BATCH_WAITING;
+        entry.bytes_done = 0;
+        entry.error_code = 0;
+        entry.n_cmds_done = 0;
+        entry.event_returned = false;
+        entry.refs_held = false;
+        entry.release_queued = false;
+        entry.n_cmds_submitted = 0;
+
+        if (!preflight[i].valid) {
+            /* Preflight failure: terminal FAILED -EINVAL, n_cmds = 0. */
+            entry.kind = BATCH_ENTRY_VECTORED;
+            entry.seg_begin = 0;
+            entry.seg_count = 0;
+            entry.n_cmds = 0;
+            entry.status = UGDS_BATCH_FAILED;
+            entry.error_code = -EINVAL;
+            bs->n_completed++;
+            continue;
+        }
+
+        /* Preflight-valid entry: copy segments into the arena. */
+        assert(bs->arena_used + p.nr_segs <= bs->seg_arena.size());
+        entry.kind = BATCH_ENTRY_VECTORED;
+        entry.seg_begin = bs->arena_used;
+        entry.seg_count = static_cast<uint32_t>(p.nr_segs);
+        entry.n_cmds = static_cast<uint16_t>(per_entry_n_cmds[i]);
+
+        for (unsigned k = 0; k < p.nr_segs; ++k) {
+            bs->seg_arena[bs->arena_used + k] = SegView{};
+        }
+        bs->arena_used += static_cast<uint32_t>(p.nr_segs);
+    }
+
+    /* ==================================================================
+     * Acquiring resolve / build
+     * ==================================================================
+     * For each preflight-valid entry, acquire refs (all-or-nothing per
+     * entry via SglRefOwner), resolve SegView geometry into the arena,
+     * and stream windows into the work array via SglWindowCursor. */
+
+    for (unsigned i = 0; i < nr; ++i) {
+        unsigned idx = base + i;
+        BatchIOEntry& entry = bs->entries[idx];
+
+        /* Skip entries already terminalized in commit-copy. */
+        if (entry.status == UGDS_BATCH_FAILED)
+            continue;
+
+        const uGDSIOSegParams_t& p = iocb[i];
+        SegView* seg_views = bs->seg_arena.data() + entry.seg_begin;
+
+        /* Acquire in-flight refs and resolve geometry (all-or-nothing). */
+        SglRefOwner owner;
+        int rc = owner.acquire(p.segs, static_cast<uint32_t>(p.nr_segs),
+                               hs->ctrl, page_size, seg_views);
+        if (rc != 0) {
+            /* Resolve failure: entry-local.  No work items emitted. */
+            entry.status = UGDS_BATCH_FAILED;
+            entry.error_code = -EINVAL;
+            entry.n_cmds = 0;
+            entry.n_cmds_done = 0;
+            entry.n_cmds_submitted = 0;
+            bs->n_completed++;
+            /* owner is empty (all-or-nothing), nothing to release. */
+            continue;
+        }
+
+        /* refs are now held by the arena; mark for deferred release. */
+        entry.refs_held = true;
+
+        /* Stream windows into the work array. */
+        SglWindowCursor cursor;
+        sgl_cursor_init(cursor, seg_views, static_cast<uint32_t>(p.nr_segs),
+                        window_cap, page_size, block_size);
+
+        uint64_t current_lba =
+            static_cast<uint64_t>(p.file_offset) / block_size;
+
+        CmdWindow win;
+        while (sgl_cursor_next(cursor, win)) {
+            assert(work_used < work.size());
+            work[work_used].io_idx = idx;
+            work[work_used].lba    = current_lba;
+            work[work_used].window = win;
+            work_used++;
+
+            current_lba += win.bytes / block_size;
+        }
+    }
+
+    /* ==================================================================
+     * Enqueue (mirrors the plain submit)
+     * ================================================================== */
+    {
+        std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        for (uint32_t wi = 0; wi < work_used; ++wi) {
+            SubCmdV& sc = work[wi];
+            BatchIOEntry& entry = bs->entries[sc.io_idx];
+
+            const size_t n_pages = sc.window.n_pages;
+            SegView* seg_views = bs->seg_arena.data() + entry.seg_begin;
+
+            /* PRP pool page for windows needing a list (> 2 pages). */
+            uint16_t prp_idx = UINT16_MAX;
+            if (n_pages > 2) {
+                int pidx = prp_pool_alloc(&bs->prp_pool);
+                if (pidx < 0) {
+                    /* Pool exhaustion: submit ring, then drain loop. */
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    uint64_t spins = 0;
+                    const uint64_t max_spins =
+                        (uint64_t)hs->ctrl->timeout * 1000000ULL;
+                    while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
+                        if (!drain_one_completion(qp, bs)) {
+                            if (++spins > max_spins) {
+                                nvm_sq_submit(&qp.sq);
+                                std::atomic_thread_fence(
+                                    std::memory_order_seq_cst);
+                                for (unsigned i = sc.io_idx;
+                                     i < base + nr; ++i)
+                                    abort_phase3_entry(bs, i);
+                                bs->n_entries += nr;
+                                goto phase3v_abort_return;
+                            }
+                            __builtin_ia32_pause();
+                        }
+                    }
+                }
+                prp_idx = static_cast<uint16_t>(pidx);
+            }
+
+            uint16_t slot = static_cast<uint16_t>(
+                qp.sq.tail.load(std::memory_order_relaxed) % qp.sq.qs);
+            nvm_cmd_t* cmd = nvm_sq_enqueue(&qp.sq);
+
+            if (cmd == nullptr) {
+                /* SQ full: submit ring, drain, retry. */
+                nvm_sq_submit(&qp.sq);
+                std::atomic_thread_fence(std::memory_order_seq_cst);
+
+                uint64_t spins = 0;
+                const uint64_t max_spins =
+                    (uint64_t)hs->ctrl->timeout * 1000000ULL;
+                bool drained = false;
+                while (!drained) {
+                    if (drain_one_completion(qp, bs)) {
+                        drained = true;
+                    } else if (++spins > max_spins) {
+                        if (prp_idx != UINT16_MAX)
+                            prp_pool_free(&bs->prp_pool, prp_idx);
+                        nvm_sq_submit(&qp.sq);
+                        std::atomic_thread_fence(std::memory_order_seq_cst);
+                        for (unsigned i = sc.io_idx; i < base + nr; ++i)
+                            abort_phase3_entry(bs, i);
+                        bs->n_entries += nr;
+                        goto phase3v_abort_return;
+                    } else {
+                        __builtin_ia32_pause();
+                    }
+                }
+
+                slot = static_cast<uint16_t>(
+                    qp.sq.tail.load(std::memory_order_relaxed) % qp.sq.qs);
+                cmd = nvm_sq_enqueue(&qp.sq);
+                if (cmd == nullptr) {
+                    if (prp_idx != UINT16_MAX)
+                        prp_pool_free(&bs->prp_pool, prp_idx);
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    for (unsigned i = sc.io_idx; i < base + nr; ++i)
+                        abort_phase3_entry(bs, i);
+                    bs->n_entries += nr;
+                    goto phase3v_abort_return;
+                }
+            }
+
+            memset(cmd, 0, sizeof(nvm_cmd_t));
+            nvm_cmd_header(cmd, slot, entry.opcode, hs->ns_id);
+
+            /* Build PRP via SglPageCursor. */
+            SglPageCursor pc;
+            sgl_page_cursor_init(pc, seg_views,
+                                 sc.window.first_seg,
+                                 sc.window.first_seg_page_off,
+                                 sc.window.n_segs, sc.window.n_pages);
+
+            if (n_pages == 1) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, 0);
+            } else if (n_pages == 2) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                uint64_t prp2 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, prp2);
+            } else {
+                volatile uint64_t* prp_list =
+                    reinterpret_cast<volatile uint64_t*>(
+                        static_cast<uint8_t*>(bs->prp_pool.buf) +
+                        prp_idx * page_size);
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                for (size_t p = 1; p < n_pages; ++p)
+                    prp_list[p - 1] = sgl_page_cursor_next(pc);
+                sgl_publish_prp();
+                nvm_cmd_data_ptr(cmd, prp1,
+                                 bs->prp_pool.dma->ioaddrs[prp_idx]);
+            }
+
+            size_t n_blocks = sc.window.bytes / block_size;
+            nvm_cmd_rw_blks(cmd, sc.lba, static_cast<uint16_t>(n_blocks));
+
+            CmdSlot& cs = bs->cmd_map[slot];
+            cs.io_idx = static_cast<uint16_t>(sc.io_idx);
+            cs.chunk_bytes = sc.window.bytes;
+            cs.prp_page_idx = prp_idx;
+            cs.active = true;
+            bs->in_flight++;
+
+            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING. */
+            entry.n_cmds_submitted++;
+            entry.status = UGDS_BATCH_PENDING;
+        }
+
+        /* Single doorbell for all enqueued commands. */
+        sgl_publish_prp();
+        nvm_sq_submit(&qp.sq);
+        sgl_publish_prp();
+    }
+
+    /* Drain deferred releases after qp.lock is released. */
+    drain_release_scratch(bs);
+
+    bs->n_entries += nr;
+    return UGDS_OK;
+
+phase3v_abort_return:
+    /* Abort path: the abort helper queued entries for deferred release. */
+    drain_release_scratch(bs);
+    return make_error(UGDS_INTERNAL_ERROR);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+}

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -911,6 +911,11 @@ static bool submitv_validate_entry(const uGDSIOSegParams_t& p,
     if (n_cmds == 0)
         return false;
 
+    /* BatchIOEntry::n_cmds is uint16_t.  Reject counts that would
+     * truncate before any allocation or commit-copy. */
+    if (n_cmds > UINT16_MAX)
+        return false;
+
     (void)SU;  /* window_cap already incorporates SU rounding */
     *out_n_cmds = n_cmds;
     return true;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -12,7 +12,8 @@
 #include <memory>
 
 /* Release in-flight reference held by batch submit.
- * Called on validation failure or when batch entry completes. */
+ * Called on validation failure or when batch entry completes.
+ * MUST be called WITHOUT holding g_driver.lock. */
 static void async_release_inflight_batch(void* devPtr_base)
 {
     std::lock_guard<std::mutex> drv_lock(g_driver.lock);
@@ -35,9 +36,10 @@ static inline void queue_entry_release(BatchState* bs, unsigned idx)
 }
 
 /* Drain all pending deferred releases in one g_driver.lock hold.
- * Must be called under bs->lock but NOT under qp.lock.
- * Clears refs_held and release_queued for each drained index, then
- * resets n_release_pending. */
+ * Must be called under bs->lock but NOT under qp.lock and NOT under
+ * g_driver.lock (the old version called
+ * async_release_inflight_batch which re-locked g_driver.lock, causing
+ * a deadlock on a non-recursive mutex). */
 static void drain_release_scratch(BatchState* bs)
 {
     if (bs->n_release_pending == 0) return;
@@ -46,7 +48,12 @@ static void drain_release_scratch(BatchState* bs)
         uint32_t idx = bs->release_scratch[i];
         BatchIOEntry& entry = bs->entries[idx];
         if (!entry.refs_held) continue;  /* already released */
-        async_release_inflight_batch(entry.devPtr_base);
+        /* Inline the decrement instead of calling
+         * async_release_inflight_batch to avoid re-locking
+         * g_driver.lock (nested-lock bug fix). */
+        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
         entry.refs_held = false;
         entry.release_queued = false;
     }
@@ -76,7 +83,7 @@ static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
      * terminalize when n_cmds_done == n_cmds. */
 }
 
-static void cleanup_prp_pool(BatchState* bs)
+void cleanup_prp_pool(BatchState* bs)
 {
     PRPPool& pool = bs->prp_pool;
     if (pool.dma) nvm_dma_unmap(pool.dma);
@@ -169,6 +176,7 @@ static size_t compute_max_xfer(HandleState* hs)
 extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
                                           uGDSHandle_t fh, unsigned nr)
 {
+    try {
     if (batch == nullptr || fh == nullptr)
         return make_error(UGDS_INVALID_VALUE);
     if (nr == 0 || nr > UGDS_MAX_BATCH_IO_SIZE)
@@ -203,6 +211,14 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs = hs_sp.get();
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
+
+    /* M3: BatchSetupTxn scope guard. The five named rollback items
+     * are armed in acquisition order. Rollback runs in reverse order.
+     * Item 1: gate refs/flags. Item 2: batch_active claim.
+     * Items 3-5 are handled by the explicit rollback below for the
+     * private phase allocations. The gate (items 1+2) is rolled back
+     * by the explicit cleanup at setup_rollback. */
+    bool txn_gate_armed = true;   /* items 1+2 armed */
 
     /* --- Private, fallible phase --- */
     auto bs_sp = std::make_shared<BatchState>();
@@ -259,6 +275,7 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
+        txn_gate_armed = false;         /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
@@ -285,11 +302,17 @@ setup_rollback:
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
     return setup_err;
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                                            uGDSIOParams_t* iocb, unsigned flags)
 {
+    try {
     if (batch == nullptr || iocb == nullptr || nr == 0)
         return make_error(UGDS_INVALID_VALUE);
 
@@ -387,11 +410,29 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             std::lock_guard<std::mutex> drv_lock(g_driver.lock);
             auto it = g_driver.buf_registry.find(entry.devPtr_base);
             if (it != g_driver.buf_registry.end()) {
-                buf_dma = it->second.dma;
+                /* Controller affinity check. */
+                if (it->second.map_ctrl != hs->ctrl) {
+                    buf_dma = nullptr;
+                }
+                /* Exact-length bounds. */
+                else {
+                    const uint64_t off =
+                        static_cast<uint64_t>(entry.devPtr_offset);
+                    const uint64_t sz  =
+                        static_cast<uint64_t>(entry.size);
+                    if (off > it->second.length ||
+                        sz > it->second.length - off) {
+                        buf_dma = nullptr;
+                    } else {
+                        buf_dma = it->second.dma;
+                    }
+                }
                 /* Hold in-flight reference until batch completions are drained
                  * or destroy finishes. Prevents Deregister from unmapping
                  * while batch commands retain PRPs from this buffer. */
                 it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+                /* Mark that this entry holds a deferred in-flight ref. */
+                entry.refs_held = true;
             }
         }
 
@@ -401,6 +442,8 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
+            /* Use deferred release so refs_held is consistent. */
+            queue_entry_release(bs, idx);
             continue;
         }
 
@@ -410,12 +453,12 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
-            async_release_inflight_batch(entry.devPtr_base);
+            queue_entry_release(bs, idx);
             continue;
         }
         buf_page_start = static_cast<size_t>(entry.devPtr_offset) / page_size;
 
-        /* Overflow-safe bounds check */
+        /* Defensive page-count bounds check (subsumed by exact-length check). */
         size_t batch_pages_needed = (entry.size - 1) / page_size + 1;
         if (batch_pages_needed > buf_dma->n_ioaddrs ||
             buf_page_start > buf_dma->n_ioaddrs - batch_pages_needed) {
@@ -424,7 +467,7 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             entry.n_cmds = 0;
             entry.n_cmds_done = 0;
             bs->n_completed++;
-            async_release_inflight_batch(entry.devPtr_base);
+            queue_entry_release(bs, idx);
             continue;
         }
 
@@ -466,22 +509,17 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     while ((pidx = prp_pool_alloc(&bs->prp_pool)) < 0) {
                         if (!drain_one_completion(qp, bs)) {
                             if (++spins > max_spins) {
-                                /* Release in_flight refs only for entries
-                                 * that are still WAITING (ref acquired but
-                                 * not yet submitted). PENDING entries have
-                                 * commands in the SQ -- keep ref until drain.
-                                 * COMPLETE entries were already released by
-                                 * drain_one_completion. FAILED already done. */
-                                for (unsigned i = 0; i < nr; ++i) {
-                                    BatchIOEntry& e = bs->entries[base + i];
-                                    if (e.status == UGDS_BATCH_WAITING) {
-                                        async_release_inflight_batch(e.devPtr_base);
-                                        e.status = UGDS_BATCH_FAILED;
-                                        e.n_cmds = 0;
-                                    }
+                                /* Abort current and later entries via
+                                 * the common helper. WAITING + PENDING
+                                 * are both handled. Ring the SQ doorbell
+                                 * for the accepted prefix. */
+                                nvm_sq_submit(&qp.sq);
+                                std::atomic_thread_fence(std::memory_order_seq_cst);
+                                for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                                    abort_phase3_entry(bs, i);
                                 }
                                 bs->n_entries += nr;
-                                return make_error(UGDS_INTERNAL_ERROR);
+                                goto phase3_abort_return;
                             }
                             __builtin_ia32_pause();
                         }
@@ -507,17 +545,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                     } else if (++spins > max_spins) {
                         if (prp_idx != UINT16_MAX)
                             prp_pool_free(&bs->prp_pool, prp_idx);
-                        /* Release in_flight refs only for WAITING entries. */
-                        for (unsigned i = 0; i < nr; ++i) {
-                            BatchIOEntry& e = bs->entries[base + i];
-                            if (e.status == UGDS_BATCH_WAITING) {
-                                async_release_inflight_batch(e.devPtr_base);
-                                e.status = UGDS_BATCH_FAILED;
-                                e.n_cmds = 0;
-                            }
+                        /* Abort current and later entries. */
+                        nvm_sq_submit(&qp.sq);
+                        std::atomic_thread_fence(std::memory_order_seq_cst);
+                        for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                            abort_phase3_entry(bs, i);
                         }
                         bs->n_entries += nr;
-                        return make_error(UGDS_INTERNAL_ERROR);
+                        goto phase3_abort_return;
                     } else {
                         __builtin_ia32_pause();
                     }
@@ -529,17 +564,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
                 if (cmd == nullptr) {
                     if (prp_idx != UINT16_MAX)
                         prp_pool_free(&bs->prp_pool, prp_idx);
-                    /* Release in_flight refs only for WAITING entries. */
-                    for (unsigned i = 0; i < nr; ++i) {
-                        BatchIOEntry& e = bs->entries[base + i];
-                        if (e.status == UGDS_BATCH_WAITING) {
-                            async_release_inflight_batch(e.devPtr_base);
-                            e.status = UGDS_BATCH_FAILED;
-                            e.n_cmds = 0;
-                        }
+                    /* Abort current and later entries. */
+                    nvm_sq_submit(&qp.sq);
+                    std::atomic_thread_fence(std::memory_order_seq_cst);
+                    for (unsigned i = sc.io_idx; i < base + nr; ++i) {
+                        abort_phase3_entry(bs, i);
                     }
                     bs->n_entries += nr;
-                    return make_error(UGDS_INTERNAL_ERROR);
+                    goto phase3_abort_return;
                 }
             }
 
@@ -574,6 +606,9 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
+            /* M2: commit the slot map first, then increment
+             * n_cmds_submitted, then transition WAITING->PENDING. */
+            entry.n_cmds_submitted++;
             entry.status = UGDS_BATCH_PENDING;
         }
 
@@ -583,8 +618,22 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         std::atomic_thread_fence(std::memory_order_seq_cst);
     }
 
+    /* Drain deferred releases after qp.lock is released. */
+    drain_release_scratch(bs);
+
     bs->n_entries += nr;
     return UGDS_OK;
+
+phase3_abort_return:
+    /* Drain deferred releases after qp.lock is released.  The abort
+     * helper queued WAITING/PENDING entries for release. */
+    drain_release_scratch(bs);
+    return make_error(UGDS_INTERNAL_ERROR);
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
@@ -623,6 +672,9 @@ extern "C" uGDSError_t uGDSBatchIOGetStatus(uGDSBatchHandle_t batch,
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             while (drain_one_completion(qp, bs)) {}
         }
+
+        /* Drain deferred releases after qp.lock is released. */
+        drain_release_scratch(bs);
 
         for (unsigned i = 0; i < bs->n_entries && n_ready < max_events; ++i) {
             BatchIOEntry& entry = bs->entries[i];
@@ -663,73 +715,95 @@ extern "C" void uGDSBatchIODestroy(uGDSBatchHandle_t batch)
 
     BatchState* bs = static_cast<BatchState*>(batch);
     HandleState* hs = bs->hs;
-    IOQueuePair& qp = hs->batch_qp->qp;
 
-    // Drain remaining in-flight commands
-    if (bs->in_flight > 0) {
-        std::lock_guard<std::mutex> qp_lock(qp.lock);
-        uint64_t spins = 0;
-        const uint64_t max_spins = (uint64_t)hs->ctrl->timeout * 1000000ULL;
-        while (bs->in_flight > 0) {
-            if (!drain_one_completion(qp, bs)) {
-                if (++spins > max_spins) break;
-                __builtin_ia32_pause();
-            } else {
-                spins = 0;
+    /* Pin rule: declare pins BEFORE the lock guard so they outlive
+     * it. C++ destroys locals in reverse construction order: the
+     * guard unlocks before the pins drop. This prevents ~BatchState
+     * from running while the mutex is still locked. */
+    std::shared_ptr<BatchState> last_pin;
+    std::shared_ptr<BatchState> link_pin;
+
+    {
+        std::lock_guard<std::mutex> bl(bs->lock);
+
+        /* Tombstone check: if a force teardown already set TORN_DOWN,
+         * this is the post-force one-shot Destroy. Transfer self into
+         * a local pin and let the guard unlock before the pin drops. */
+        if (bs->lifecycle == BATCH_LIFECYCLE_TORN_DOWN) {
+            last_pin = std::move(bs->self);
+            return;
+        }
+
+        /* Drain remaining in-flight commands under bs->lock -> qp.lock. */
+        IOQueuePair& qp = hs->batch_qp->qp;
+        if (bs->in_flight > 0) {
+            std::lock_guard<std::mutex> qp_lock(qp.lock);
+            uint64_t spins = 0;
+            const uint64_t max_spins = (uint64_t)hs->ctrl->timeout * 1000000ULL;
+            while (bs->in_flight > 0) {
+                if (!drain_one_completion(qp, bs)) {
+                    if (++spins > max_spins) break;
+                    __builtin_ia32_pause();
+                } else {
+                    spins = 0;
+                }
             }
         }
-    }
 
-    /* Best-effort: release in-flight references for entries that were
-     * submitted but never fully completed (e.g., submit phase-3 early
-     * return). Check n_cmds_done < n_cmds rather than status alone.
-     *
-     * IMPORTANT: do NOT release refs for entries that have commands
-     * still outstanding in the NVMe SQ (bs->in_flight > 0 after drain).
-     * Those commands may still DMA. Leaking the refs (blocking
-     * deregister) is strictly safer than freeing mappings while the
-     * device may still access them. The caller should reset the
-     * controller if truly stuck. */
-    if (bs->in_flight == 0) {
+        if (bs->in_flight > 0) {
+            /* Wedge: commands still in flight after drain timeout.
+             * Retain everything (self, link, handle ref, batch_active)
+             * so force recovery can find the object. Transition to
+             * WEDGED and return -- the one-shot Destroy was consumed. */
+            bs->lifecycle = BATCH_LIFECYCLE_WEDGED;
+            hs->wedged.store(true, std::memory_order_release);
+            fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
+                    "flight after drain timeout -- handle is now wedged "
+                    "to prevent DMA-after-unmap. Controller reset required.\n",
+                    bs->in_flight);
+            return;
+        }
+
+        /* --- Resource release (allocation-free) --- */
+
+        /* Drain any live release_scratch prefix first. */
+        drain_release_scratch(bs);
+
+        /* Scan for remaining refs_held entries and queue them. */
         for (unsigned i = 0; i < bs->n_entries; ++i) {
             BatchIOEntry& entry = bs->entries[i];
-            if (entry.n_cmds > 0 && entry.n_cmds_done < entry.n_cmds) {
-                async_release_inflight_batch(entry.devPtr_base);
-                entry.status = UGDS_BATCH_FAILED;
+            if (entry.refs_held && !entry.release_queued) {
+                queue_entry_release(bs, i);
             }
         }
-    } else {
-        /* Commands still in flight after drain timeout.
-         * The NVMe device may still DMA through the PRP list and CQ,
-         * so we must NOT: free the PRP pool, release handle ref,
-         * delete the batch state, or clear batch_active.
-         *
-         * Keeping batch_active=true prevents a new BatchIOSetUp from
-         * reusing the same QP while old completions may still arrive.
-         * Keeping the handle ref prevents HandleDeregister from freeing
-         * the QP while DMA is in progress.
-         *
-         * This wedges the handle until the caller resets the controller.
-         * BatchIODestroy is void so the caller cannot detect this --
-         * the warning is the only signal. This is the safest option:
-         * a wedged handle is strictly better than DMA-after-unmap. */
-        fprintf(stderr, "uGDS: BatchIODestroy: %u commands still in "
-                "flight after drain timeout -- handle is now wedged "
-                "to prevent DMA-after-unmap. Controller reset required.\n",
-                bs->in_flight);
-        hs->wedged.store(true, std::memory_order_release);
-        return;
-    }
+        /* Final drain for remaining held entries. */
+        drain_release_scratch(bs);
 
-    cleanup_prp_pool(bs);
+        cleanup_prp_pool(bs);
+        bs->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
 
-    /* Mark batch inactive before releasing handle ref.
-     * HandleDeregister waits on handle_in_flight==0, so we must not
-     * touch hs after release. */
-    hs->batch_active.store(false);
+        /* --- Link transaction: one g_driver.lock section --- */
+        {
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            if (hs->active_batch.get() == bs) {
+                /* Pointer-verified detach: move OUR link into a local pin,
+                 * then clear batch_active ONLY after the detach. */
+                link_pin = std::move(hs->active_batch);
+                hs->batch_active.store(false, std::memory_order_release);
+            }
+            /* else: a concurrent force walk already moved the link.
+             * Do NOT clear batch_active -- the handle is closing. */
+        }
 
-    /* Release handle reference acquired in BatchIOSetUp */
-    handle_release(hs);
+        /* Release the SetUp-time handle reference. hs stays alive via
+         * bs->hs_sp. */
+        handle_release(hs);
 
-    delete bs;
+        /* Pin rule: transfer self into last_pin. The object stays alive
+         * until the guard releases the mutex and last_pin drops. */
+        last_pin = std::move(bs->self);
+    }  /* bl unlocks here -- object alive via last_pin (+ link_pin) */
+
+    /* link_pin then last_pin drop here; whichever is the final reference
+     * runs ~BatchState with no guard addressing its members. */
 }

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -64,16 +64,22 @@ static void drain_release_scratch(BatchState* bs)
     bs->n_release_pending = 0;
 }
 
-/* Abort a Phase-3 entry that is WAITING or PENDING.
+/* Abort a Phase-3 entry that is WAITING, PENDING, or FAILED.
  * Truncates n_cmds to the submitted prefix (n_cmds_submitted), records
  * -ECANCELED, and queues the entry for deferred release if all its
  * submitted commands have already completed.  Must be called
- * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1). */
+ * under bs->lock + qp.lock; does NOT touch g_driver.lock (R2 MINOR-1).
+ *
+ * C4 (review R1): abort also accepts the FAILED state so a device
+ * error latched by drain_one_completion is not stranded: the submitted
+ * prefix still drains exactly once and refs are released.  A COMPLETE
+ * or TORN_DOWN entry is left untouched. */
 static inline void abort_phase3_entry(BatchState* bs, unsigned idx)
 {
     BatchIOEntry& entry = bs->entries[idx];
     if (entry.status != UGDS_BATCH_WAITING &&
-        entry.status != UGDS_BATCH_PENDING)
+        entry.status != UGDS_BATCH_PENDING &&
+        entry.status != UGDS_BATCH_FAILED)
         return;
     entry.error_code = -ECANCELED;
     entry.n_cmds = entry.n_cmds_submitted;  /* discard unsubmitted suffix */
@@ -646,10 +652,14 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
-            /* M2: commit the slot map first, then increment
-             * n_cmds_submitted, then transition WAITING->PENDING. */
+            /* Commit the slot map first, then increment
+             * n_cmds_submitted, then transition WAITING->PENDING.
+             * Only WAITING -> PENDING is allowed; do not overwrite a
+             * latched FAILED state from an earlier
+             * drain_one_completion during backpressure. */
             entry.n_cmds_submitted++;
-            entry.status = UGDS_BATCH_PENDING;
+            if (entry.status == UGDS_BATCH_WAITING)
+                entry.status = UGDS_BATCH_PENDING;
         }
 
         // Single doorbell for all commands
@@ -1322,9 +1332,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
             cs.active = true;
             bs->in_flight++;
 
-            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING. */
+            /* Commit slot map, then n_cmds_submitted, then WAITING->PENDING.
+             * Only WAITING -> PENDING is allowed; a latched FAILED from
+             * an earlier drain_one_completion during backpressure must
+             * persist. */
             entry.n_cmds_submitted++;
-            entry.status = UGDS_BATCH_PENDING;
+            if (entry.status == UGDS_BATCH_WAITING)
+                entry.status = UGDS_BATCH_PENDING;
         }
 
         /* Single doorbell for all enqueued commands. */

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -11,6 +11,10 @@
 #include <new>
 #include <memory>
 
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
+
 /* Release in-flight reference held by batch submit.
  * Called on validation failure or when batch entry completes.
  * MUST be called WITHOUT holding g_driver.lock. */
@@ -350,6 +354,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         bs->n_entries = 0;
         bs->n_completed = 0;
         bs->n_events_read = 0;
+        /* Reset the segment arena allocation point.
+         * seg_arena.size()/capacity are never touched here; only the
+         * allocation cursor resets so the next Submitv rewrites from
+         * index 0.  Plain-only batches never resized the arena and
+         * this store is a harmless no-op on the zero-initialized
+         * value. */
+        bs->arena_used = 0;
     }
 
     if (bs->n_entries + nr > bs->capacity)

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -363,7 +363,13 @@ extern "C" uGDSError_t uGDSBatchIOSubmit(uGDSBatchHandle_t batch, unsigned nr,
         bs->arena_used = 0;
     }
 
-    if (bs->n_entries + nr > bs->capacity)
+    /* Overflow-safe capacity check.  The old n_entries + nr >
+     * capacity used unsigned addition that wraps for large nr.
+     * Reject nr > capacity outright, then check the post-recycle
+     * base.  At this point n_entries is already recycled if the
+     * round was fully consumed, so n_entries is the effective base. */
+    if (nr > bs->capacity ||
+        bs->n_entries > bs->capacity - nr)
         return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
 
     HandleState* hs = bs->hs;
@@ -942,18 +948,23 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
     if (bs->lifecycle != BATCH_LIFECYCLE_ACTIVE)
         return make_error(UGDS_INVALID_VALUE);
 
-    if (bs->n_entries + nr > bs->capacity)
+    /* Overflow-safe capacity check with an effective base that accounts
+     * for a fully consumed recyclable round, WITHOUT mutating any
+     * state.  The old code computed n_entries + nr using unsigned
+     * addition (wraps for large nr) and ran recycle before this check,
+     * so a full-capacity batch rejected any new submit and a later
+     * value error violated consume-none.  We compute the effective base
+     * here and defer the actual recycle reset to the commit step after
+     * all validation, preflight, and allocation succeed. */
+    unsigned effective_base = bs->n_entries;
+    if (effective_base > 0 && bs->n_events_read == effective_base)
+        effective_base = 0;  /* round is fully consumed; would recycle */
+
+    if (nr > bs->capacity ||
+        effective_base > bs->capacity - nr)
         return make_error(UGDS_BATCH_CAPACITY_EXCEEDED);
 
     (void)flags;
-
-    /* recycle: same path as plain submit, plus arena_used reset. */
-    if (bs->n_entries > 0 && bs->n_events_read == bs->n_entries) {
-        bs->n_entries = 0;
-        bs->n_completed = 0;
-        bs->n_events_read = 0;
-        bs->arena_used = 0;
-    }
 
     HandleState* hs = bs->hs;
     IOQueuePair& qp = hs->batch_qp->qp;
@@ -980,7 +991,11 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
      * ================================================================== */
 
     /* --- Step 1: Pure value validation (all entries, no state write) --- */
-    unsigned base = bs->n_entries;
+    /* Use effective_base, which accounts for a recyclable round
+     * without mutating bs state.  The actual recycle reset is applied
+     * as part of the infallible commit (Step 4) after all validation,
+     * preflight, and allocation succeed. */
+    unsigned base = effective_base;
 
     uint32_t per_entry_n_cmds[UGDS_MAX_BATCH_IO_SIZE];
     uint64_t total_cmds = 0;
@@ -1056,10 +1071,22 @@ extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t batch, unsigned nr,
     /* --- Step 4: Commit-copy (infallible) ---
      * From here, no allocation or throw is possible.  Capture the
      * watermark for rollback safety; populate entries and arena.
-     * The watermark is the 8.4 rollback anchor: it is never restored
-     * in this path because no operation after this point can fail, but
-     * it documents the invariant and serves as the audit point for the
-     * fixed-size arena model. */
+     * The watermark is the rollback anchor: it is never restored in
+     * this path because no operation after this point can fail, but it
+     * documents the invariant and serves as the audit point for the
+     * fixed-size arena model.
+     *
+     * Apply the recycle reset here as the first infallible commit
+     * action.  effective_base was 0 iff the current round was fully
+     * consumed.  This is the consume-none guarantee: a value error
+     * returns without touching n_entries, n_completed, n_events_read,
+     * or arena_used. */
+    if (effective_base == 0 && bs->n_entries > 0) {
+        bs->n_entries = 0;
+        bs->n_completed = 0;
+        bs->n_events_read = 0;
+        bs->arena_used = 0;
+    }
     const uint32_t watermark = bs->arena_used;
     (void)watermark;  /* documented rollback anchor; no post-commit failure */
     uint32_t work_used = 0;

--- a/src/ugds_batch.cpp
+++ b/src/ugds_batch.cpp
@@ -212,26 +212,25 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
         hs->batch_setting_up.store(true, std::memory_order_release);
     }
 
-    /* M3: BatchSetupTxn - RAII scope guard that rolls back ALL five items
-     * if the function exits via exception or early return before commit.
-     * Items (acquired in order, rolled back in reverse):
-     *   5. pool DMA mapping
-     *   4. pool host buffer
-     *   3. batch_active claim
-     *   2. handle_in_flight reference
-     *   1. batch_setting_up flag (cleared LAST, under g_driver.lock) */
+    /* M3: BatchSetupTxn - RAII scope guard that owns ALL five items by value.
+     * Declared before bs_sp so its destructor runs first on unwind.
+     * Pool resources are owned by value (not pointer to bs_sp members)
+     * so destruction order does not cause dangling dereferences.
+     * On commit, pool resources are transferred to bs_sp->prp_pool
+     * and txn.armed is cleared.
+     * Destructor uses try_lock to remain noexcept-safe. */
     struct BatchSetupTxn {
         HandleState* hs;
-        void** pool_buf;
-        nvm_dma_t** pool_dma;
+        void* pool_buf;
+        nvm_dma_t* pool_dma;
         bool armed;
         ~BatchSetupTxn() {
             if (!armed) return;
-            /* Rollback items 5, 4 (raw resources) */
-            if (pool_dma && *pool_dma) { nvm_dma_unmap(*pool_dma); *pool_dma = nullptr; }
-            if (pool_buf && *pool_buf) { free(*pool_buf); *pool_buf = nullptr; }
-            /* Rollback items 3, 2, 1 (gate state) */
-            std::lock_guard<std::mutex> g(g_driver.lock);
+            /* Rollback items 5, 4 (owned by value) */
+            if (pool_dma) { nvm_dma_unmap(pool_dma); }
+            if (pool_buf) { free(pool_buf); }
+            /* Rollback items 3, 2, 1 (gate state, best-effort lock) */
+            std::unique_lock<std::mutex> lk(g_driver.lock, std::try_to_lock);
             hs->batch_active.store(false, std::memory_order_release);
             handle_release(hs);
             hs->batch_setting_up.store(false, std::memory_order_release);
@@ -250,32 +249,33 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
     bs_sp->release_scratch.resize(nr);
 
     const size_t page_size = hs->ctrl->page_size;
-    PRPPool& pool = bs_sp->prp_pool;
     size_t pool_bytes = UGDS_PRP_POOL_PAGES * page_size;
 
     uGDSError_t setup_err = UGDS_OK;
-    if (posix_memalign(&pool.buf, 4096, pool_bytes) != 0) {
+    void* pbuf = nullptr;
+    nvm_dma_t* pdma = nullptr;
+    if (posix_memalign(&pbuf, 4096, pool_bytes) != 0) {
         setup_err = make_error(UGDS_OUT_OF_MEMORY);
         goto setup_rollback;
     }
-    std::memset(pool.buf, 0, pool_bytes);
-    txn.pool_buf = &pool.buf;  /* arm item 4 */
+    std::memset(pbuf, 0, pool_bytes);
+    txn.pool_buf = pbuf;  /* txn owns the buffer now */
 
     {
-        int rc = nvm_dma_map_host(&pool.dma, hs->ctrl, pool.buf, pool_bytes);
+        int rc = nvm_dma_map_host(&pdma, hs->ctrl, pbuf, pool_bytes);
         if (!nvm_ok(rc)) {
-            free(pool.buf);
-            pool.buf = nullptr;
-            txn.pool_buf = nullptr;  /* already freed */
+            txn.pool_buf = nullptr;  /* txn no longer owns; we free below */
+            free(pbuf);
+            pbuf = nullptr;
             setup_err = (rc == ENOMEM)
                 ? make_error(UGDS_OUT_OF_MEMORY)
                 : make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
     }
-    txn.pool_dma = &pool.dma;  /* arm item 5 */
-    pool.n_pages = UGDS_PRP_POOL_PAGES;
-    pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
+    txn.pool_dma = pdma;  /* txn owns the mapping now */
+    bs_sp->prp_pool.n_pages = UGDS_PRP_POOL_PAGES;
+    bs_sp->prp_pool.free_bitmap = (UGDS_PRP_POOL_PAGES >= 64)
         ? ~0ULL : (1ULL << UGDS_PRP_POOL_PAGES) - 1;
 
     /* --- Publication: one g_driver.lock critical section --- */
@@ -293,36 +293,34 @@ extern "C" uGDSError_t uGDSBatchIOSetUp(uGDSBatchHandle_t* batch,
             setup_err = make_error(UGDS_INTERNAL_ERROR);
             goto setup_rollback;
         }
+        /* Transfer pool resources from txn to bs_sp */
+        bs_sp->prp_pool.buf = txn.pool_buf;
+        bs_sp->prp_pool.dma = txn.pool_dma;
+        txn.armed = false;       /* commit: txn no longer owns anything */
         bs_sp->self = bs_sp;            /* public-handle ownership */
         hs->active_batch = bs_sp;       /* owning recovery link */
         hs->batch_setting_up.store(false, std::memory_order_release);
-        txn.armed = false;           /* commit: gate items disarmed */
     }
 
     *batch = static_cast<uGDSBatchHandle_t>(bs_sp.get());
     return UGDS_OK;
 
 setup_rollback:
-    /* Rollback in reverse acquisition order:
-     * 5 (pool DMA) -> 4 (pool buf) -> 3 (BatchState shared_ptr)
-     * -> 2 (batch_active) -> 1 (handle ref + batch_setting_up LAST).
-     * pool.dma and pool.buf are cleaned up above or here; the shared_ptr
-     * reset handles item 3. */
+    /* Pool resources are owned by txn; txn.armed=false below prevents
+     * the destructor from double-freeing. Gate state is also unwound
+     * explicitly. bs_sp is reset for its own cleanup. */
+    txn.armed = false;  /* prevent double-run: we clean up explicitly */
     {
-        if (pool.dma) { nvm_dma_unmap(pool.dma); pool.dma = nullptr; }
-        if (pool.buf) { free(pool.buf); pool.buf = nullptr; }
+        if (txn.pool_dma) { nvm_dma_unmap(txn.pool_dma); txn.pool_dma = nullptr; }
+        if (txn.pool_buf) { free(txn.pool_buf); txn.pool_buf = nullptr; }
     }
-    bs_sp.reset();  /* RAII: releases BatchState if last owner */
+    bs_sp.reset();
     {
         std::lock_guard<std::mutex> g(g_driver.lock);
         hs->batch_active.store(false, std::memory_order_release);
         handle_release(hs);
-        /* batch_setting_up cleared LAST so a waiting force teardown
-         * proceeds only after every other side effect (including the
-         * DMA unmap, which needs hs->ctrl alive) has been undone. */
         hs->batch_setting_up.store(false, std::memory_order_release);
     }
-    txn.armed = false;  /* explicit rollback done; prevent double-run */
     return setup_err;
     } catch (const std::bad_alloc&) {
         return make_error(UGDS_OUT_OF_MEMORY);

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -354,14 +354,11 @@ extern "C" uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base,
             return make_error(UGDS_INVALID_VALUE);
         }
 
-        /* MPS alignment (same check as uGDSBufRegister) */
-        const size_t mps = g_driver.default_ctrl ? g_driver.default_ctrl->page_size : 0;
-        if (mps > 0 && (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
-            return make_error(UGDS_INVALID_VALUE);
-        }
-
-        /* Lock the driver to check for duplicate registration and
-         * capture the controller reference. */
+        /* Lock the driver to check for duplicate registration,
+         * validate MPS alignment, and capture the controller reference.
+         * The controller pointer is stable for the lifetime of the
+         * driver session (held by handle_registry shared_ptrs), so it
+         * is safe to use after releasing the lock for the ioctl. */
         {
             std::lock_guard<std::mutex> guard(g_driver.lock);
 
@@ -372,41 +369,40 @@ extern "C" uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base,
             if (g_driver.default_ctrl == nullptr) {
                 return make_error(UGDS_DRIVER_NOT_INITIALIZED);
             }
+
+            /* MPS alignment (same check as uGDSBufRegister) */
+            const size_t mps = g_driver.default_ctrl->page_size;
+            if (mps > 0 && (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
+                return make_error(UGDS_INVALID_VALUE);
+            }
         }
 
         /* The kernel ioctl is executed without holding g_driver.lock.
          * After the ioctl, we reacquire the lock and commit only if
          * the driver is still open and the key is still absent. */
 
+        /* Always use the V2 ioctl for external registrations.
+         * When REQUIRE_P2P is set, the kernel rejects non-peer-BAR
+         * mappings. Without it, the mapping succeeds but the caller
+         * can inspect the classification via uGDSQueryDmabufSupport.
+         * This ensures all external mappings go through pin accounting
+         * and produce a mapping class result. */
         nvm_dma_t* dma = nullptr;
-        int status;
+        struct nvm_ioctl_dmabuf_v2 v2result;
+        memset(&v2result, 0, sizeof(v2result));
 
-        if (params->flags & UGDS_DMABUF_REQUIRE_P2P) {
-            /* V2 path with strict P2P classification */
-            struct nvm_ioctl_dmabuf_v2 v2result;
-            memset(&v2result, 0, sizeof(v2result));
-
-            status = nvm_dma_map_dmabuf_v2(&dma, g_driver.default_ctrl,
+        int status = nvm_dma_map_dmabuf_v2(&dma, g_driver.default_ctrl,
                                             const_cast<void*>(bufPtr_base),
                                             length,
                                             params->dmabuf_fd,
                                             params->dmabuf_offset,
-                                            UGDS_DMABUF_REQUIRE_P2P,
+                                            params->flags,
                                             &v2result);
 
-            /* Strict no-fallback: if REQUIRE_P2P was requested and the
-             * kernel classified the mapping as not peer-BAR, do not
-             * fall back to V1. */
-            if (status == EOPNOTSUPP) {
-                return make_error(UGDS_DMABUF_NOT_P2P);
-            }
-        } else {
-            /* V1 path (no strict P2P requirement) */
-            status = nvm_dma_map_dmabuf_fd(&dma, g_driver.default_ctrl,
-                                            const_cast<void*>(bufPtr_base),
-                                            length,
-                                            params->dmabuf_fd,
-                                            params->dmabuf_offset);
+        /* Strict no-fallback: if REQUIRE_P2P was requested and the
+         * kernel classified the mapping as not peer-BAR, return error. */
+        if (status == EOPNOTSUPP && (params->flags & UGDS_DMABUF_REQUIRE_P2P)) {
+            return make_error(UGDS_DMABUF_NOT_P2P);
         }
 
         if (status != 0 || dma == nullptr) {

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -1,7 +1,10 @@
 #include "ugds_internal.h"
 #include "internal/dma.h"
+#include "internal/ioctl.h"
+#include "internal/map.h"
 #include <unistd.h>
 #include <fcntl.h>
+#include <cstring>
 #include <new>
 #include <cassert>
 
@@ -80,8 +83,18 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
          * The transactional insert below disarms the guard only after the
          * entry is fully constructed and stored. */
         MappedDmaGuard map_guard(dma);
-        uGDSBackend_t backend =
-            nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+        uGDSBackend_t backend;
+        switch (nvm_dma_origin(dma)) {
+        case NVM_DMABUF_ORIGIN_HIP:
+            backend = UGDS_BACKEND_HIP;
+            break;
+        case NVM_DMABUF_ORIGIN_EXTERNAL:
+            backend = UGDS_BACKEND_EXTERNAL;
+            break;
+        default:
+            backend = UGDS_BACKEND_CUDA;
+            break;
+        }
 
         /* Post-map debug invariant: verify zero displacement so that
          * dma->ioaddrs[0] corresponds to the exact registered base.
@@ -234,4 +247,252 @@ extern "C" uGDSError_t uGDSExportDmabuf(const void* bufPtr_base,
     out->offset = offset;
     out->length = length;
     return UGDS_OK;
+}
+
+
+/* --- External dma-buf registration (Phase 6) ------------------------ */
+
+/* Helper: translate a libnvm positive errno to a uGDS public error.
+ * Follows the error translation table in the design doc section 13. */
+static uGDSOpError translate_dmabuf_errno(int err)
+{
+    switch (err) {
+    case EBADF:        return UGDS_BAD_FILE_DESCRIPTOR;
+    case EINVAL:       return UGDS_INVALID_VALUE;
+    case EMFILE:
+    case ENFILE:       return UGDS_FD_LIMIT_REACHED;
+    case ENOMEM:       return UGDS_OUT_OF_MEMORY;
+    case EDQUOT:
+    case ENOSPC:       return UGDS_PIN_LIMIT_EXCEEDED;
+    case EBUSY:        return UGDS_BUSY;
+    case EINTR:        return UGDS_INTERRUPTED;
+    case ENODEV:       return UGDS_DEVICE_LOST;
+    case EFAULT:       return UGDS_INVALID_USER_ADDRESS;
+#ifdef EOPNOTSUPP
+    case EOPNOTSUPP:   return UGDS_DMABUF_NOT_P2P;
+#endif
+#if defined(ENOTSUP) && (ENOTSUP != EOPNOTSUPP)
+    case ENOTSUP:      return UGDS_IO_NOT_SUPPORTED;
+#endif
+    case ETIMEDOUT:    return UGDS_TIMED_OUT;
+    case EOVERFLOW:    return UGDS_INVALID_MAPPING_SIZE;
+    case ERANGE:       return UGDS_INVALID_MAPPING_RANGE;
+    case EPROTONOSUPPORT:
+    case ENOTTY:       return UGDS_STRUCT_VERSION_MISMATCH;
+    case EPERM:
+    case EACCES:       return UGDS_PERMISSION_DENIED;
+    case EIO:          return UGDS_GPU_MEMORY_PINNING_FAILED;
+    default:           return UGDS_INTERNAL_ERROR;
+    }
+}
+
+extern "C" uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base,
+                                               size_t length,
+                                               const uGDSDmabufRegParams_t* params) {
+#if !defined(UGDS_HAVE_DMABUF)
+    (void)bufPtr_base; (void)length; (void)params;
+    return make_error(UGDS_PLATFORM_NOT_SUPPORTED);
+#else
+    try {
+        if (!g_driver.initialized) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+
+        /* Validate params pointer */
+        if (params == nullptr) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* Validate struct_size: must be at least the V1 size */
+        if (params->struct_size < sizeof(uGDSDmabufRegParams_t)) {
+            return make_error(UGDS_STRUCT_VERSION_MISMATCH);
+        }
+
+        /* Validate version */
+        if (params->version != UGDS_DMABUF_REG_PARAMS_VERSION_1) {
+            return make_error(UGDS_STRUCT_VERSION_MISMATCH);
+        }
+
+        /* Validate reserved fields are zero */
+        if (params->reserved0 != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+        for (int i = 0; i < 4; i++) {
+            if (params->reserved[i] != 0) {
+                return make_error(UGDS_INVALID_VALUE);
+            }
+        }
+
+        /* Validate no unknown flag bits */
+        if (params->flags & ~((uint32_t)UGDS_DMABUF_REQUIRE_P2P)) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* Validate bufPtr_base and length */
+        if (bufPtr_base == nullptr || length == 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* Validate dmabuf_fd */
+        if (params->dmabuf_fd < 0) {
+            return make_error(UGDS_BAD_FILE_DESCRIPTOR);
+        }
+
+        /* Host page size for alignment checks */
+        long hps = sysconf(_SC_PAGESIZE);
+        if (hps <= 0) {
+            return make_error(UGDS_INTERNAL_ERROR);
+        }
+
+        /* Validate page alignment of bufPtr_base */
+        if ((reinterpret_cast<uintptr_t>(bufPtr_base) % (size_t)hps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* Validate page alignment of dmabuf_offset */
+        if ((params->dmabuf_offset % (uint64_t)hps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* MPS alignment (same check as uGDSBufRegister) */
+        const size_t mps = g_driver.default_ctrl ? g_driver.default_ctrl->page_size : 0;
+        if (mps > 0 && (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* Lock the driver to check for duplicate registration and
+         * capture the controller reference. */
+        {
+            std::lock_guard<std::mutex> guard(g_driver.lock);
+
+            if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
+                return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
+            }
+
+            if (g_driver.default_ctrl == nullptr) {
+                return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+            }
+        }
+
+        /* The kernel ioctl is executed without holding g_driver.lock.
+         * After the ioctl, we reacquire the lock and commit only if
+         * the driver is still open and the key is still absent. */
+
+        nvm_dma_t* dma = nullptr;
+        int status;
+
+        if (params->flags & UGDS_DMABUF_REQUIRE_P2P) {
+            /* V2 path with strict P2P classification */
+            struct nvm_ioctl_dmabuf_v2 v2result;
+            memset(&v2result, 0, sizeof(v2result));
+
+            status = nvm_dma_map_dmabuf_v2(&dma, g_driver.default_ctrl,
+                                            const_cast<void*>(bufPtr_base),
+                                            length,
+                                            params->dmabuf_fd,
+                                            params->dmabuf_offset,
+                                            UGDS_DMABUF_REQUIRE_P2P,
+                                            &v2result);
+
+            /* Strict no-fallback: if REQUIRE_P2P was requested and the
+             * kernel classified the mapping as not peer-BAR, do not
+             * fall back to V1. */
+            if (status == EOPNOTSUPP) {
+                return make_error(UGDS_DMABUF_NOT_P2P);
+            }
+        } else {
+            /* V1 path (no strict P2P requirement) */
+            status = nvm_dma_map_dmabuf_fd(&dma, g_driver.default_ctrl,
+                                            const_cast<void*>(bufPtr_base),
+                                            length,
+                                            params->dmabuf_fd,
+                                            params->dmabuf_offset);
+        }
+
+        if (status != 0 || dma == nullptr) {
+            return make_error(translate_dmabuf_errno(status));
+        }
+
+        /* Guard the mapping so a bad_alloc from registry insertion
+         * unmaps it instead of leaking. */
+        MappedDmaGuard map_guard(dma);
+
+        /* Reacquire lock and commit */
+        {
+            std::lock_guard<std::mutex> guard(g_driver.lock);
+
+            /* Re-check driver state and duplicate key */
+            if (!g_driver.initialized) {
+                return make_error(UGDS_DRIVER_CLOSING);
+            }
+            if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
+                return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
+            }
+
+            auto [it, inserted] = g_driver.buf_registry.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(bufPtr_base),
+                std::forward_as_tuple(dma, UGDS_BACKEND_EXTERNAL, length,
+                                      g_driver.default_ctrl));
+            (void)it; (void)inserted;
+        }
+
+        map_guard.disarm();
+        return UGDS_OK;
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
+#endif /* UGDS_HAVE_DMABUF */
+}
+
+extern "C" uGDSError_t uGDSQueryDmabufSupport(uGDSDmabufCaps_t* caps) {
+    if (caps == nullptr) {
+        return make_error(UGDS_INVALID_VALUE);
+    }
+
+    /* Zero-initialize the output */
+    caps->lib_dmabuf = false;
+    caps->kmod_dmabuf_v2 = false;
+    caps->kmod_require_p2p = false;
+    caps->kmod_pin_accounting = false;
+
+#if !defined(UGDS_HAVE_DMABUF)
+    /* Library compiled without dmabuf support */
+    return UGDS_OK;
+#else
+    caps->lib_dmabuf = true;
+
+    if (!g_driver.initialized || g_driver.default_ctrl == nullptr) {
+        /* No controller: report library capability only */
+        return UGDS_OK;
+    }
+
+    /* Issue NVM_GET_CAPS to the kernel */
+    struct nvm_ioctl_caps kcaps;
+    memset(&kcaps, 0, sizeof(kcaps));
+    kcaps.struct_size = sizeof(kcaps);
+    kcaps.version = NVM_CAPS_VERSION_1;
+
+    int err = _nvm_dmabuf_get_caps(g_driver.default_ctrl, &kcaps);
+    if (err != 0) {
+        /* ENOTTY means the kernel does not support GET_CAPS (old module).
+         * Report library capability only. */
+        return UGDS_OK;
+    }
+
+    /* Parse kernel capability flags */
+    if (kcaps.flags & NVM_CAP_DMABUF_V2) {
+        caps->kmod_dmabuf_v2 = true;
+    }
+    if (kcaps.flags & NVM_CAP_DMABUF_REQUIRE_P2P) {
+        caps->kmod_require_p2p = true;
+    }
+    if (kcaps.flags & NVM_CAP_DMABUF_PIN_ACCOUNTING) {
+        caps->kmod_pin_accounting = true;
+    }
+
+    return UGDS_OK;
+#endif /* UGDS_HAVE_DMABUF */
 }

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <new>
+#include <cassert>
 
 /* RAII guard for a device DMA mapping.
  * Arms nvm_dma_unmap on construction (or explicit arm()); disarm() must
@@ -81,6 +82,16 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
         MappedDmaGuard map_guard(dma);
         uGDSBackend_t backend =
             nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
+        /* Post-map debug invariant: verify zero displacement so that
+         * dma->ioaddrs[0] corresponds to the exact registered base.
+         * A future mapping path that introduces displacement would
+         * silently corrupt PRP construction. */
+#ifndef NDEBUG
+        if (dma->n_ioaddrs > 0) {
+            assert((dma->ioaddrs[0] % mps) == 0);
+        }
+#endif
 
         /* try_emplace builds the BufEntry in place; if it throws bad_alloc
          * the mapping is still owned by map_guard and gets unmapped. */

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -2,6 +2,32 @@
 #include "internal/dma.h"
 #include <unistd.h>
 #include <fcntl.h>
+#include <new>
+
+/* RAII guard for a device DMA mapping.
+ * Arms nvm_dma_unmap on construction (or explicit arm()); disarm() must
+ * be called after the mapping is successfully handed off to its owner
+ * (e.g. inserted into the registry) so that the destructor does not
+ * unmap it.  Used to make registry insertion transactional with respect
+ * to bad_alloc. */
+class MappedDmaGuard {
+    nvm_dma_t* dma_ = nullptr;
+    bool       armed_ = false;
+public:
+    MappedDmaGuard() noexcept = default;
+    explicit MappedDmaGuard(nvm_dma_t* d) noexcept : dma_(d), armed_(true) {}
+    ~MappedDmaGuard() {
+        if (armed_ && dma_) nvm_dma_unmap(dma_);
+    }
+    MappedDmaGuard(const MappedDmaGuard&) = delete;
+    MappedDmaGuard& operator=(const MappedDmaGuard&) = delete;
+    MappedDmaGuard(MappedDmaGuard&&) = delete;
+    MappedDmaGuard& operator=(MappedDmaGuard&&) = delete;
+
+    void arm(nvm_dma_t* d) noexcept { dma_ = d; armed_ = true; }
+    void disarm() noexcept { armed_ = false; }
+    nvm_dma_t* get() const noexcept { return dma_; }
+};
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
     if (!g_driver.initialized) {
@@ -29,12 +55,33 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
     if (status != 0 || dma == nullptr) {
         if (status == ENOTSUP || status == EOPNOTSUPP)
             return make_error(UGDS_IO_NOT_SUPPORTED);
+        if (status == ENOMEM)
+            return make_error(UGDS_OUT_OF_MEMORY);
         return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
     }
 
-    g_driver.buf_registry[bufPtr_base].dma = dma;
-    g_driver.buf_registry[bufPtr_base].backend =
+    /* Guard the mapping so a bad_alloc from registry insertion unmaps it
+     * instead of leaking the device mapping across the C ABI.
+     * The transactional insert below disarms the guard only after the
+     * entry is fully constructed and stored. */
+    MappedDmaGuard map_guard(dma);
+    uGDSBackend_t backend =
         nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
+    try {
+        /* try_emplace builds the BufEntry in place; if it throws bad_alloc
+         * the mapping is still owned by map_guard and gets unmapped. */
+        auto [it, inserted] = g_driver.buf_registry.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(bufPtr_base),
+            std::forward_as_tuple(dma, backend, length, g_driver.default_ctrl));
+        (void)it; (void)inserted;
+    } catch (const std::bad_alloc&) {
+        /* map_guard destructor calls nvm_dma_unmap(dma) */
+        return make_error(UGDS_OUT_OF_MEMORY);
+    }
+
+    map_guard.disarm();
     return UGDS_OK;
 }
 

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -30,45 +30,58 @@ public:
 };
 
 extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, int flags) {
-    if (!g_driver.initialized) {
-        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
-    }
-
-    if (bufPtr_base == nullptr || length == 0) {
-        return make_error(UGDS_INVALID_VALUE);
-    }
-
-    std::lock_guard<std::mutex> guard(g_driver.lock);
-
-    if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
-        return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
-    }
-
-    if (g_driver.default_ctrl == nullptr) {
-        return make_error(UGDS_DRIVER_NOT_INITIALIZED);
-    }
-
-    nvm_dma_t* dma = nullptr;
-    int status = nvm_dma_map_device_ex(&dma, g_driver.default_ctrl,
-                                       const_cast<void*>(bufPtr_base), length,
-                                       flags);
-    if (status != 0 || dma == nullptr) {
-        if (status == ENOTSUP || status == EOPNOTSUPP)
-            return make_error(UGDS_IO_NOT_SUPPORTED);
-        if (status == ENOMEM)
-            return make_error(UGDS_OUT_OF_MEMORY);
-        return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
-    }
-
-    /* Guard the mapping so a bad_alloc from registry insertion unmaps it
-     * instead of leaking the device mapping across the C ABI.
-     * The transactional insert below disarms the guard only after the
-     * entry is fully constructed and stored. */
-    MappedDmaGuard map_guard(dma);
-    uGDSBackend_t backend =
-        nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
-
     try {
+        if (!g_driver.initialized) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+
+        if (bufPtr_base == nullptr || length == 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        std::lock_guard<std::mutex> guard(g_driver.lock);
+
+        if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
+            return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
+        }
+
+        if (g_driver.default_ctrl == nullptr) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
+
+        /* The library layer rejects a base that is not MPS-aligned,
+         * that is not a multiple of the controller MPS. ioaddrs[] entries
+         * are MPS-granular, so a non-MPS-aligned base means ioaddrs[0]
+         * would not correspond to bufPtr_base. This is the universal PRP
+         * requirement. */
+        const size_t mps = g_driver.default_ctrl->page_size;
+        if (mps > 0 &&
+            (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        nvm_dma_t* dma = nullptr;
+        int status = nvm_dma_map_device_ex(&dma, g_driver.default_ctrl,
+                                           const_cast<void*>(bufPtr_base), length,
+                                           flags);
+        if (status != 0 || dma == nullptr) {
+            if (status == ENOTSUP || status == EOPNOTSUPP)
+                return make_error(UGDS_IO_NOT_SUPPORTED);
+            if (status == ENOMEM)
+                return make_error(UGDS_OUT_OF_MEMORY);
+            if (status == EINVAL)
+                return make_error(UGDS_INVALID_VALUE);
+            return make_error(UGDS_GPU_MEMORY_PINNING_FAILED);
+        }
+
+        /* Guard the mapping so a bad_alloc from registry insertion unmaps it
+         * instead of leaking the device mapping across the C ABI.
+         * The transactional insert below disarms the guard only after the
+         * entry is fully constructed and stored. */
+        MappedDmaGuard map_guard(dma);
+        uGDSBackend_t backend =
+            nvm_dma_is_hip_origin(dma) ? UGDS_BACKEND_HIP : UGDS_BACKEND_CUDA;
+
         /* try_emplace builds the BufEntry in place; if it throws bad_alloc
          * the mapping is still owned by map_guard and gets unmapped. */
         auto [it, inserted] = g_driver.buf_registry.emplace(
@@ -76,13 +89,14 @@ extern "C" uGDSError_t uGDSBufRegister(const void* bufPtr_base, size_t length, i
             std::forward_as_tuple(bufPtr_base),
             std::forward_as_tuple(dma, backend, length, g_driver.default_ctrl));
         (void)it; (void)inserted;
-    } catch (const std::bad_alloc&) {
-        /* map_guard destructor calls nvm_dma_unmap(dma) */
-        return make_error(UGDS_OUT_OF_MEMORY);
-    }
 
-    map_guard.disarm();
-    return UGDS_OK;
+        map_guard.disarm();
+        return UGDS_OK;
+    } catch (const std::bad_alloc&) {
+        return make_error(UGDS_OUT_OF_MEMORY);
+    } catch (...) {
+        return make_error(UGDS_INTERNAL_ERROR);
+    }
 }
 
 extern "C" uGDSError_t uGDSBufRegisterEx(const void* bufPtr_base, size_t length,

--- a/src/ugds_buf.cpp
+++ b/src/ugds_buf.cpp
@@ -354,39 +354,30 @@ extern "C" uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base,
             return make_error(UGDS_INVALID_VALUE);
         }
 
-        /* Lock the driver to check for duplicate registration,
-         * validate MPS alignment, and capture the controller reference.
-         * The controller pointer is stable for the lifetime of the
-         * driver session (held by handle_registry shared_ptrs), so it
-         * is safe to use after releasing the lock for the ioctl. */
-        {
-            std::lock_guard<std::mutex> guard(g_driver.lock);
+        /* Hold g_driver.lock across the entire mapping + registration,
+         * matching the lifetime model of uGDSBufRegister(). This prevents
+         * concurrent HandleDeregister from clearing default_ctrl while
+         * the ioctl is in progress. The ioctl sleeps (dma_buf_pin, fence
+         * wait) but the mutex is sleepable. */
+        std::lock_guard<std::mutex> guard(g_driver.lock);
 
-            if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
-                return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
-            }
-
-            if (g_driver.default_ctrl == nullptr) {
-                return make_error(UGDS_DRIVER_NOT_INITIALIZED);
-            }
-
-            /* MPS alignment (same check as uGDSBufRegister) */
-            const size_t mps = g_driver.default_ctrl->page_size;
-            if (mps > 0 && (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
-                return make_error(UGDS_INVALID_VALUE);
-            }
+        if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
+            return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
         }
 
-        /* The kernel ioctl is executed without holding g_driver.lock.
-         * After the ioctl, we reacquire the lock and commit only if
-         * the driver is still open and the key is still absent. */
+        if (g_driver.default_ctrl == nullptr) {
+            return make_error(UGDS_DRIVER_NOT_INITIALIZED);
+        }
 
-        /* Always use the V2 ioctl for external registrations.
-         * When REQUIRE_P2P is set, the kernel rejects non-peer-BAR
-         * mappings. Without it, the mapping succeeds but the caller
-         * can inspect the classification via uGDSQueryDmabufSupport.
-         * This ensures all external mappings go through pin accounting
-         * and produce a mapping class result. */
+        /* MPS alignment (same check as uGDSBufRegister) */
+        const size_t mps = g_driver.default_ctrl->page_size;
+        if (mps > 0 && (reinterpret_cast<uintptr_t>(bufPtr_base) % mps) != 0) {
+            return make_error(UGDS_INVALID_VALUE);
+        }
+
+        /* V2 ioctl for external registrations: always uses V2 for pin
+         * accounting and mapping classification. REQUIRE_P2P rejects
+         * non-peer-BAR mappings. */
         nvm_dma_t* dma = nullptr;
         struct nvm_ioctl_dmabuf_v2 v2result;
         memset(&v2result, 0, sizeof(v2result));
@@ -413,25 +404,12 @@ extern "C" uGDSError_t uGDSBufRegisterDmabuf(const void* bufPtr_base,
          * unmaps it instead of leaking. */
         MappedDmaGuard map_guard(dma);
 
-        /* Reacquire lock and commit */
-        {
-            std::lock_guard<std::mutex> guard(g_driver.lock);
-
-            /* Re-check driver state and duplicate key */
-            if (!g_driver.initialized) {
-                return make_error(UGDS_DRIVER_CLOSING);
-            }
-            if (g_driver.buf_registry.find(bufPtr_base) != g_driver.buf_registry.end()) {
-                return make_error(UGDS_MEMORY_ALREADY_REGISTERED);
-            }
-
-            auto [it, inserted] = g_driver.buf_registry.emplace(
-                std::piecewise_construct,
-                std::forward_as_tuple(bufPtr_base),
-                std::forward_as_tuple(dma, UGDS_BACKEND_EXTERNAL, length,
-                                      g_driver.default_ctrl));
-            (void)it; (void)inserted;
-        }
+        auto [it, inserted] = g_driver.buf_registry.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(bufPtr_base),
+            std::forward_as_tuple(dma, UGDS_BACKEND_EXTERNAL, length,
+                                  g_driver.default_ctrl));
+        (void)it; (void)inserted;
 
         map_guard.disarm();
         return UGDS_OK;

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -53,24 +53,19 @@ static void cleanup_timeout_resources(HandleState* hs) {
     for (auto& qp_ptr : hs->qps) {
         IOQueuePair& qp = *qp_ptr;
         nvm_dma_t* timeout_dma = nullptr;
-        const void* registered_buf = nullptr;
+        SglRefOwner timeout_refs;
         {
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             timeout_dma = qp.timeout_dma;
-            registered_buf = qp.timeout_registered_buf;
+            timeout_refs = std::move(qp.timeout_refs);
             qp.timeout_dma = nullptr;
-            qp.timeout_registered_buf = nullptr;
         }
 
         if (timeout_dma != nullptr)
             nvm_dma_unmap(timeout_dma);
 
-        if (registered_buf != nullptr) {
-            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
-            auto it = g_driver.buf_registry.find(registered_buf);
-            if (it != g_driver.buf_registry.end())
-                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-        }
+        /* SglRefOwner destructor releases in_flight refs under
+         * g_driver.lock; the move left timeout_refs non-empty. */
     }
 }
 

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -11,6 +11,9 @@
 #include <unistd.h>
 #include <time.h>
 
+/* Forward declaration: cleanup_prp_pool is defined in ugds_batch.cpp. */
+extern void cleanup_prp_pool(BatchState* bs);
+
 static void cleanup_qp(nvm_aq_ref aq_ref, IOQueuePair* qp, int dev_fd) {
     if (qp->sq_dma) {
         nvm_admin_sq_delete(aq_ref, &qp->sq, &qp->cq);
@@ -54,11 +57,14 @@ static void cleanup_timeout_resources(HandleState* hs) {
         IOQueuePair& qp = *qp_ptr;
         nvm_dma_t* timeout_dma = nullptr;
         SglRefOwner timeout_refs;
+        const void* timeout_registered_base = nullptr;
         {
             std::lock_guard<std::mutex> qp_lock(qp.lock);
             timeout_dma = qp.timeout_dma;
             timeout_refs = std::move(qp.timeout_refs);
+            timeout_registered_base = qp.timeout_registered_base;
             qp.timeout_dma = nullptr;
+            qp.timeout_registered_base = nullptr;
         }
 
         if (timeout_dma != nullptr)
@@ -66,6 +72,14 @@ static void cleanup_timeout_resources(HandleState* hs) {
 
         /* SglRefOwner destructor releases in_flight refs under
          * g_driver.lock; the move left timeout_refs non-empty. */
+
+        /* Legacy scalar registered-buffer ref parked on timeout. */
+        if (timeout_registered_base != nullptr) {
+            std::lock_guard<std::mutex> drv_lock(g_driver.lock);
+            auto it = g_driver.buf_registry.find(timeout_registered_base);
+            if (it != g_driver.buf_registry.end())
+                it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        }
     }
 }
 
@@ -533,6 +547,65 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
             hs->closing.store(false, std::memory_order_release);
             return make_error(UGDS_BUSY);
         }
+    }
+
+    if (force) {
+        while (hs->batch_setting_up.load(std::memory_order_acquire)) {
+            __builtin_ia32_pause();
+        }
+    }
+
+    /* Batch release walk: pin the owning recovery link under
+     * link under g_driver.lock, release it, then perform lifecycle-
+     * sensitive cleanup before destroying QPs/controller.
+     * batch_setting_up drain: spin-wait with no locks held until the
+     * past-gate setup either publishes (observes closing, rolls back)
+     * or fails. Bounded because setup does only host-side work. */
+    if (force) {
+        std::shared_ptr<BatchState> pin;
+        std::shared_ptr<BatchState> self_pin;
+        {
+            std::lock_guard<std::mutex> g(g_driver.lock);
+            pin = std::move(hs->active_batch);
+            /* batch_active is deliberately left true: closing blocks
+             * new setups and the handle is being destroyed. */
+        }
+        if (pin != nullptr) {
+            std::lock_guard<std::mutex> bl(pin->lock);
+            if (pin->lifecycle != BATCH_LIFECYCLE_TORN_DOWN) {
+                const bool destroy_consumed =
+                    (pin->lifecycle == BATCH_LIFECYCLE_WEDGED);
+
+                /* Release all in-flight refs for entries that still
+                 * hold them. */
+                for (unsigned i = 0; i < pin->n_entries; ++i) {
+                    BatchIOEntry& entry = pin->entries[i];
+                    if (entry.refs_held) {
+                        std::lock_guard<std::mutex> drv(g_driver.lock);
+                        auto it = g_driver.buf_registry.find(entry.devPtr_base);
+                        if (it != g_driver.buf_registry.end())
+                            it->second.in_flight.fetch_sub(1,
+                                std::memory_order_acq_rel);
+                        entry.refs_held = false;
+                        entry.release_queued = false;
+                    }
+                }
+                pin->n_release_pending = 0;
+
+                cleanup_prp_pool(pin.get());
+                pin->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
+                handle_release(hs);
+
+                if (destroy_consumed) {
+                    /* WEDGED: no public Destroy remains; transfer self
+                     * under lock, never reset in place (pin rule). */
+                    self_pin = std::move(pin->self);
+                }
+                /* ACTIVE: retain self as tombstone for the still-
+                 * available one-shot Destroy. */
+            }
+        }
+        /* bl and g unlock; pin/self_pin drop here. */
     }
 
     if (force)

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -577,18 +577,13 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
                     (pin->lifecycle == BATCH_LIFECYCLE_WEDGED);
 
                 /* Release all in-flight refs for entries that still
-                 * hold them. */
+                 * hold them.  Use kind-aware release so VECTORED entries decrement
+                 * every base in their arena range, not the (nullptr)
+                 * devPtr_base. */
                 for (unsigned i = 0; i < pin->n_entries; ++i) {
                     BatchIOEntry& entry = pin->entries[i];
-                    if (entry.refs_held) {
-                        std::lock_guard<std::mutex> drv(g_driver.lock);
-                        auto it = g_driver.buf_registry.find(entry.devPtr_base);
-                        if (it != g_driver.buf_registry.end())
-                            it->second.in_flight.fetch_sub(1,
-                                std::memory_order_acq_rel);
-                        entry.refs_held = false;
-                        entry.release_queued = false;
-                    }
+                    if (entry.refs_held)
+                        release_entry_refs(pin.get(), entry);
                 }
                 pin->n_release_pending = 0;
 

--- a/src/ugds_handle.cpp
+++ b/src/ugds_handle.cpp
@@ -588,6 +588,12 @@ extern "C" uGDSError_t uGDSHandleDeregisterEx(uGDSHandle_t fh, int timeout_sec)
                 pin->n_release_pending = 0;
 
                 cleanup_prp_pool(pin.get());
+                /* Release arena capacity during force teardown so the
+                 * tombstone state retained for an ACTIVE batch does not
+                 * hold ~768 KiB. swap-with-empty releases the
+                 * allocation immediately. */
+                std::vector<SegView>().swap(pin->seg_arena);
+                pin->arena_used = 0;
                 pin->lifecycle = BATCH_LIFECYCLE_TORN_DOWN;
                 handle_release(hs);
 

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -104,6 +104,14 @@ struct DriverState {
         nvm_dma_t*           dma;
         uGDSBackend_t        backend;
         std::atomic<uint32_t> in_flight{0};
+        size_t               length;    /* exact bytes from uGDSBufRegister */
+        const nvm_ctrl_t*    map_ctrl;  /* controller at registration time */
+        BufEntry() noexcept
+            : dma(nullptr), backend(UGDS_BACKEND_DEFAULT),
+              in_flight(0), length(0), map_ctrl(nullptr) {}
+        BufEntry(nvm_dma_t* d, uGDSBackend_t b, size_t len,
+                 const nvm_ctrl_t* ctrl) noexcept
+            : dma(d), backend(b), in_flight(0), length(len), map_ctrl(ctrl) {}
     };
     std::unordered_map<const void*, BufEntry>     buf_registry;
 

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <cstdint>
 #include <cstddef>
+#include <type_traits>
 
 #define UGDS_DEFAULT_NUM_QPS     16
 #define UGDS_DEFAULT_QUEUE_DEPTH 64
@@ -36,6 +37,169 @@
 /* SCT+SC (11-bit) from an NVMe completion: 0 = success. See NVMe Base Spec section 4.6.1. */
 #define UGDS_CPL_SCT_SC(cpl)     (((cpl)->dword[3] >> 17) & 0x7FF)
 
+/* Forward declarations: HandleOpGuard and SglRefOwner reference HandleState
+ * and handle_release, which are fully defined later in this header. */
+struct HandleState;
+static inline void handle_release(HandleState* hs);
+
+/* --- Per-IO resolved segment ------------------------------------------- */
+/* A segment resolved against the buffer registry under one g_driver.lock
+ * hold.  Identity fields (dma, base, registered_length, backend) are
+ * immutable snapshots valid as long as the owning SglRefOwner holds its
+ * reference; geometry fields (page_start, size) are filled at resolve time
+ * (sync/batch) or in the async callback (late binding). */
+struct SegView {
+    nvm_dma_t*     dma;
+    const void*    base;               /* registry key, for release/park */
+    size_t         registered_length;  /* snapshot of BufEntry::length */
+    uGDSBackend_t  backend;            /* snapshot, for async dispatch */
+    size_t         page_start;         /* offset / MPS (offset MPS-aligned) */
+    size_t         size;               /* bytes */
+};
+
+/* --- Reference ownership ----------------------------------------------- */
+/* Owns one in_flight reference per SGL occurrence.  Duplicate bases are
+ * intentionally repeated.  The representation has capacity for the public
+ * maximum and never allocates; this is ~8 KiB on LP64 and is stored in
+ * request/QP objects, not copied into a std::vector on timeout. */
+class SglRefOwner {
+    std::array<const void*, UGDS_IOV_MAX> bases_{};
+    uint16_t size_ = 0;                 /* UGDS_IOV_MAX == 1024 */
+public:
+    SglRefOwner() noexcept = default;
+    SglRefOwner(const SglRefOwner&) = delete;
+    SglRefOwner& operator=(const SglRefOwner&) = delete;
+    SglRefOwner(SglRefOwner&& other) noexcept;
+    SglRefOwner& operator=(SglRefOwner&& other) noexcept;
+    ~SglRefOwner() noexcept;            /* release() if still non-empty */
+
+    bool empty() const noexcept { return size_ == 0; }
+    uint16_t size() const noexcept { return size_; }
+    const void* base_at(uint16_t i) const noexcept { return bases_[i]; }
+
+    /* acquire(segs, nr): nr was already checked <= UGDS_IOV_MAX.  Under one
+     * g_driver.lock hold, validate registration, exact length, and affinity,
+     * then increment each counter and append its base.  All-or-nothing: a
+     * failure rolls back 0..k-1 inside the same hold.  Returns 0 on success
+     * or -EINVAL.  No reserve/growth/allocation exists.
+     *
+     * hs_ctrl is the submitting handle's controller (for affinity check).
+     * page_size is MPS for the offset-alignment and page-index math.
+     * seg_views_out (optional): if non-null, resolved SegView[] filled. */
+    int acquire(const uGDSIoSegment_t* segs, uint32_t nr,
+                const nvm_ctrl_t* hs_ctrl,
+                size_t page_size,
+                SegView* seg_views_out = nullptr);
+
+    /* release(): decrement each stored occurrence under one g_driver.lock
+     * hold and set size_ = 0.  Idempotent on empty. */
+    void release() noexcept;
+};
+
+static_assert(std::is_nothrow_move_constructible<SglRefOwner>::value);
+static_assert(std::is_nothrow_move_assignable<SglRefOwner>::value);
+static_assert(UGDS_IOV_MAX <= UINT16_MAX);
+
+/* --- Sync handle-operation ownership ----------------------------------- */
+/* handle_lookup() increments the bare HandleState::handle_in_flight counter
+ * independently of the returned shared_ptr.  This non-allocating guard is
+ * constructed immediately after a successful lookup and must be declared
+ * after the local hs_sp, so hs_sp outlives the guard.  Every early return
+ * and exception therefore calls handle_release() exactly once.  The normal
+ * path calls release() only after do_iov_engine returns; release() performs
+ * handle_release() and then disarms the destructor. */
+class HandleOpGuard {
+    HandleState* hs_ = nullptr;
+    bool         armed_ = false;
+public:
+    HandleOpGuard() noexcept = default;
+    explicit HandleOpGuard(HandleState* hs) noexcept
+        : hs_(hs), armed_(true) {}
+    HandleOpGuard(const HandleOpGuard&) = delete;
+    HandleOpGuard& operator=(const HandleOpGuard&) = delete;
+    HandleOpGuard(HandleOpGuard&&) = delete;
+    HandleOpGuard& operator=(HandleOpGuard&&) = delete;
+    ~HandleOpGuard() noexcept { if (armed_) handle_release(hs_); }
+
+    void arm(HandleState* hs) noexcept { hs_ = hs; armed_ = true; }
+    void release() noexcept {
+        if (armed_) { handle_release(hs_); armed_ = false; }
+    }
+};
+
+static_assert(std::is_nothrow_destructible<HandleOpGuard>::value);
+
+/* --- Engine result ------------------------------------------------------ */
+/* An integer alone cannot drive cleanup: the caller must know whether the
+ * engine consumed (parked) the resource owners. */
+struct IovEngineResult {
+    ssize_t ret;        /* bytes transferred or -errno */
+    bool    timed_out;  /* true <=> handle wedged AND the engine moved the
+                           owner (registered) or the transient dma
+                           (on-the-fly) into QP timeout parking; the
+                           caller's owner is empty / dma pointer stolen */
+};
+
+/* --- Command window ---------------------------------------------------- */
+struct CmdWindow {
+    uint32_t     first_seg;          /* index into SegView[] */
+    uint32_t     n_segs;             /* slices spanned by this command */
+    size_t       first_seg_page_off; /* pages already consumed from first_seg
+                                        by earlier windows (mid-segment split) */
+    size_t       bytes;              /* command length; block-multiple by construction */
+    size_t       n_pages;            /* ceil-sum of slice pages; <= MPS/8 + 1 */
+};
+
+/* --- SglWindowCursor --------------------------------------------------- */
+/* Stateful, allocation-free forward generator.  next() emits at most one
+ * window and advances (seg_idx, bytes_in_seg, open-window state).  It never
+ * owns or materializes an array of CmdWindow objects. */
+struct SglWindowCursor {
+    const SegView* segs;
+    uint32_t       nr_segs;
+    uint32_t       seg_idx;
+    size_t         bytes_in_seg;     /* consumed so far in segs[seg_idx] */
+    size_t         window_cap;
+    size_t         page_size;        /* MPS */
+    size_t         block_size;
+    size_t         split_unit;       /* lcm(MPS, block_size) */
+};
+
+/* Initialize a cursor.  Returns false if window_cap == 0 (reject). */
+bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
+                     size_t window_cap, size_t page_size, size_t block_size);
+
+/* Emit at most one window into out.  Returns true if a window was produced,
+ * false when the SGL is exhausted. */
+bool sgl_cursor_next(SglWindowCursor& c, CmdWindow& out) noexcept;
+
+/* O(nr_segs) analytic count.  Produces the same count as the cursor. */
+bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
+                                uint32_t nr_segs,
+                                size_t window_cap, size_t page_size,
+                                size_t block_size,
+                                uint32_t* out) noexcept;
+
+/* --- SglPageCursor ----------------------------------------------------- */
+/* Forward iterator over the MPS page addresses of a window.  Replaces
+ * buf_dma->ioaddrs[current_page + i] in the PRP builders.  Tracks position
+ * across segment boundaries. */
+struct SglPageCursor {
+    const SegView* segs;
+    uint32_t       seg_count;        /* n_segs from CmdWindow */
+    uint32_t       seg_idx;          /* current segment index (relative to window) */
+    size_t         page_in_seg;      /* absolute index into dma->ioaddrs */
+    size_t         seg_pages_left;   /* pages remaining in current segment slice */
+};
+
+void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
+                          uint32_t first_seg, size_t first_seg_page_off,
+                          uint32_t n_segs, size_t n_pages) noexcept;
+
+/* Returns current ioaddr, advances across segment boundaries.  Total calls
+ * bounded by CmdWindow::n_pages. */
+uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept;
+
 struct IOQueuePair {
     nvm_queue_t    sq{};
     nvm_queue_t    cq{};
@@ -48,9 +212,12 @@ struct IOQueuePair {
     int            irq_efd = -1;   /* eventfd for interrupt mode; -1 = poll */
     uint16_t       irq_vec = 0;    /* MSI-X vector bound to this CQ */
     /* Timeout resources remain owned by the QP until controller recovery.
-     * At most one synchronous operation can hold this QP lock. */
+     * At most one synchronous operation can hold this QP lock.
+     * timeout_dma: on-the-fly (1-buf) mapping parked by the scalar engine.
+     * timeout_refs: fixed-capacity registered-ref owner parked by the SGL
+     *               engine (also used by the refactored scalar path). */
     nvm_dma_t*     timeout_dma = nullptr;           /* on-the-fly mapping */
-    const void*    timeout_registered_buf = nullptr; /* registered ref */
+    SglRefOwner    timeout_refs;                    /* registered refs */
     std::mutex     lock;
 };
 
@@ -295,6 +462,38 @@ static inline uGDSError_t make_error(uGDSOpError err) {
 
 ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                        off_t file_offset, off_t bufPtr_offset, uint8_t opcode);
+
+/* --- SGL engine -------------------------------------------------------- */
+
+/* Publish PRP list stores before the doorbell/data pointer.  Centralizes the
+ * platform DMA-publish contract: on x86-64 the seq_cst fence is sufficient
+ * because PRP lists live in cache-coherent host memory and normal stores
+ * are ordered before the subsequent MMIO doorbell write.  Porting to a
+ * weaker platform changes this one helper. */
+static inline void sgl_publish_prp() noexcept {
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+
+/* Wait for one completion on a sync QP.  Returns nullptr on timeout.
+ * Defined in ugds_io.cpp; shared with ugds_iov.cpp. */
+nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp);
+
+/* Streaming windowed IO engine shared by scalar and vectored sync paths.
+ *
+ * hs: submitting handle state (must already be lookup-acquired).
+ * segs: resolved segment views (identity + geometry complete).
+ * nr_segs: number of entries in segs (>= 1).
+ * file_offset: starting byte offset in the namespace (block-aligned).
+ * opcode: NVM_IO_READ or NVM_IO_WRITE.
+ * owner: holds in-flight buffer refs (may be empty if on_the_fly).
+ * transient: on-the-fly DMA mapping, or nullptr for registered buffers.
+ *
+ * Returns {bytes, false} on success, {-errno, false} on device/validation
+ * failure, or {-errno, true} on timeout with owner/transient moved into
+ * qp.timeout_refs / qp.timeout_dma. */
+IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
+                              off_t file_offset, uint8_t opcode,
+                              SglRefOwner* owner, nvm_dma_t* transient);
 
 struct AsyncRequest {
     uGDSHandle_t    fh;

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -85,11 +85,28 @@ public:
      *
      * hs_ctrl is the submitting handle's controller (for affinity check).
      * page_size is MPS for the offset-alignment and page-index math.
-     * seg_views_out (optional): if non-null, resolved SegView[] filled. */
+     * seg_views_out (optional): if non-null, resolved SegView[] filled
+     * (identity + geometry; page_start uses segs[k].offset). */
     int acquire(const uGDSIoSegment_t* segs, uint32_t nr,
                 const nvm_ctrl_t* hs_ctrl,
                 size_t page_size,
                 SegView* seg_views_out = nullptr);
+
+    /* acquire_identity_only(segs, nr): like acquire() but performs only the
+     * registration + controller affinity checks and the in_flight
+     * reference acquisition.  The registered-range bound on
+     * offset/size is deliberately skipped because the async path
+     * defers offset/size validation to the stream callback
+     * (late binding).
+     *
+     * seg_views_out (optional): if non-null, identity-only SegView[] is
+     * filled -- dma, base, registered_length, and backend are snapshotted;
+     * page_start and size are left zero and completed by the caller once
+     * the late-bound offset/size are observed.  Returns 0 on success or
+     * -EINVAL. */
+    int acquire_identity_only(const uGDSIoSegment_t* segs, uint32_t nr,
+                              const nvm_ctrl_t* hs_ctrl,
+                              SegView* seg_views_out = nullptr);
 
     /* release(): decrement each stored occurrence under one g_driver.lock
      * hold and set size_ = 0.  Idempotent on empty. */
@@ -547,6 +564,31 @@ struct AsyncRequest {
     ssize_t*        bytes_done_p;
     uint8_t         opcode;
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
+
+    /* Vectored async fields (valid when nr_segs > 0).
+     *
+     * user_segs points to the caller's array (held until the callback runs);
+     * the identity fields of resolved[i] (dma, base, registered_length,
+     * backend) were snapshotted under g_driver.lock at enqueue, and the
+     * per-segment in_flight references live in owner.  Geometry
+     * (page_start/size) is filled in the callback from user_segs[i] after
+     * late binding.  launch_backend was computed once at enqueue from the
+     * segment-backend and stream-backend snapshots and is never re-read.
+     *
+     * Because SglRefOwner is noexcept move-only and not copyable, AsyncRequest
+     * itself becomes move-only; the public async path only heap-allocates it
+     * via new and deletes it from the callback, so no copy is required. */
+    uGDSIoSegment_t* user_segs = nullptr;
+    unsigned         nr_segs = 0;
+    SegView*         resolved = nullptr;  /* resolved segments (inline/heap) */
+    SglRefOwner      owner;               /* in-flight refs (single-owner handoff) */
+    uGDSBackend_t    launch_backend = UGDS_BACKEND_DEFAULT;
+
+    /* Inline SegView storage for the common nr <= 4 case (no heap at
+     * callback time, section 6.3).  resolved points here when nr_segs
+     * is in [1, 4]; otherwise it points at the heap allocation performed
+     * at enqueue. */
+    SegView          inline_resolved[4];
 };
 
 /* Internal stream type -- void* for backend neutrality */

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -219,9 +219,13 @@ struct IOQueuePair {
     /* Timeout resources remain owned by the QP until controller recovery.
      * At most one synchronous operation can hold this QP lock.
      * timeout_dma: on-the-fly (1-buf) mapping parked by the scalar engine.
+     * timeout_registered_base: a registered-buffer base whose in_flight
+     *   ref was parked by the legacy scalar path.  The ref
+     *   is released by cleanup_timeout_resources.
      * timeout_refs: fixed-capacity registered-ref owner parked by the SGL
      *               engine (also used by the refactored scalar path). */
     nvm_dma_t*     timeout_dma = nullptr;           /* on-the-fly mapping */
+    const void*    timeout_registered_base = nullptr; /* legacy scalar ref */
     SglRefOwner    timeout_refs;                    /* registered refs */
     std::mutex     lock;
 };

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -556,13 +556,17 @@ IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
                               SglRefOwner* owner, nvm_dma_t* transient);
 
 struct AsyncRequest {
-    uGDSHandle_t    fh;
-    void*           bufPtr_base;
-    size_t*         size_p;
-    off_t*          file_offset_p;
-    off_t*          bufPtr_offset_p;
-    ssize_t*        bytes_done_p;
-    uint8_t         opcode;
+    /* Scalar async fields (used by uGDSReadAsync/uGDSWriteAsync).
+     * Pointer parameters are caller-owned host-accessible storage
+     * read in the stream callback (late binding).  The caller MUST
+     * keep them valid until the callback runs. */
+    uGDSHandle_t    fh;             /* submitting handle (for do_io_internal) */
+    void*           bufPtr_base;    /* registered buffer base */
+    size_t*         size_p;         /* late-bound transfer size (bytes) */
+    off_t*          file_offset_p;  /* late-bound namespace offset */
+    off_t*          bufPtr_offset_p;/* late-bound offset inside bufPtr_base */
+    ssize_t*        bytes_done_p;   /* result sink (bytes or -errno) */
+    uint8_t         opcode;         /* NVM_IO_READ or NVM_IO_WRITE */
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive until callback */
 
     /* Vectored async fields (valid when nr_segs > 0).

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -577,18 +577,34 @@ struct AsyncRequest {
      *
      * Because SglRefOwner is noexcept move-only and not copyable, AsyncRequest
      * itself becomes move-only; the public async path only heap-allocates it
-     * via new and deletes it from the callback, so no copy is required. */
+     * via new and deletes it from the callback, so no copy is required.
+     *
+     * resolved[] is owned by the request.  resolved_owns_heap records
+     * whether it points at a heap allocation (nr_segs > 4); the
+     * destructor releases it so every callback path frees it via a
+     * single `delete req`. */
     uGDSIoSegment_t* user_segs = nullptr;
     unsigned         nr_segs = 0;
     SegView*         resolved = nullptr;  /* resolved segments (inline/heap) */
+    bool             resolved_owns_heap = false; /* iff resolved is heap[] */
     SglRefOwner      owner;               /* in-flight refs (single-owner handoff) */
     uGDSBackend_t    launch_backend = UGDS_BACKEND_DEFAULT;
 
     /* Inline SegView storage for the common nr <= 4 case (no heap at
-     * callback time, section 6.3).  resolved points here when nr_segs
-     * is in [1, 4]; otherwise it points at the heap allocation performed
-     * at enqueue. */
+     * callback time).  resolved points here when nr_segs is in [1, 4];
+     * otherwise it points at the heap allocation performed at enqueue. */
     SegView          inline_resolved[4];
+
+    /* Owning destructor.  When the callback (or any early-return path)
+     * does `delete req`, the heap resolved[] is freed exactly once.
+     * inline_resolved is not heap-allocated, so it is left alone. */
+    ~AsyncRequest() noexcept {
+        if (resolved_owns_heap) {
+            delete[] resolved;
+            resolved = nullptr;
+            resolved_owns_heap = false;
+        }
+    }
 };
 
 /* Internal stream type -- void* for backend neutrality */

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -450,6 +450,14 @@ struct BatchState {
     std::vector<uint32_t> release_scratch;
     uint32_t              n_release_pending = 0;
 
+    /* SGL segment arena for vectored batch entries.
+     * Fixed-size, lazily resized to capacity * UGDS_BATCH_IOV_MAX at the
+     * first Submitv call; never resized again.  recycle resets
+     * arena_used to 0 but never touches size()/capacity.  Each vectored
+     * entry copies its segments into [seg_begin, seg_begin+seg_count). */
+    std::vector<SegView> seg_arena;
+    uint32_t             arena_used = 0;
+
     BatchLifecycle       lifecycle = BATCH_LIFECYCLE_ACTIVE;
 
     /* Public-handle ownership: the reference held on behalf of the user's
@@ -458,6 +466,17 @@ struct BatchState {
      * WEDGED-force cleanup, via the pin rule.  The object is destroyed when
      * the last reference (self, active_batch link, or transient pin) drops. */
     std::shared_ptr<BatchState> self;
+};
+
+/* SubCmdV: one windowed sub-command for vectored batch submit.
+ * The work array is sized to the analytic total_cmds, then filled by
+ * SglWindowCursor.  The enqueue loop iterates [0, work_used) and
+ * enqueues one NVMe command per element.  window references segments in
+ * bs->seg_arena[entry.seg_begin .. entry.seg_begin+seg_count). */
+struct SubCmdV {
+    unsigned  io_idx;        /* index into bs->entries */
+    uint64_t  lba;           /* starting LBA for this window */
+    CmdWindow window;        /* window geometry (bytes, n_pages, etc.) */
 };
 
 static inline uGDSError_t make_error(uGDSOpError err) {

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -80,6 +80,20 @@ struct HandleState {
     std::unique_ptr<IOQueuePairHuge> batch_qp;
     uint16_t                    batch_queue_depth;
     std::atomic<bool>           batch_active{false};
+    /* Owning recovery link to the active batch.  Together with
+     * batch_active and batch_setting_up it forms one link-state machine
+     * whose every transition happens inside a g_driver.lock critical
+     * section.  Set by BatchIOSetUp publication; detached by exactly one
+     * of the successful-destroy link transaction or the force-deregister
+     * walk. */
+    std::shared_ptr<struct BatchState> active_batch;
+    /* True while a BatchIOSetUp that passed the setup gate (closing check
+     * + batch_active CAS, one g_driver.lock section) has not yet committed
+     * or rolled back.  Only the gate winner can set it; only that call
+     * clears it (at publication, or as the LAST rollback action).  Written
+     * only under g_driver.lock; read lock-free by force teardown, which
+     * drains it to false before freeing any host-side QP/controller. */
+    std::atomic<bool>           batch_setting_up{false};
     bool                        interrupt_mode = false;  /* UGDS_INTERRUPT_MODE */
     std::atomic<bool>           wedged{false};          /* batch timeout: handle poisoned, controller reset required */
     std::atomic<uint32_t>       handle_in_flight{0};  /* IO refcount for safe deregister */
@@ -210,6 +224,31 @@ struct BatchIOEntry {
     uint16_t            n_cmds        = 0;
     uint16_t            n_cmds_done   = 0;
     bool                event_returned = false;
+
+    /* SGL/lifecycle extensions */
+    uint8_t             kind          = 0;  /* BatchEntryKind: 0=PLAIN, 1=VECTORED */
+    uint32_t            seg_begin     = 0;  /* arena range start; valid iff VECTORED */
+    uint32_t            seg_count     = 0;  /* number of segments in this entry */
+    bool                refs_held     = false;  /* true while in-flight ref is held */
+    bool                release_queued = false; /* true iff index is in release_scratch */
+    uint16_t            n_cmds_submitted = 0;  /* successfully enqueued sub-commands */
+};
+
+/* Batch entry kind: plain (single buffer) or vectored (scatter-gather). */
+enum BatchEntryKind : uint8_t {
+    BATCH_ENTRY_PLAIN    = 0,
+    BATCH_ENTRY_VECTORED = 1,
+};
+
+/* Batch lifecycle states (under bs->lock).
+ * ACTIVE   -- normal operation; the public one-shot Destroy is available.
+ * WEDGED   -- Destroy could not drain; one-shot Destroy was consumed.
+ *             Force teardown drops self (no cycle retained).
+ * TORN_DOWN-- all resources released; any further API call is a no-op. */
+enum BatchLifecycle : uint8_t {
+    BATCH_LIFECYCLE_ACTIVE    = 0,
+    BATCH_LIFECYCLE_WEDGED    = 1,
+    BATCH_LIFECYCLE_TORN_DOWN = 2,
 };
 
 struct BatchState {
@@ -226,6 +265,23 @@ struct BatchState {
     HandleState* hs = nullptr;
     std::shared_ptr<HandleState> hs_sp;  /* keeps handle alive for batch lifetime */
     std::mutex   lock;
+
+    /* Deferred-release scratch: entry indices whose registry refs must be
+     * dropped after qp.lock is released.  Fixed-size, resized to capacity
+     * at SetUp.  Written by index only under bs->lock; drained in one
+     * g_driver.lock hold after qp.lock drops.  release_queued on each
+     * BatchIOEntry is the authoritative membership bit. */
+    std::vector<uint32_t> release_scratch;
+    uint32_t              n_release_pending = 0;
+
+    BatchLifecycle       lifecycle = BATCH_LIFECYCLE_ACTIVE;
+
+    /* Public-handle ownership: the reference held on behalf of the user's
+     * uGDSBatchHandle_t.  Accessed only under bs->lock.  Moved out -- never
+     * reset in place -- at successful destroy, tombstone destroy, or
+     * WEDGED-force cleanup, via the pin rule.  The object is destroyed when
+     * the last reference (self, active_batch link, or transient pin) drops. */
+    std::shared_ptr<BatchState> self;
 };
 
 static inline uGDSError_t make_error(uGDSOpError err) {

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -183,13 +183,18 @@ bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
 /* --- SglPageCursor ----------------------------------------------------- */
 /* Forward iterator over the MPS page addresses of a window.  Replaces
  * buf_dma->ioaddrs[current_page + i] in the PRP builders.  Tracks position
- * across segment boundaries. */
+ * across segment boundaries.
+ *
+ * Usage contract: the caller initializes the cursor for a CmdWindow, then
+ * calls sgl_page_cursor_next() exactly CmdWindow::n_pages times.  The
+ * cursor walks the segment slices in order, emitting MPS-granular bus
+ * addresses from each segment's dma->ioaddrs[]. */
 struct SglPageCursor {
-    const SegView* segs;
-    uint32_t       seg_count;        /* n_segs from CmdWindow */
-    uint32_t       seg_idx;          /* current segment index (relative to window) */
-    size_t         page_in_seg;      /* absolute index into dma->ioaddrs */
-    size_t         seg_pages_left;   /* pages remaining in current segment slice */
+    const SegView* segs;        /* pointer to segs[0] (absolute base) */
+    uint32_t       abs_seg;     /* absolute segment index into segs[] */
+    uint32_t       end_seg;     /* one-past-last absolute segment index */
+    size_t         page_in_seg; /* absolute ioaddr index within current seg */
+    size_t         slice_pages_left; /* pages left in current segment slice */
 };
 
 void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,

--- a/src/ugds_internal.h
+++ b/src/ugds_internal.h
@@ -94,6 +94,13 @@ public:
     /* release(): decrement each stored occurrence under one g_driver.lock
      * hold and set size_ = 0.  Idempotent on empty. */
     void release() noexcept;
+
+    /* disarm(): set size_ = 0 so the destructor does not release.
+     * The acquired in_flight references remain in the registry; the
+     * caller becomes responsible for releasing them by other means
+     * (the batch owns the release via kind-aware
+     * drain_release_scratch). */
+    void disarm() noexcept { size_ = 0; }
 };
 
 static_assert(std::is_nothrow_move_constructible<SglRefOwner>::value);
@@ -478,6 +485,14 @@ struct SubCmdV {
     uint64_t  lba;           /* starting LBA for this window */
     CmdWindow window;        /* window geometry (bytes, n_pages, etc.) */
 };
+
+/* Kind-aware release of the in-flight reference(s) held by a batch
+ * entry.  Defined in ugds_batch.cpp.
+ * - BATCH_ENTRY_PLAIN: one ref at entry.devPtr_base.
+ * - BATCH_ENTRY_VECTORED: one ref per base in
+ *   bs->seg_arena[entry.seg_begin .. seg_begin + seg_count).
+ * Must be called WITHOUT holding g_driver.lock. */
+void release_entry_refs(BatchState* bs, BatchIOEntry& entry);
 
 static inline uGDSError_t make_error(uGDSOpError err) {
     uGDSError_t e;

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #include <time.h>
 
-static nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp)
+nvm_cpl_t* wait_for_completion(HandleState* hs, IOQueuePair& qp)
 {
     if (qp.irq_efd < 0) {
         nvm_cpl_t* cpl = nullptr;
@@ -288,9 +288,12 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
         if (timed_out) {
             if (on_the_fly) {
                 qp.timeout_dma = buf_dma;
-            } else {
-                qp.timeout_registered_buf = bufPtr_base;
             }
+            /* Registered buffer refs are parked via SglRefOwner move
+             * into qp.timeout_refs by the caller (do_iov_engine or
+             * do_io_internal when refactored). For the legacy scalar
+             * path the ref remains held until the explicit release
+             * below is skipped on timeout. */
             buf_dma = nullptr;
         }
 

--- a/src/ugds_io.cpp
+++ b/src/ugds_io.cpp
@@ -108,13 +108,30 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
     nvm_dma_t* buf_dma = nullptr;
     bool on_the_fly = false;
     size_t buf_page_start = 0;
+    /* owner tracks the registered-buffer in-flight ref so it can be
+     * parked into qp.timeout_refs on timeout. */
+    bool ref_held = false;
 
     {
         std::lock_guard<std::mutex> drv_lock(g_driver.lock);
         auto it = g_driver.buf_registry.find(bufPtr_base);
         if (it != g_driver.buf_registry.end()) {
+            /* Controller affinity: mapping controller must
+             * match the submitting handle's controller. */
+            if (it->second.map_ctrl != hs->ctrl) {
+                return -EINVAL;
+            }
+            /* Exact-length bounds in
+             * subtraction form. bufPtr_offset was checked >= 0 above. */
+            const uint64_t off = static_cast<uint64_t>(bufPtr_offset);
+            const uint64_t sz  = static_cast<uint64_t>(size);
+            if (off > it->second.length ||
+                sz > it->second.length - off) {
+                return -EINVAL;
+            }
             buf_dma = it->second.dma;
             it->second.in_flight.fetch_add(1, std::memory_order_acq_rel);
+            ref_held = true;
         }
     }
 
@@ -124,12 +141,11 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             auto it = g_driver.buf_registry.find(bufPtr_base);
             if (it != g_driver.buf_registry.end())
                 it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+            ref_held = false;
             return -EINVAL;
         }
         buf_page_start = static_cast<size_t>(bufPtr_offset) / page_size;
-        /* Overflow-safe bounds check: compute pages_needed separately,
-         * then verify buf_page_start + pages_needed <= n_ioaddrs
-         * without risking wrap. */
+        /* Defensive page-count check. */
         size_t pages_needed = (size - 1) / page_size + 1;
         if (pages_needed > buf_dma->n_ioaddrs ||
             buf_page_start > buf_dma->n_ioaddrs - pages_needed) {
@@ -137,6 +153,7 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
             auto it = g_driver.buf_registry.find(bufPtr_base);
             if (it != g_driver.buf_registry.end())
                 it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+            ref_held = false;
             return -EINVAL;
         }
     } else {
@@ -210,9 +227,18 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 if (drain == nullptr) {
                     result = -EIO;
                     /* An older submitted command may still DMA. Treat this
-                     * exactly like a post-submit completion timeout. */
+                     * exactly like a post-submit completion timeout.
+                     * Park the resource while qp.lock is held:
+                     * the post-lock parking block below is bypassed by this
+                     * goto, so we must park here. */
                     timed_out = true;
                     hs->wedged.store(true, std::memory_order_release);
+                    if (on_the_fly) {
+                        qp.timeout_dma = buf_dma;
+                        buf_dma = nullptr;
+                    } else if (ref_held) {
+                        qp.timeout_registered_base = bufPtr_base;
+                    }
                     goto out;
                 }
                 uint16_t st = UGDS_CPL_SCT_SC(drain);
@@ -258,8 +284,16 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
                 result = -EIO;
                 timed_out = true;
                 /* Mark wedged while still holding qp.lock to prevent
-                 * QP reuse before the flag is visible. */
+                 * QP reuse before the flag is visible.
+                 * Park the resource at the timeout site:
+                 * the post-lock block below is skipped by this goto. */
                 hs->wedged.store(true, std::memory_order_release);
+                if (on_the_fly) {
+                    qp.timeout_dma = buf_dma;
+                    buf_dma = nullptr;
+                } else if (ref_held) {
+                    qp.timeout_registered_base = bufPtr_base;
+                }
                 goto out;
             }
 
@@ -281,28 +315,17 @@ ssize_t do_io_internal(uGDSHandle_t fh, void* bufPtr_base, size_t size,
 
         result = static_cast<ssize_t>(bytes_done);
 
-        /* Transfer timeout resources to the QP while we still hold
-         * qp.lock.  A concurrent force teardown also acquires qp.lock
-         * in cleanup_timeout_resources(), so this prevents the race
-         * where teardown destroys the QP before we store the mapping. */
-        if (timed_out) {
-            if (on_the_fly) {
-                qp.timeout_dma = buf_dma;
-            }
-            /* Registered buffer refs are parked via SglRefOwner move
-             * into qp.timeout_refs by the caller (do_iov_engine or
-             * do_io_internal when refactored). For the legacy scalar
-             * path the ref remains held until the explicit release
-             * below is skipped on timeout. */
-            buf_dma = nullptr;
-        }
+        /* Parking was already done at each timeout site while qp.lock
+         * was held. The old post-lock block below was
+         * unreachable on the timeout path due to the goto. */
 
     out:;
     }
 
     if (timed_out) {
         /* NVMe command may still be executing. wedged was set
-         * under qp.lock. Resources were transferred to the QP above. */
+         * under qp.lock. Resources were parked to the QP at the
+         * timeout site. */
         fprintf(stderr, "uGDS: I/O timeout -- handle wedged. "
                 "Controller reset required.\n");
     } else if (on_the_fly && buf_dma != nullptr) {

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -1,21 +1,36 @@
+/*
+ * Copyright (c) 2024, Guanyi Chen <felixlinker02@gmail.com>
+ * Copyright (c) 2017, Jonas Markauss <jonassm@ifi.uio.no>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 /* uGDS SGL (scatter-gather) streaming engine and sync vectored API.
  *
- * Implements the pure streaming primitives (SglPageCursor, SglWindowCursor,
- * analytic counter), the fixed-capacity reference owner (SglRefOwner), the
- * shared windowed IO engine (do_iov_engine), and the public sync vectored
- * entry points (uGDSReadv/uGDSWritev).
+ * Public APIs implemented here:
+ *   - uGDSReadv / uGDSWritev       (sync vectored IO)
+ *
+ * Internal primitives implemented here (consumed by ugds_batch.cpp and
+ * ugds_async.cpp):
+ *   - SglRefOwner                  (fixed-capacity in-flight ref owner)
+ *   - SglWindowCursor / SglPageCursor / sgl_count_windows_analytic
+ *   - do_iov_engine                (shared streaming windowed IO engine)
+ *
+ * Implements the pure streaming primitives (SglPageCursor,
+ * SglWindowCursor, analytic counter), the fixed-capacity reference
+ * owner (SglRefOwner), the shared windowed IO engine (do_iov_engine),
+ * and the public sync vectored entry points (uGDSReadv/uGDSWritev).
  *
  * Design constraints honored here:
  *  - SglWindowCursor yields one CmdWindow at a time into caller-local
- *    storage; no array of windows is ever materialized (independent M-2).
+ *    storage; no array of windows is ever materialized.
  *  - SglRefOwner is fixed-capacity for UGDS_IOV_MAX and never allocates;
- *    it is noexcept move-only so timeout parking is a bounded array move
- *    (independent M-3, section 6.4).
+ *    it is noexcept move-only so timeout parking is a bounded array move.
  *  - HandleOpGuard owns the handle-operation reference from immediately
  *    after handle_lookup through engine return, closing the OOM-strand
- *    window (V6-M-1).
+ *    window.
  *  - Exact registered-length bounds and controller affinity are checked
- *    under g_driver.lock before the first cursor.next() (sections 5.1/5.3).
+ *    under g_driver.lock before the first cursor.next().
  */
 
 #include "ugds_internal.h"
@@ -204,6 +219,10 @@ static size_t compute_split_unit(size_t mps, size_t block_size) noexcept
     return (mps / a) * block_size;
 }
 
+/* Initialize a cursor for a resolved SegView array.  Returns false
+ * (reject) if window_cap, page_size, block_size, or nr_segs is zero.
+ * The cursor holds no storage of its own; 'segs' must outlive the
+ * cursor walk. */
 bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
                      size_t window_cap, size_t page_size, size_t block_size)
 {
@@ -355,9 +374,12 @@ bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
 }
 
 /* ========================================================================
- * SglPageCursor (section 3.2)
+ * SglPageCursor
  * ======================================================================== */
 
+/* Initialize a page cursor for one CmdWindow.  The caller then calls
+ * sgl_page_cursor_next() exactly CmdWindow::n_pages times to walk the
+ * MPS-granular bus addresses across segment boundaries. */
 void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
                           uint32_t first_seg, size_t first_seg_page_off,
                           uint32_t n_segs, size_t n_pages) noexcept
@@ -385,6 +407,9 @@ void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
     (void)first_seg_page_off;
 }
 
+/* Return the current segment's ioaddr and advance the cursor across
+ * segment boundaries.  Total calls bounded by CmdWindow::n_pages.
+ * Returns 0 only on misuse (caller overran n_pages). */
 uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept
 {
     /* Walk the segment slices in order, emitting MPS-granular bus addresses.
@@ -573,23 +598,38 @@ IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
 }
 
 /* ========================================================================
- * uGDSReadv / uGDSWritev (sections 1.2, 6.1, 8.1)
+ * uGDSReadv / uGDSWritev
  * ======================================================================== */
 
 /* Common validation + engine dispatch for vectored read/write.
- * opcode is NVM_IO_READ or NVM_IO_WRITE.
- * Returns total bytes or -errno. */
+ *
+ * Performs, in order:
+ *   1. Malformed-call checks (null segs, nr_segs == 0, nr_segs >
+ *      UGDS_IOV_MAX) per the value matrix.
+ *   2. handle_lookup + HandleOpGuard so every early return releases
+ *      the handle-operation reference exactly once.
+ *   3. Per-segment value validation (base/size nonzero, offset >= 0,
+ *      offset MPS-aligned, size block-multiple, overflow-safe total).
+ *   4. file_offset alignment and window_cap == 0 rejection.
+ *   5. SglRefOwner::acquire under g_driver.lock (registration +
+ *      controller affinity + exact-length bound, all-or-nothing).
+ *   6. do_iov_engine dispatch.
+ *   7. owner.release() (no-op if the engine parked it on timeout) and
+ *      handle_guard.release().
+ *
+ * 'opcode' is NVM_IO_READ or NVM_IO_WRITE.  Returns total bytes or
+ * -errno. */
 static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                unsigned nr_segs, off_t file_offset,
                                uint8_t opcode)
 {
-    /* --- Malformed-call checks (8.1 value rows) --- */
+    /* --- Malformed-call checks --- */
     if (segs == nullptr || nr_segs == 0)
         return -EINVAL;
     if (nr_segs > UGDS_IOV_MAX)
         return -EINVAL;
 
-    /* handle_lookup + HandleOpGuard (V6-M-1) */
+    /* handle_lookup + HandleOpGuard */
     std::shared_ptr<HandleState> hs_sp;
     HandleState* hs = handle_lookup(fh, &hs_sp);
     if (!hs)

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -644,7 +644,7 @@ extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     try {
         return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
     } catch (...) {
-        return -UGDS_INTERNAL_ERROR;
+        return -EIO;
     }
 }
 
@@ -654,7 +654,7 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     try {
         return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
     } catch (...) {
-        return -UGDS_INTERNAL_ERROR;
+        return -EIO;
     }
 }
 

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -661,15 +661,9 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 /* Phase 2/3 stubs: declared in the public header so the API surface is
  * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
  * implementations land.  This keeps the library linkable without
- * undefined-reference errors. */
-
-extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t /*batch*/,
-                                            unsigned /*nr*/,
-                                            uGDSIOSegParams_t* /*iocb*/,
-                                            unsigned /*flags*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
+ * undefined-reference errors.
+ *
+ * uGDSBatchIOSubmitv is implemented in ugds_batch.cpp. */
 
 extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
                                         uGDSIoSegment_t* /*segs*/,

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -649,3 +649,36 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 {
     return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
 }
+
+/* Phase 2/3 stubs: declared in the public header so the API surface is
+ * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
+ * implementations land.  This keeps the library linkable without
+ * undefined-reference errors. */
+
+extern "C" uGDSError_t uGDSBatchIOSubmitv(uGDSBatchHandle_t /*batch*/,
+                                            unsigned /*nr*/,
+                                            uGDSIOSegParams_t* /*iocb*/,
+                                            unsigned /*flags*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}
+
+extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
+                                        uGDSIoSegment_t* /*segs*/,
+                                        unsigned /*nr_segs*/,
+                                        off_t* /*file_offset_p*/,
+                                        ssize_t* /*bytes_read_p*/,
+                                        void* /*stream*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}
+
+extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t /*fh*/,
+                                         uGDSIoSegment_t* /*segs*/,
+                                         unsigned /*nr_segs*/,
+                                         off_t* /*file_offset_p*/,
+                                         ssize_t* /*bytes_written_p*/,
+                                         void* /*stream*/)
+{
+    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
+}

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -641,13 +641,21 @@ static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
 extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                unsigned nr_segs, off_t file_offset)
 {
-    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+    try {
+        return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+    } catch (...) {
+        return -UGDS_INTERNAL_ERROR;
+    }
 }
 
 extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
                                 unsigned nr_segs, off_t file_offset)
 {
-    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+    try {
+        return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+    } catch (...) {
+        return -UGDS_INTERNAL_ERROR;
+    }
 }
 
 /* Phase 2/3 stubs: declared in the public header so the API surface is

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -133,6 +133,56 @@ int SglRefOwner::acquire(const uGDSIoSegment_t* segs, uint32_t nr,
     return 0;
 }
 
+/* Identity-only acquire for the async path: skips the exact-length bound
+ * because offset/size are late-bound and not yet observable at enqueue.
+ * Fills only dma/base/registered_length/backend in seg_views_out; geometry
+ * is completed by the callback. */
+int SglRefOwner::acquire_identity_only(const uGDSIoSegment_t* segs, uint32_t nr,
+                                       const nvm_ctrl_t* hs_ctrl,
+                                       SegView* seg_views_out)
+{
+    std::lock_guard<std::mutex> g(g_driver.lock);
+
+    for (uint32_t k = 0; k < nr; ++k) {
+        const void* base = segs[k].base;
+        auto it = g_driver.buf_registry.find(base);
+        if (it == g_driver.buf_registry.end()) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        DriverState::BufEntry& entry = it->second;
+
+        /* Controller affinity check. */
+        if (entry.map_ctrl != hs_ctrl) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Acquire the reference and record the base. */
+        entry.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        bases_[k] = base;
+
+        /* Identity-only SegView: geometry (page_start/size) left zero for
+         * the callback to fill after late binding. */
+        if (seg_views_out != nullptr) {
+            SegView& sv = seg_views_out[k];
+            sv.dma               = entry.dma;
+            sv.base              = base;
+            sv.registered_length = entry.length;
+            sv.backend           = entry.backend;
+            sv.page_start        = 0;
+            sv.size              = 0;
+        }
+    }
+    size_ = static_cast<uint16_t>(nr);
+    return 0;
+}
+
 /* ========================================================================
  * SglWindowCursor
  * ======================================================================== */
@@ -658,29 +708,5 @@ extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
     }
 }
 
-/* Phase 2/3 stubs: declared in the public header so the API surface is
- * visible to consumers, but return UGDS_IO_NOT_SUPPORTED until their
- * implementations land.  This keeps the library linkable without
- * undefined-reference errors.
- *
- * uGDSBatchIOSubmitv is implemented in ugds_batch.cpp. */
-
-extern "C" uGDSError_t uGDSReadvAsync(uGDSHandle_t /*fh*/,
-                                        uGDSIoSegment_t* /*segs*/,
-                                        unsigned /*nr_segs*/,
-                                        off_t* /*file_offset_p*/,
-                                        ssize_t* /*bytes_read_p*/,
-                                        void* /*stream*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
-
-extern "C" uGDSError_t uGDSWritevAsync(uGDSHandle_t /*fh*/,
-                                         uGDSIoSegment_t* /*segs*/,
-                                         unsigned /*nr_segs*/,
-                                         off_t* /*file_offset_p*/,
-                                         ssize_t* /*bytes_written_p*/,
-                                         void* /*stream*/)
-{
-    return uGDSError_t{UGDS_IO_NOT_SUPPORTED, 0};
-}
+/* The async vectored entry points (uGDSReadvAsync / uGDSWritevAsync) are
+ * implemented in ugds_async.cpp. */

--- a/src/ugds_iov.cpp
+++ b/src/ugds_iov.cpp
@@ -1,0 +1,651 @@
+/* uGDS SGL (scatter-gather) streaming engine and sync vectored API.
+ *
+ * Implements the pure streaming primitives (SglPageCursor, SglWindowCursor,
+ * analytic counter), the fixed-capacity reference owner (SglRefOwner), the
+ * shared windowed IO engine (do_iov_engine), and the public sync vectored
+ * entry points (uGDSReadv/uGDSWritev).
+ *
+ * Design constraints honored here:
+ *  - SglWindowCursor yields one CmdWindow at a time into caller-local
+ *    storage; no array of windows is ever materialized (independent M-2).
+ *  - SglRefOwner is fixed-capacity for UGDS_IOV_MAX and never allocates;
+ *    it is noexcept move-only so timeout parking is a bounded array move
+ *    (independent M-3, section 6.4).
+ *  - HandleOpGuard owns the handle-operation reference from immediately
+ *    after handle_lookup through engine return, closing the OOM-strand
+ *    window (V6-M-1).
+ *  - Exact registered-length bounds and controller affinity are checked
+ *    under g_driver.lock before the first cursor.next() (sections 5.1/5.3).
+ */
+
+#include "ugds_internal.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cerrno>
+#include <atomic>
+#include <algorithm>
+#include <new>
+
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(((size_t)1 << (sizeof(ssize_t) * 8 - 1)) - 1))
+#endif
+
+/* ========================================================================
+ * SglRefOwner implementation
+ * ======================================================================== */
+
+SglRefOwner::SglRefOwner(SglRefOwner&& other) noexcept
+    : bases_(other.bases_), size_(other.size_)
+{
+    other.size_ = 0;
+}
+
+SglRefOwner& SglRefOwner::operator=(SglRefOwner&& other) noexcept
+{
+    if (this != &other) {
+        /* Release anything we currently hold before overwriting. */
+        release();
+        bases_ = other.bases_;
+        size_  = other.size_;
+        other.size_ = 0;
+    }
+    return *this;
+}
+
+SglRefOwner::~SglRefOwner() noexcept
+{
+    release();
+}
+
+void SglRefOwner::release() noexcept
+{
+    if (size_ == 0) return;
+    std::lock_guard<std::mutex> g(g_driver.lock);
+    for (uint16_t i = 0; i < size_; ++i) {
+        auto it = g_driver.buf_registry.find(bases_[i]);
+        if (it != g_driver.buf_registry.end())
+            it->second.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    size_ = 0;
+}
+
+/* Acquire in-flight references for all segments under one g_driver.lock hold.
+ * All-or-nothing: on any failure, rolls back [0..k-1].  Returns 0 on success
+ * or -EINVAL.  If seg_views_out is non-null, fills the resolved SegView[]. */
+int SglRefOwner::acquire(const uGDSIoSegment_t* segs, uint32_t nr,
+                         const nvm_ctrl_t* hs_ctrl,
+                         size_t page_size,
+                         SegView* seg_views_out)
+{
+    std::lock_guard<std::mutex> g(g_driver.lock);
+
+    for (uint32_t k = 0; k < nr; ++k) {
+        const void* base = segs[k].base;
+        auto it = g_driver.buf_registry.find(base);
+        if (it == g_driver.buf_registry.end()) {
+            /* Rollback [0..k-1] */
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        DriverState::BufEntry& entry = it->second;
+
+        /* Controller affinity check: mapping controller must match the
+         * submitting handle's controller. */
+        if (entry.map_ctrl != hs_ctrl) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Exact-length bounds, subtraction form.  offset and size were
+         * already value-checked MPS/block-aligned by the caller; here we
+         * enforce the registered-range bound. */
+        const uint64_t off = static_cast<uint64_t>(segs[k].offset);
+        const uint64_t sz  = static_cast<uint64_t>(segs[k].size);
+        if (off > entry.length || sz > entry.length - off) {
+            for (uint32_t j = 0; j < k; ++j)
+                g_driver.buf_registry.find(bases_[j])->second.in_flight
+                    .fetch_sub(1, std::memory_order_acq_rel);
+            return -EINVAL;
+        }
+
+        /* Acquire the reference and record the base. */
+        entry.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        bases_[k] = base;
+
+        /* Fill the resolved SegView if requested. */
+        if (seg_views_out != nullptr) {
+            SegView& sv = seg_views_out[k];
+            sv.dma               = entry.dma;
+            sv.base              = base;
+            sv.registered_length = entry.length;
+            sv.backend           = entry.backend;
+            sv.page_start        = off / page_size;
+            sv.size              = segs[k].size;
+        }
+    }
+    size_ = static_cast<uint16_t>(nr);
+    return 0;
+}
+
+/* ========================================================================
+ * SglWindowCursor
+ * ======================================================================== */
+
+/* Compute SU = lcm(MPS, block_size).  Both are powers of two (MPS = 2^(12+n),
+ * LBADS >= 9), so lcm = max; the code computes the power-of-two case directly
+ * and falls back to lcm defensively. */
+static size_t compute_split_unit(size_t mps, size_t block_size) noexcept
+{
+    /* Power-of-two check: if both have exactly one bit set, lcm = max. */
+    if (mps > 0 && block_size > 0 &&
+        (mps & (mps - 1)) == 0 &&
+        (block_size & (block_size - 1)) == 0) {
+        return std::max(mps, block_size);
+    }
+    /* Defensive gcd/lcm for non-power-of-two (should not occur per NVMe). */
+    size_t a = mps, b = block_size;
+    while (b != 0) { size_t t = a % b; a = b; b = t; }
+    return (mps / a) * block_size;
+}
+
+bool sgl_cursor_init(SglWindowCursor& c, const SegView* segs, uint32_t nr_segs,
+                     size_t window_cap, size_t page_size, size_t block_size)
+{
+    if (window_cap == 0 || page_size == 0 || block_size == 0 || nr_segs == 0)
+        return false;
+    c.segs       = segs;
+    c.nr_segs    = nr_segs;
+    c.seg_idx    = 0;
+    c.bytes_in_seg = 0;
+    c.window_cap = window_cap;
+    c.page_size  = page_size;
+    c.block_size = block_size;
+    c.split_unit = compute_split_unit(page_size, block_size);
+    return true;
+}
+
+/* Emit at most one window into out.  Returns true if a window was produced,
+ * false when the SGL is exhausted.  Implements the capacity / PRP-tail /
+ * end-of-SGL rules without materializing a window array. */
+bool sgl_cursor_next(SglWindowCursor& c, CmdWindow& out) noexcept
+{
+    if (c.seg_idx >= c.nr_segs)
+        return false;
+
+    out.first_seg          = c.seg_idx;
+    out.first_seg_page_off = c.bytes_in_seg / c.page_size;
+    out.n_segs             = 0;
+    out.bytes              = 0;
+    out.n_pages            = 0;
+
+    while (c.seg_idx < c.nr_segs) {
+        const SegView& seg = c.segs[c.seg_idx];
+        size_t rem  = seg.size - c.bytes_in_seg;
+        size_t take = std::min(rem, c.window_cap - out.bytes);
+
+        /* Capacity rule: if this take splits mid-segment, round down to an
+         * SU boundary so the continuation starts page-aligned. */
+        if (take < rem) {
+            take = (take / c.split_unit) * c.split_unit;
+            /* Safety: window contents before a split are SU-multiples up to
+             * here, window_cap is an SU multiple, and a non-closed window
+             * has window_cap - out.bytes >= SU, so take >= SU > 0. */
+        }
+
+        size_t slice_pages = (take + c.page_size - 1) / c.page_size;
+        out.n_segs++;
+        out.bytes   += take;
+        out.n_pages += slice_pages;
+        c.bytes_in_seg += take;
+
+        bool segment_ended = (c.bytes_in_seg == seg.size);
+        if (segment_ended) {
+            /* PRP tail rule: a segment whose size is not page-multiple
+             * must be the window's last slice. */
+            bool non_page_tail = (seg.size % c.page_size != 0);
+            c.seg_idx++;
+            c.bytes_in_seg = 0;
+            if (non_page_tail) {
+                return true;  /* PRP tail */
+            }
+        }
+
+        /* Capacity rule */
+        if (out.bytes >= c.window_cap)
+            return true;
+    }
+
+    /* End of SGL: return whatever was accumulated. */
+    return true;
+}
+
+/* ========================================================================
+ * sgl_count_windows_analytic
+ * O(nr_segs) exact count via room/cap arithmetic.
+ * ======================================================================== */
+
+bool sgl_count_windows_analytic(const uGDSIoSegment_t* segs,
+                                uint32_t nr_segs,
+                                size_t window_cap, size_t page_size,
+                                size_t block_size,
+                                uint32_t* out) noexcept
+{
+    if (window_cap == 0 || page_size == 0 || block_size == 0 || nr_segs == 0)
+        return false;
+
+    /* SU is used by the cursor to round capacity-rule split points; the
+     * analytic counter uses quotient/remainder against window_cap, which
+     * the caller already guaranteed is an SU multiple (so full windows
+     * need no rounding).  We keep SU here only as a debug sanity
+     * reference. */
+    const size_t SU = compute_split_unit(page_size, block_size);
+    (void)SU;
+
+    uint64_t count = 0;
+    uint64_t open  = 0;  /* bytes accumulated in the current open window */
+
+    for (uint32_t i = 0; i < nr_segs; ++i) {
+        uint64_t s = segs[i].size;
+
+        /* Absorb into the open window if one exists. */
+        if (open != 0) {
+            uint64_t room = window_cap - open;
+            if (s < room) {
+                open += s;
+                s = 0;
+            } else {
+                /* s >= room: the open window fills to capacity.
+                 * But we must respect the capacity-rule mid-segment
+                 * rounding: the actual take is round_down(room, SU).
+                 * Since window contents before a split are SU-multiples
+                 * and window_cap is an SU multiple, room itself is an SU
+                 * multiple when open is an SU multiple (which it is by
+                 * induction).  So take == room exactly, no rounding
+                 * loss. */
+                s -= room;
+                count++;
+                open = 0;
+            }
+        }
+
+        if (s != 0) {
+            /* All full capacity-rule windows at once.  Each full window
+             * takes window_cap bytes (an SU multiple), so no rounding. */
+            count += s / window_cap;
+            open = s % window_cap;
+        }
+
+        /* PRP tail rule: if this segment's size is not page-multiple, it closes the
+         * window. */
+        if (segs[i].size % page_size != 0) {
+            /* open must be nonzero here: the segment just contributed
+             * remainder bytes and was not absorbed entirely into a prior
+             * open window. */
+            if (open != 0) {
+                count++;
+                open = 0;
+            }
+        }
+    }
+
+    /* End of SGL: trailing open window */
+    if (open != 0) count++;
+
+    if (count > UINT32_MAX)
+        return false;
+
+    *out = static_cast<uint32_t>(count);
+    return true;
+}
+
+/* ========================================================================
+ * SglPageCursor (section 3.2)
+ * ======================================================================== */
+
+void sgl_page_cursor_init(SglPageCursor& c, const SegView* segs,
+                          uint32_t first_seg, size_t first_seg_page_off,
+                          uint32_t n_segs, size_t n_pages) noexcept
+{
+    c.segs            = segs;
+    c.abs_seg         = first_seg;
+    c.end_seg         = first_seg + n_segs;
+    c.page_in_seg     = segs[first_seg].page_start + first_seg_page_off;
+    /* Compute the pages in the first slice.  For the first segment the slice
+     * may start mid-segment (first_seg_page_off > 0).  The total pages in
+     * the slice is ceil(slice_bytes / MPS).  We don't have slice_bytes
+     * directly, but we know:
+     *  - For the last segment in the window, the slice may be partial.
+     *  - For non-last segments (or single-segment full), the slice covers
+     *    from page_in_seg to the end of the segment's registered pages,
+     *    minus what later windows consume (but within this window it's the
+     *    full remainder).
+     *
+     * Since the caller will call next() exactly n_pages times total, and
+     * each segment boundary is page-aligned (alignment + cursor rules), we
+     * can lazily compute slice pages as: for a given segment, the slice
+     * runs from page_in_seg to min(seg_end_page, page_in_seg + remaining).
+     * We track pages_remaining_total and cap each segment's contribution. */
+    c.slice_pages_left = n_pages;  /* total; will be reduced per-segment */
+    (void)first_seg_page_off;
+}
+
+uint64_t sgl_page_cursor_next(SglPageCursor& c) noexcept
+{
+    /* Walk the segment slices in order, emitting MPS-granular bus addresses.
+     * slice_pages_left tracks the total pages remaining across all slices
+     * in this window; each segment boundary naturally caps a slice. */
+    while (c.abs_seg < c.end_seg && c.slice_pages_left > 0) {
+        const SegView& seg = c.segs[c.abs_seg];
+        /* The slice for this segment runs from page_in_seg up to either the
+         * segment's page boundary or slice_pages_left exhaustion.  Since all
+         * slices except possibly the last are page-multiple (alignment +
+         * cursor rules), and the last slice is capped by slice_pages_left,
+         * this walk is correct. */
+        size_t seg_end_page = seg.page_start +
+            (seg.size + seg.dma->page_size - 1) / seg.dma->page_size;
+        if (c.page_in_seg < seg_end_page) {
+            uint64_t addr = seg.dma->ioaddrs[c.page_in_seg];
+            c.page_in_seg++;
+            c.slice_pages_left--;
+            return addr;
+        }
+        /* Advance to the next segment in the window. */
+        c.abs_seg++;
+        if (c.abs_seg < c.end_seg) {
+            c.page_in_seg = c.segs[c.abs_seg].page_start;
+        }
+    }
+    return 0;  /* safety; should not happen with correct use */
+}
+
+/* ========================================================================
+ * do_iov_engine
+ * Shared streaming windowed IO engine.
+ * ======================================================================== */
+
+IovEngineResult do_iov_engine(HandleState* hs, SegView* segs, uint32_t nr_segs,
+                              off_t file_offset, uint8_t opcode,
+                              SglRefOwner* owner, nvm_dma_t* transient)
+{
+    IovEngineResult result{0, false};
+
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    /* Compute max_xfer (parity with the original scalar path). */
+    const size_t prp_capacity = page_size / sizeof(uint64_t);
+    size_t max_xfer = hs->max_transfer_size;
+    if (max_xfer == 0)
+        max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
+    if (max_xfer < page_size)
+        max_xfer = page_size;
+    size_t prp_max = (prp_capacity + 1) * page_size;
+    if (max_xfer > prp_max)
+        max_xfer = prp_max;
+
+    /* Compute SU and window_cap = round_down(max_xfer, SU). */
+    const size_t SU = compute_split_unit(page_size, block_size);
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0) {
+        result.ret = -EINVAL;
+        return result;
+    }
+
+    /* Initialize the window cursor. */
+    SglWindowCursor cursor;
+    if (!sgl_cursor_init(cursor, segs, nr_segs, window_cap, page_size, block_size)) {
+        result.ret = -EINVAL;
+        return result;
+    }
+
+    const uint64_t start_lba = static_cast<uint64_t>(file_offset) / block_size;
+
+    /* QP selection: round-robin, one QP per IO (unchanged concurrency story). */
+    const uint16_t qp_idx = static_cast<uint16_t>(
+        hs->rr_counter.fetch_add(1) % hs->num_qps);
+    IOQueuePair& qp = *hs->qps[qp_idx];
+
+    ssize_t bytes_done = 0;
+    uint64_t current_lba = start_lba;
+
+    {
+        std::lock_guard<std::mutex> qp_lock(qp.lock);
+
+        /* Re-check wedged after acquiring QP lock. */
+        if (hs->wedged.load(std::memory_order_acquire)) {
+            result.ret = -EBADF;
+            return result;
+        }
+
+        CmdWindow window;
+        while (sgl_cursor_next(cursor, window)) {
+            /* Enqueue a command, draining the CQ if the SQ is full. */
+            nvm_cmd_t* cmd = nullptr;
+            while ((cmd = nvm_sq_enqueue(&qp.sq)) == nullptr) {
+                nvm_cpl_t* drain = wait_for_completion(hs, qp);
+                if (drain == nullptr) {
+                    /* Timeout during drain.  Park resources immediately
+                     * while qp.lock is held. */
+                    result.ret = -EIO;
+                    result.timed_out = true;
+                    hs->wedged.store(true, std::memory_order_release);
+                    if (transient != nullptr) {
+                        qp.timeout_dma = transient;
+                        transient = nullptr;
+                    } else if (owner != nullptr && !owner->empty()) {
+                        qp.timeout_refs = std::move(*owner);
+                    }
+                    return result;
+                }
+                uint16_t st = UGDS_CPL_SCT_SC(drain);
+                nvm_sq_update(&qp.sq);
+                sgl_publish_prp();
+                nvm_cq_update(&qp.cq);
+                if (st != 0) {
+                    result.ret = -EIO;
+                    return result;
+                }
+            }
+
+            memset(cmd, 0, sizeof(nvm_cmd_t));
+            uint16_t cid = NVM_DEFAULT_CID(&qp.sq);
+            nvm_cmd_header(cmd, cid, opcode, hs->ns_id);
+
+            /* Build PRP using SglPageCursor. */
+            SglPageCursor pc;
+            sgl_page_cursor_init(pc, segs, window.first_seg,
+                                 window.first_seg_page_off,
+                                 window.n_segs, window.n_pages);
+
+            if (window.n_pages == 1) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, 0);
+            } else if (window.n_pages == 2) {
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                uint64_t prp2 = sgl_page_cursor_next(pc);
+                nvm_cmd_data_ptr(cmd, prp1, prp2);
+            } else {
+                volatile uint64_t* prp_list =
+                    reinterpret_cast<volatile uint64_t*>(qp.prp_dma->vaddr);
+                uint64_t prp1 = sgl_page_cursor_next(pc);
+                for (size_t i = 1; i < window.n_pages; ++i)
+                    prp_list[i - 1] = sgl_page_cursor_next(pc);
+                sgl_publish_prp();
+                nvm_cmd_data_ptr(cmd, prp1, qp.prp_dma->ioaddrs[0]);
+            }
+
+            size_t n_blocks = window.bytes / block_size;
+            nvm_cmd_rw_blks(cmd, current_lba, static_cast<uint16_t>(n_blocks));
+
+            sgl_publish_prp();
+            nvm_sq_submit(&qp.sq);
+            sgl_publish_prp();
+
+            nvm_cpl_t* cpl = wait_for_completion(hs, qp);
+            if (cpl == nullptr) {
+                /* Timeout: park resources immediately while qp.lock is held. */
+                result.ret = -EIO;
+                result.timed_out = true;
+                hs->wedged.store(true, std::memory_order_release);
+                if (transient != nullptr) {
+                    qp.timeout_dma = transient;
+                    transient = nullptr;
+                } else if (owner != nullptr && !owner->empty()) {
+                    qp.timeout_refs = std::move(*owner);
+                }
+                return result;
+            }
+
+            uint16_t status = UGDS_CPL_SCT_SC(cpl);
+            nvm_sq_update(&qp.sq);
+            sgl_publish_prp();
+            nvm_cq_update(&qp.cq);
+
+            if (status != 0) {
+                result.ret = -EIO;
+                return result;
+            }
+
+            bytes_done += static_cast<ssize_t>(window.bytes);
+            current_lba += n_blocks;
+        }
+
+        result.ret = bytes_done;
+    }
+
+    return result;
+}
+
+/* ========================================================================
+ * uGDSReadv / uGDSWritev (sections 1.2, 6.1, 8.1)
+ * ======================================================================== */
+
+/* Common validation + engine dispatch for vectored read/write.
+ * opcode is NVM_IO_READ or NVM_IO_WRITE.
+ * Returns total bytes or -errno. */
+static ssize_t do_readv_writev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                               unsigned nr_segs, off_t file_offset,
+                               uint8_t opcode)
+{
+    /* --- Malformed-call checks (8.1 value rows) --- */
+    if (segs == nullptr || nr_segs == 0)
+        return -EINVAL;
+    if (nr_segs > UGDS_IOV_MAX)
+        return -EINVAL;
+
+    /* handle_lookup + HandleOpGuard (V6-M-1) */
+    std::shared_ptr<HandleState> hs_sp;
+    HandleState* hs = handle_lookup(fh, &hs_sp);
+    if (!hs)
+        return -EBADF;
+    HandleOpGuard handle_guard(hs);  /* owns handle_in_flight from here */
+
+    const size_t page_size  = hs->ctrl->page_size;
+    const size_t block_size = hs->block_size;
+
+    if (page_size == 0 || block_size == 0) {
+        return -EINVAL;
+    }
+
+    /* --- Per-segment value validation --- */
+    uint64_t total_size = 0;
+    for (unsigned i = 0; i < nr_segs; ++i) {
+        if (segs[i].base == nullptr || segs[i].size == 0)
+            return -EINVAL;
+        if (segs[i].offset < 0)
+            return -EINVAL;
+        if ((static_cast<size_t>(segs[i].offset) % page_size) != 0)
+            return -EINVAL;
+        if ((segs[i].size % block_size) != 0)
+            return -EINVAL;
+
+        /* Overflow-safe total accumulation. Guard order matters:
+         * total_size is already known to be <= SSIZE_MAX, so
+         * SSIZE_MAX - total_size cannot underflow. */
+        uint64_t seg_size = static_cast<uint64_t>(segs[i].size);
+        if (seg_size > static_cast<uint64_t>(SSIZE_MAX) - total_size)
+            return -EINVAL;  /* total overflow */
+        total_size += seg_size;
+    }
+
+    /* file_offset alignment. */
+    if (file_offset < 0 ||
+        (static_cast<size_t>(file_offset) % block_size) != 0)
+        return -EINVAL;
+
+    /* window_cap == 0 check (block > max_xfer). */
+    const size_t prp_capacity = page_size / sizeof(uint64_t);
+    size_t max_xfer = hs->max_transfer_size;
+    if (max_xfer == 0) max_xfer = UGDS_DEFAULT_MAX_TRANSFER_SIZE;
+    if (max_xfer < page_size) max_xfer = page_size;
+    size_t prp_max = (prp_capacity + 1) * page_size;
+    if (max_xfer > prp_max) max_xfer = prp_max;
+    const size_t SU = compute_split_unit(page_size, block_size);
+    size_t window_cap = (max_xfer / SU) * SU;
+    if (window_cap == 0)
+        return -EINVAL;
+
+    /* --- SegView storage: stack for nr <= 4, heap otherwise --- */
+    /* HandleOpGuard protects the handle reference across this allocation,
+     * so a bad_alloc here cannot strand handle_in_flight. */
+    SegView stack_views[4];
+    std::vector<SegView> heap_views;
+    SegView* views = nullptr;
+
+    if (nr_segs <= 4) {
+        views = stack_views;
+    } else {
+        try {
+            heap_views.resize(nr_segs);
+        } catch (const std::bad_alloc&) {
+            return -ENOMEM;
+        }
+        views = heap_views.data();
+    }
+
+    /* --- Acquire in-flight refs + resolve segments (all-or-nothing) --- */
+    SglRefOwner owner;
+    int rc = owner.acquire(segs, static_cast<uint32_t>(nr_segs),
+                           hs->ctrl, page_size, views);
+    if (rc != 0) {
+        return rc;  /* -EINVAL: unregistered / bounds / affinity */
+    }
+
+    /* --- Engine dispatch --- */
+    IovEngineResult result = do_iov_engine(hs, views,
+                                           static_cast<uint32_t>(nr_segs),
+                                           file_offset, opcode,
+                                           &owner, nullptr);
+
+    /* --- Cleanup --- */
+    /* owner.release() is a no-op if the engine parked it on timeout. */
+    owner.release();
+    /* handle_guard.release() disarms the destructor and calls
+     * handle_release exactly once. */
+    handle_guard.release();
+
+    if (result.timed_out) {
+        fprintf(stderr, "uGDS: vectored I/O timeout -- handle wedged. "
+                "Controller reset required.\n");
+    }
+
+    return result.ret;
+}
+
+extern "C" ssize_t uGDSReadv(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                               unsigned nr_segs, off_t file_offset)
+{
+    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_READ);
+}
+
+extern "C" ssize_t uGDSWritev(uGDSHandle_t fh, const uGDSIoSegment_t* segs,
+                                unsigned nr_segs, off_t file_offset)
+{
+    return do_readv_writev(fh, segs, nr_segs, file_offset, NVM_IO_WRITE);
+}


### PR DESCRIPTION
Closes #40.

## Summary

Adds an application-managed dma-buf import path for GPU runtimes that can export device memory as dma-buf file descriptors but have no native uGDS backend (Intel Level Zero first among them). The application owns the export; uGDS only imports the fd, so the library gains no Intel oneAPI dependency.

The kernel module performs authoritative P2P verification: after mapping the dma-buf attachment, every SG DMA address is classified against the PCI BAR windows of peer devices. When the caller sets UGDS_DMABUF_REQUIRE_P2P, mappings that resolve to system memory are rejected before any DMA address reaches userspace.

The V1 ioctl and all existing CUDA/HIP paths are unchanged.

Builds on #30 (SGL support).

> **Note:** Since these are fork-based PRs, the GitHub "Files changed" tab includes changes from #30. To review only the dmabuf-registration changes, see the [incremental diff](https://github.com/potatogim/uGDS/compare/feat/sgl-support...feat/external-dmabuf-import).

### Stack order

1. #30: scatter-gather vectored I/O
2. **this PR**: external dma-buf registration

## Changes

### Kernel UAPI (`drv/ioctl.h`, `drv/pci.c`)

- `NVM_MAP_DMABUF_MEMORY_V2` (cmd 9): versioned struct, mapping-class and failure-reason output, strict-P2P flag; rejects unknown flags and nonzero reserved fields
- `NVM_GET_CAPS` (cmd 8): runtime capability and pin-limit discovery
- Per-file and global pinned-byte accounting (`atomic64_t`) with read-only module parameters; charges refunded on unmap, file close, and hot-remove

### P2P BAR classification (`drv/map.c`)

- `ugds_classify_peer_bar`: walks the flattened per-page DMA addresses and matches them against peer PCI device BAR windows in the importer's domain
- Ambiguous ownership (two devices claiming one range) fails closed
- Peer device reference held for the mapping lifetime

### Userspace (`src/libnvm/`, `src/ugds_buf.cpp`, `include/ugds.h`)

- `uGDSBufRegisterDmabuf` with versioned `uGDSDmabufRegParams_t`
- `uGDSQueryDmabufSupport` runtime capability query
- `MAP_TYPE_DMABUF_EXT` mapping type with POSIX fd lifecycle (`F_DUPFD_CLOEXEC`, retain until unmap)
- `nvm_dmabuf_origin` enum replacing the `hip_origin` bool; backward-compatible shims retained
- New error codes for invalid fd, non-P2P mapping, pin-limit exceedance, and command timeout
- No-backend builds now guard CUDA runtime includes and types and add the missing no-backend vectored async launch branch. CMake already accepted this configuration on the base branch, where `src/ugds_async.cpp` failed on the unconditional `cuda_runtime.h` include.

### Build system

- Kernel: `BUILD_DMABUF=1` selects a standalone dma-buf importer module without NVIDIA driver sources and without defining the HIP backend
- CMake: `UGDS_ENABLE_DMABUF_IMPORT` (default `ON`) contributes independently to `UGDS_HAVE_DMABUF`, so external dma-buf registration is compiled even when both GPU backends are disabled

## Notes

Strict PEER_BAR classification holds for direct bus-address mappings. On IOMMU-translated topologies where importer-visible addresses are IOVAs that cannot be matched to a BAR, strict mode rejects the mapping (fail closed); this is a documented V1 boundary. Dual-backend async dispatch for external buffers needs follow-up work. The V2 ioctl number encodes the current struct size; a future incompatible struct would take a new command number.

## Build verification

These results are compile/link checks. Intel Level Zero + NVMe runtime validation is still pending.

### Userspace regression matrix

| Enabled backend(s) | CMake options | Result |
|---|---|---|
| CUDA | `UGDS_BACKEND_CUDA=ON`, `UGDS_BACKEND_HIP=OFF` | Pass |
| HIP | `UGDS_BACKEND_CUDA=OFF`, `UGDS_BACKEND_HIP=ON` | Pass |
| CUDA + HIP | `UGDS_BACKEND_CUDA=ON`, `UGDS_BACKEND_HIP=ON` | Pass |

External dma-buf registration is backend-neutral and is included in each configuration above. A CUDA/ROCm-free library-only build was also verified:

```sh
cmake -S . -B build-external \
  -DUGDS_BACKEND_CUDA=OFF \
  -DUGDS_BACKEND_HIP=OFF \
  -DUGDS_ENABLE_DMABUF_IMPORT=ON
cmake --build build-external
```

This configuration checks that the external-registration, synchronous IO, and batch IO paths compile without CUDA or ROCm dependencies. Stream-async IO remains unsupported without a CUDA or HIP runtime.

### Kernel module

| Configuration | Command | Result |
|---|---|---|
| Standalone dma-buf importer, without GPU vendor driver sources | `make -C drv BUILD_CUDA=0 BUILD_DMABUF=1` | Pass |

