### PR TITLE
[test] Add vLLM-LMCache-uGDS benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ See [examples/01_basic_read_write.cu](examples/01_basic_read_write.cu) for a com
 
 For build instructions, environment setup, and driver management, see the **[Installation Guide](docs/installation.md)**.
 
+Run the [vLLM + LMCache + uGDS end-to-end benchmark](examples/vllm_lmcache_bench/README.md) to validate KV-cache offloading on a dedicated NVMe SSD.
+
 ### AMD Infinity Storage (HIP/ROCm) Backend
 
 To build with the AMD HIP backend instead of CUDA:

--- a/examples/vllm_lmcache_bench/.gitignore
+++ b/examples/vllm_lmcache_bench/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+.tools/
+.uv-cache/
+.python-bin
+artifacts/
+models/
+__pycache__/

--- a/examples/vllm_lmcache_bench/README.md
+++ b/examples/vllm_lmcache_bench/README.md
@@ -1,0 +1,184 @@
+# vLLM + LMCache + uGDS End-to-End Benchmark
+
+This benchmark validates the following Qwen3-0.6B inference path:
+
+```text
+vLLM -> LMCache MP Server -> uGDS -> NVMe SSD
+```
+
+It sends one cold request followed by a warm request with the same prefix, then
+uses vLLM metrics to verify that the warm request hits KV cache stored by
+LMCache through uGDS.
+
+## Benchmark Files
+
+| File | Purpose |
+|---|---|
+| `quickstart.sh` | Main entry point: prepares the environment, builds uGDS, binds the SSD, downloads the model, and runs the benchmark |
+| `setup_env.sh` | Creates `.venv`, installs the current vLLM and LMCache sources, builds `libugds.so`, and builds `ugds_drv.ko` when `BUILD_UGDS_DRIVER=1` |
+| `run_e2e_bench.sh` | Starts LMCache and vLLM, invokes the benchmark client, collects logs, and stops the services |
+| `bench_client.py` | Sends the cold and warm requests, reads vLLM metrics, and writes `bench-result.json` |
+| `tests/test_bench_client.py` | Unit tests for `bench_client.py`; uses mocks to test metrics and streaming-response parsing and is not part of the real benchmark |
+
+`bench_client.py` connects to a real vLLM service and produces benchmark data.
+`tests/test_bench_client.py` only validates the client-side parsing logic and
+does not require a GPU, LMCache, or uGDS.
+
+## Recommended Test Environment
+
+| Component | Recommendation |
+|---|---|
+| GPU | NVIDIA CUDA GPU with at least 16 GB of memory |
+| GPU driver | NVIDIA open kernel driver 550 or newer |
+| CUDA | CUDA Toolkit 12.x with `nvcc` available |
+| Linux | Kernel headers matching the running kernel |
+| SSD | A dedicated NVMe SSD larger than the configured uGDS slab |
+| Build tools | `cmake`, `make`, a C/C++ compiler, `curl`, `git`, `pciutils`, and `util-linux` |
+| Network | Access to a Python package index and Hugging Face |
+
+The three repositories must be siblings in the same workspace:
+
+```text
+workspace/
+├── uGDS/
+├── LMCache/
+└── vllm/
+```
+
+The default model is `Qwen/Qwen3-0.6B`, and the default uGDS slab size is
+1 GiB. This benchmark has been validated on an NVIDIA A100 40 GB, CUDA 12.4,
+and a Samsung 990 PRO.
+
+> **Data loss warning:** uGDS bypasses the filesystem and overwrites raw blocks
+> on the target SSD. Use a dedicated, disposable SSD. Never use a system disk,
+> a mounted disk, or a disk containing important data.
+
+## Run the Benchmark
+
+First identify the dedicated SSD's PCI address and verify that it is not
+mounted:
+
+```bash
+lspci -Dnn | grep -i 'non-volatile memory'
+lsblk -o NAME,PATH,SIZE,MODEL,SERIAL,FSTYPE,MOUNTPOINTS
+```
+
+Enter the benchmark directory and replace the example PCI address with the
+address of the target SSD:
+
+```bash
+cd uGDS/examples/vllm_lmcache_bench
+
+UGDS_PCI_SLOT=0000:b8:00.0 \
+I_UNDERSTAND_UGDS_ERASES_DEVICE=1 \
+./quickstart.sh
+```
+
+`quickstart.sh` creates an isolated `.venv`, builds the uGDS driver and library,
+binds the selected SSD to `ugds_drv`, downloads the model, and starts LMCache
+and vLLM to run the benchmark.
+
+If the system already has multiple `/dev/ugds_drv*` devices, explicitly specify
+the character device that corresponds to the PCI address:
+
+```bash
+UGDS_PCI_SLOT=0000:b8:00.0 \
+UGDS_DEVICE=/dev/ugds_drv0 \
+I_UNDERSTAND_UGDS_ERASES_DEVICE=1 \
+./quickstart.sh
+```
+
+Common overrides:
+
+```bash
+GPU_ID=1 \
+MODEL=/models/Qwen3-0.6B \
+L1_SIZE_GB=2 \
+UGDS_PCI_SLOT=0000:b8:00.0 \
+I_UNDERSTAND_UGDS_ERASES_DEVICE=1 \
+./quickstart.sh
+```
+
+## Expected Results
+
+The terminal output follows this format; exact values depend on the hardware
+and system load:
+
+```text
+Running cold request...
+Running warm request...
+Cold TTFT: 0.1408 s
+Warm TTFT: 0.1121 s
+TTFT speedup: 1.26x
+External query tokens: 4764
+External hit tokens: 2304
+Local prefix-cache hit tokens: 0
+PASS: LMCache external cache hit increased by 2304 tokens
+
+Artifacts: .../artifacts/20260823-001746-573777
+```
+
+The complete run exits with status 0 when:
+
+- the LMCache log contains `GDSContext: uGDS raw-device slab opened`;
+- `external_cache_query_tokens > 0`; and
+- `external_cache_hit_tokens > 0`.
+
+The benchmark disables vLLM's local prefix cache, so
+`local_prefix_cache_hit_tokens` is expected to be `0`. TTFT speedup is an
+observed performance result, not a pass condition.
+
+Each run creates a separate artifact directory:
+
+```text
+artifacts/<run-id>/
+├── bench-result.json
+├── lmcache.log
+├── lmcache-status.json
+├── versions.txt
+└── vllm.log
+```
+
+`bench-result.json` uses the following format:
+
+```json
+{
+  "cold": {
+    "completion_tokens": 8,
+    "latency_seconds": 0.15999239403754473,
+    "prompt_tokens": 2382,
+    "ttft_seconds": 0.14077616506256163
+  },
+  "external_cache_hit_tokens": 2304.0,
+  "external_cache_query_tokens": 4764.0,
+  "local_prefix_cache_hit_tokens": 0.0,
+  "model": "/path/to/uGDS/examples/vllm_lmcache_bench/models/Qwen3-0.6B",
+  "passed": true,
+  "prompt_repeats": 64,
+  "ttft_speedup": 1.2555576759465554,
+  "warm": {
+    "completion_tokens": 8,
+    "latency_seconds": 0.1462629099842161,
+    "prompt_tokens": 2382,
+    "ttft_seconds": 0.11212241998873651
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `cold` / `warm` | Latency, TTFT, and token counts for the cold and warm requests |
+| `ttft_speedup` | `cold.ttft_seconds / warm.ttft_seconds` |
+| `external_cache_query_tokens` | Total tokens queried from LMCache by both requests |
+| `external_cache_hit_tokens` | Tokens retrieved from LMCache/uGDS |
+| `local_prefix_cache_hit_tokens` | Tokens served by vLLM's local prefix cache; expected to be 0 |
+| `passed` | `true` when both external queries and external hits are greater than 0 |
+
+`lmcache.log` should also contain entries in this format:
+
+```text
+GDSContext: uGDS raw-device slab opened at /dev/ugds_drv0 (1.0 GiB)
+Stored 2048 tokens in 0.009 seconds
+Stored 256 tokens in 0.001 seconds
+Retrieved 2304 tokens in 0.006 seconds
+```

--- a/examples/vllm_lmcache_bench/bench_client.py
+++ b/examples/vllm_lmcache_bench/bench_client.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Drive a cold/warm vLLM request pair and verify an external KV cache hit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+METRIC_NAMES = {
+    "vllm:external_prefix_cache_hits",
+    "vllm:external_prefix_cache_hits_total",
+    "vllm:external_prefix_cache_queries",
+    "vllm:external_prefix_cache_queries_total",
+    "vllm:prefix_cache_hits",
+    "vllm:prefix_cache_hits_total",
+}
+
+
+@dataclass
+class RequestResult:
+    """Timing and token counts from one streaming completion request."""
+
+    ttft_seconds: float
+    latency_seconds: float
+    prompt_tokens: int | None
+    completion_tokens: int | None
+
+
+def http_get(url: str, timeout: float = 10.0) -> bytes:
+    """Fetch a URL and return its response body."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GET {url} failed: HTTP {error.code}: {detail}") from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"GET {url} failed: {error.reason}") from error
+
+
+def read_metrics(base_url: str) -> dict[str, float]:
+    """Read and aggregate the vLLM Prometheus counters used by this bench."""
+    values = {name: 0.0 for name in METRIC_NAMES}
+    body = http_get(f"{base_url}/metrics").decode("utf-8", errors="replace")
+    found: set[str] = set()
+    for line in body.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            continue
+        name = fields[0].split("{", 1)[0]
+        if name not in values:
+            continue
+        try:
+            values[name] += float(fields[1])
+            found.add(name)
+        except ValueError:
+            continue
+    if not any("external_prefix_cache_hits" in name for name in found):
+        raise RuntimeError(
+            "vLLM /metrics does not expose external prefix cache counters; "
+            "make sure stats are enabled and this vLLM source is installed"
+        )
+    return values
+
+
+def metric_value(metrics: dict[str, float], stem: str) -> float:
+    """Return one counter regardless of Prometheus' optional _total suffix."""
+    total_name = f"{stem}_total"
+    if metrics.get(total_name, 0.0) != 0.0:
+        return metrics[total_name]
+    return metrics.get(stem, 0.0)
+
+
+def make_prompt(repeats: int) -> str:
+    """Build a deterministic, sufficiently long prefix for KV reuse."""
+    paragraph = (
+        "LMCache keeps reusable key value tensors outside the inference engine. "
+        "uGDS moves those tensors directly between GPU memory and NVMe storage. "
+        "This repeated benchmark passage is deterministic and intentionally long. "
+    )
+    return (
+        "Read the following technical context and return one short summary.\n\n"
+        + paragraph * repeats
+        + "\nSummary:"
+    )
+
+
+def run_completion(
+    base_url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: float,
+) -> RequestResult:
+    """Send one streaming completion and measure first-token and total latency."""
+    payload = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}/v1/completions",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    first_token_at: float | None = None
+    usage: dict[str, Any] = {}
+    event_count = 0
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            for raw_line in response:
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                event = json.loads(data)
+                event_count += 1
+                if first_token_at is None and event.get("choices"):
+                    first_token_at = time.perf_counter()
+                if event.get("usage"):
+                    usage = event["usage"]
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"completion request failed: HTTP {error.code}: {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"completion request failed: {error.reason}") from error
+
+    end = time.perf_counter()
+    if event_count == 0 or first_token_at is None:
+        raise RuntimeError("completion stream returned no token events")
+    return RequestResult(
+        ttft_seconds=first_token_at - start,
+        latency_seconds=end - start,
+        prompt_tokens=usage.get("prompt_tokens"),
+        completion_tokens=usage.get("completion_tokens"),
+    )
+
+
+def wait_for_metrics(
+    base_url: str,
+    initial_hits: float,
+    timeout: float,
+) -> dict[str, float]:
+    """Wait for vLLM's periodic metric logger to publish the warm hit."""
+    deadline = time.monotonic() + timeout
+    latest: dict[str, float] = {}
+    while time.monotonic() < deadline:
+        latest = read_metrics(base_url)
+        hits = metric_value(latest, "vllm:external_prefix_cache_hits")
+        if hits > initial_hits:
+            return latest
+        time.sleep(1.0)
+    return latest
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--prompt-repeats", type=int, default=64)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--store-wait", type=float, default=3.0)
+    parser.add_argument("--request-timeout", type=float, default=180.0)
+    parser.add_argument("--metrics-timeout", type=float, default=30.0)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    if args.prompt_repeats < 1:
+        parser.error("--prompt-repeats must be positive")
+    if args.max_tokens < 1:
+        parser.error("--max-tokens must be positive")
+    return args
+
+
+def main() -> int:
+    """Run the cold/warm benchmark and return nonzero unless uGDS is exercised."""
+    args = parse_args()
+    prompt = make_prompt(args.prompt_repeats)
+    before = read_metrics(args.base_url)
+    initial_external_hits = metric_value(
+        before, "vllm:external_prefix_cache_hits"
+    )
+    initial_external_queries = metric_value(
+        before, "vllm:external_prefix_cache_queries"
+    )
+    initial_local_hits = metric_value(before, "vllm:prefix_cache_hits")
+
+    print("Running cold request...", flush=True)
+    cold = run_completion(
+        args.base_url, args.model, prompt, args.max_tokens, args.request_timeout
+    )
+    time.sleep(args.store_wait)
+
+    print("Running warm request...", flush=True)
+    warm = run_completion(
+        args.base_url, args.model, prompt, args.max_tokens, args.request_timeout
+    )
+    after = wait_for_metrics(
+        args.base_url, initial_external_hits, args.metrics_timeout
+    )
+
+    external_hits = (
+        metric_value(after, "vllm:external_prefix_cache_hits")
+        - initial_external_hits
+    )
+    external_queries = (
+        metric_value(after, "vllm:external_prefix_cache_queries")
+        - initial_external_queries
+    )
+    local_hits = metric_value(after, "vllm:prefix_cache_hits") - initial_local_hits
+    passed = external_hits > 0 and external_queries > 0
+    speedup = cold.ttft_seconds / warm.ttft_seconds if warm.ttft_seconds else None
+    result = {
+        "passed": passed,
+        "model": args.model,
+        "prompt_repeats": args.prompt_repeats,
+        "cold": asdict(cold),
+        "warm": asdict(warm),
+        "ttft_speedup": speedup,
+        "external_cache_query_tokens": external_queries,
+        "external_cache_hit_tokens": external_hits,
+        "local_prefix_cache_hit_tokens": local_hits,
+    }
+
+    output_dir = os.path.dirname(os.path.abspath(args.output))
+    os.makedirs(output_dir, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as output_file:
+        json.dump(result, output_file, indent=2, sort_keys=True)
+        output_file.write("\n")
+
+    print(f"Cold TTFT: {cold.ttft_seconds:.4f} s")
+    print(f"Warm TTFT: {warm.ttft_seconds:.4f} s")
+    print(f"TTFT speedup: {speedup:.2f}x")
+    print(f"External query tokens: {external_queries:.0f}")
+    print(f"External hit tokens: {external_hits:.0f}")
+    print(f"Local prefix-cache hit tokens: {local_hits:.0f}")
+    if passed:
+        print(
+            "PASS: LMCache external cache hit increased by "
+            f"{external_hits:.0f} tokens"
+        )
+        return 0
+    print(
+        "FAIL: no LMCache external cache hit was observed; inspect the service logs",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vllm_lmcache_bench/quickstart.sh
+++ b/examples/vllm_lmcache_bench/quickstart.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BENCH_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+UGDS_REPO="${UGDS_REPO:-$(cd -- "$BENCH_DIR/../.." && pwd)}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$(dirname -- "$UGDS_REPO")}"
+LMCACHE_REPO="${LMCACHE_REPO:-$WORKSPACE_DIR/LMCache}"
+VLLM_REPO="${VLLM_REPO:-$WORKSPACE_DIR/vllm}"
+UGDS_PCI_SLOT="${UGDS_PCI_SLOT:-}"
+UGDS_DEVICE="${UGDS_DEVICE:-}"
+SKIP_SETUP="${SKIP_SETUP:-0}"
+HF_MODEL_ID="${HF_MODEL_ID:-Qwen/Qwen3-0.6B}"
+MODEL="${MODEL:-$BENCH_DIR/models/Qwen3-0.6B}"
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+normalize_slot() {
+    local slot="$1"
+    [[ "$slot" == ????:* ]] || slot="0000:$slot"
+    printf '%s\n' "$slot"
+}
+
+get_driver() {
+    local link="/sys/bus/pci/devices/$1/driver"
+    if [[ -L "$link" ]]; then
+        basename "$(readlink -f "$link")"
+    else
+        printf 'none\n'
+    fi
+}
+
+list_ugds_nodes() {
+    local node
+    for node in /dev/ugds_drv*; do
+        [[ -c "$node" ]] && printf '%s\n' "$node"
+    done
+}
+
+check_target_not_mounted() {
+    local pci_dir="/sys/bus/pci/devices/$1"
+    local controller namespace block_device mounts
+    for controller in "$pci_dir"/nvme/nvme*; do
+        [[ -d "$controller" ]] || continue
+        for namespace in "$controller"/nvme*n*; do
+            [[ -e "$namespace" ]] || continue
+            block_device="/dev/$(basename "$namespace")"
+            [[ -b "$block_device" ]] || continue
+            mounts="$(lsblk -nrpo NAME,MOUNTPOINT "$block_device" | awk 'NF > 1')"
+            if [[ -n "$mounts" ]]; then
+                printf '%s\n' "$mounts" >&2
+                die "$block_device or one of its partitions is mounted"
+            fi
+        done
+    done
+}
+
+ensure_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        command -v uv
+        return
+    fi
+    if [[ -x "$BENCH_DIR/.tools/uv" ]]; then
+        printf '%s\n' "$BENCH_DIR/.tools/uv"
+        return
+    fi
+    command -v curl >/dev/null 2>&1 || die "curl is required to install uv"
+    printf '==> Installing uv locally under %s/.tools\n' "$BENCH_DIR" >&2
+    local installer
+    installer="$(mktemp)"
+    curl -LsSf https://astral.sh/uv/install.sh -o "$installer"
+    UV_UNMANAGED_INSTALL="$BENCH_DIR/.tools" sh "$installer"
+    rm -f "$installer"
+    printf '%s\n' "$BENCH_DIR/.tools/uv"
+}
+
+select_new_ugds_node() {
+    local before="$1"
+    local node
+    while IFS= read -r node; do
+        [[ -n "$node" ]] || continue
+        if ! grep -Fxq "$node" <<<"$before"; then
+            printf '%s\n' "$node"
+            return
+        fi
+    done < <(list_ugds_nodes)
+}
+
+[[ "${I_UNDERSTAND_UGDS_ERASES_DEVICE:-0}" == "1" ]] || die \
+    "set I_UNDERSTAND_UGDS_ERASES_DEVICE=1 after confirming the target SSD may be overwritten"
+[[ -n "$UGDS_PCI_SLOT" ]] || die \
+    "set UGDS_PCI_SLOT to the dedicated NVMe controller (example: 0000:b8:00.0)"
+UGDS_PCI_SLOT="$(normalize_slot "$UGDS_PCI_SLOT")"
+PCI_DIR="/sys/bus/pci/devices/$UGDS_PCI_SLOT"
+[[ -d "$PCI_DIR" ]] || die "PCI device not found: $UGDS_PCI_SLOT"
+[[ "$(<"$PCI_DIR/class")" == "0x010802" ]] || die \
+    "$UGDS_PCI_SLOT is not an NVMe controller"
+
+printf '==> Target NVMe\n'
+printf 'PCI slot: %s\n' "$UGDS_PCI_SLOT"
+printf 'PCI ID: %s:%s\n' "$(<"$PCI_DIR/vendor")" "$(<"$PCI_DIR/device")"
+printf 'Current driver: %s\n' "$(get_driver "$UGDS_PCI_SLOT")"
+check_target_not_mounted "$UGDS_PCI_SLOT"
+
+export UV_CACHE_DIR="${UV_CACHE_DIR:-$BENCH_DIR/.uv-cache}"
+if [[ "$SKIP_SETUP" != "1" ]]; then
+    UV_BIN="${UV_BIN:-$(ensure_uv)}"
+    printf '==> Building and installing the software stack\n'
+    UV_BIN="$UV_BIN" BUILD_UGDS_DRIVER=1 \
+        UGDS_REPO="$UGDS_REPO" LMCACHE_REPO="$LMCACHE_REPO" \
+        VLLM_REPO="$VLLM_REPO" EXISTING_PYTHON="${EXISTING_PYTHON:-}" \
+        CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}" \
+        "$BENCH_DIR/setup_env.sh"
+fi
+
+if [[ -n "${PYTHON_BIN:-}" ]]; then
+    :
+elif [[ -n "${EXISTING_PYTHON:-}" ]]; then
+    PYTHON_BIN="$EXISTING_PYTHON"
+elif [[ -f "$BENCH_DIR/.python-bin" ]]; then
+    PYTHON_BIN="$(<"$BENCH_DIR/.python-bin")"
+else
+    PYTHON_BIN="$BENCH_DIR/.venv/bin/python"
+fi
+[[ -x "$PYTHON_BIN" ]] || die "Python environment is not ready: $PYTHON_BIN"
+
+current_driver="$(get_driver "$UGDS_PCI_SLOT")"
+if [[ "$current_driver" != "ugds_drv" ]]; then
+    before_nodes="$(list_ugds_nodes || true)"
+    printf '==> Binding %s to ugds_drv\n' "$UGDS_PCI_SLOT"
+    "$UGDS_REPO/scripts/env_switch.sh" ugds "$UGDS_PCI_SLOT"
+    if [[ -z "$UGDS_DEVICE" ]]; then
+        UGDS_DEVICE="$(select_new_ugds_node "$before_nodes")"
+    fi
+fi
+
+if [[ -z "$UGDS_DEVICE" ]]; then
+    mapfile -t nodes < <(list_ugds_nodes)
+    if [[ "${#nodes[@]}" == "1" ]]; then
+        UGDS_DEVICE="${nodes[0]}"
+    else
+        die "multiple uGDS nodes exist; set UGDS_DEVICE for PCI $UGDS_PCI_SLOT"
+    fi
+fi
+[[ -c "$UGDS_DEVICE" ]] || die "uGDS character device not found: $UGDS_DEVICE"
+sudo chown "$(id -u):$(id -g)" "$UGDS_DEVICE"
+sudo chmod 600 "$UGDS_DEVICE"
+printf 'uGDS device: %s\n' "$UGDS_DEVICE"
+
+if [[ ! -s "$MODEL/config.json" ]]; then
+    printf '==> Downloading %s to %s\n' "$HF_MODEL_ID" "$MODEL"
+    "$PYTHON_BIN" - "$HF_MODEL_ID" "$MODEL" <<'PY'
+from huggingface_hub import snapshot_download
+import sys
+
+snapshot_download(repo_id=sys.argv[1], local_dir=sys.argv[2])
+PY
+fi
+
+if [[ -n "${EXISTING_PYTHON:-}" ]]; then
+    USE_LOCAL_VLLM_SOURCE="${USE_LOCAL_VLLM_SOURCE:-0}"
+else
+    USE_LOCAL_VLLM_SOURCE="${USE_LOCAL_VLLM_SOURCE:-1}"
+fi
+
+printf '==> Running vLLM + LMCache + uGDS end-to-end benchmark\n'
+env PYTHON_BIN="$PYTHON_BIN" MODEL="$MODEL" UGDS_DEVICE="$UGDS_DEVICE" \
+    UGDS_REPO="$UGDS_REPO" LMCACHE_REPO="$LMCACHE_REPO" \
+    VLLM_REPO="$VLLM_REPO" USE_LOCAL_VLLM_SOURCE="$USE_LOCAL_VLLM_SOURCE" \
+    UGDS_PCI_SLOT="$UGDS_PCI_SLOT" I_UNDERSTAND_UGDS_ERASES_DEVICE=1 \
+    "$BENCH_DIR/run_e2e_bench.sh"

--- a/examples/vllm_lmcache_bench/run_e2e_bench.sh
+++ b/examples/vllm_lmcache_bench/run_e2e_bench.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BENCH_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+UGDS_REPO="${UGDS_REPO:-$(cd -- "$BENCH_DIR/../.." && pwd)}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$(dirname -- "$UGDS_REPO")}"
+LMCACHE_REPO="${LMCACHE_REPO:-$WORKSPACE_DIR/LMCache}"
+VLLM_REPO="${VLLM_REPO:-$WORKSPACE_DIR/vllm}"
+if [[ -z "${PYTHON_BIN:-}" && -f "$BENCH_DIR/.python-bin" ]]; then
+    PYTHON_BIN="$(<"$BENCH_DIR/.python-bin")"
+fi
+PYTHON_BIN="${PYTHON_BIN:-$BENCH_DIR/.venv/bin/python}"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+UGDS_DEVICE="${UGDS_DEVICE:-/dev/ugds_drv0}"
+UGDS_LIB_DIR="${UGDS_LIB_DIR:-$UGDS_REPO/build}"
+GPU_ID="${GPU_ID:-0}"
+L1_SIZE_GB="${L1_SIZE_GB:-1}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+PROMPT_REPEATS="${PROMPT_REPEATS:-64}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-600}"
+KEEP_SERVERS="${KEEP_SERVERS:-0}"
+USE_LOCAL_VLLM_SOURCE="${USE_LOCAL_VLLM_SOURCE:-1}"
+LMCACHE_CONNECTOR_MODULE="${LMCACHE_CONNECTOR_MODULE:-}"
+RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$BENCH_DIR/artifacts/$RUN_ID}"
+LMCACHE_PID=""
+VLLM_PID=""
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+stop_process_group() {
+    local pid="$1"
+    local name="$2"
+    [[ -n "$pid" ]] || return 0
+    if kill -0 "$pid" 2>/dev/null; then
+        printf 'Stopping %s (process group %s)\n' "$name" "$pid"
+        kill -TERM -- "-$pid" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$pid" 2>/dev/null || return 0
+            sleep 0.25
+        done
+        kill -KILL -- "-$pid" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    local status=$?
+    if [[ "$KEEP_SERVERS" == "1" && "$status" == "0" ]]; then
+        printf 'KEEP_SERVERS=1: LMCache PID=%s, vLLM PID=%s\n' \
+            "$LMCACHE_PID" "$VLLM_PID"
+    else
+        stop_process_group "$VLLM_PID" "vLLM"
+        stop_process_group "$LMCACHE_PID" "LMCache"
+    fi
+    if [[ "$status" != "0" && -d "$ARTIFACT_DIR" ]]; then
+        printf 'Benchmark failed. Logs: %s\n' "$ARTIFACT_DIR" >&2
+        [[ -f "$ARTIFACT_DIR/lmcache.log" ]] && \
+            tail -n 30 "$ARTIFACT_DIR/lmcache.log" >&2 || true
+        [[ -f "$ARTIFACT_DIR/vllm.log" ]] && \
+            tail -n 30 "$ARTIFACT_DIR/vllm.log" >&2 || true
+    elif [[ "$status" != "0" ]]; then
+        printf 'Benchmark failed during preflight; no artifacts were created.\n' >&2
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+wait_for_url() {
+    local url="$1"
+    local pid="$2"
+    local name="$3"
+    local timeout_seconds="$4"
+    local deadline=$((SECONDS + timeout_seconds))
+    while ((SECONDS < deadline)); do
+        if curl --fail --silent --show-error --max-time 2 "$url" \
+            >/dev/null 2>&1; then
+            printf '%s is ready: %s\n' "$name" "$url"
+            return 0
+        fi
+        kill -0 "$pid" 2>/dev/null || die \
+            "$name exited before becoming ready; inspect $ARTIFACT_DIR/${name,,}.log"
+        sleep 1
+    done
+    die "$name did not become ready within ${timeout_seconds}s"
+}
+
+port_is_busy() {
+    local port="$1"
+    timeout 1 bash -c "</dev/tcp/127.0.0.1/$port" >/dev/null 2>&1
+}
+
+[[ "${I_UNDERSTAND_UGDS_ERASES_DEVICE:-0}" == "1" ]] || die \
+    "uGDS overwrites its slab. Re-run with I_UNDERSTAND_UGDS_ERASES_DEVICE=1 after verifying UGDS_DEVICE is a disposable dedicated SSD"
+
+[[ -f "$UGDS_REPO/CMakeLists.txt" ]] || die "invalid uGDS repo: $UGDS_REPO"
+[[ -f "$LMCACHE_REPO/pyproject.toml" ]] || die "invalid LMCache repo: $LMCACHE_REPO"
+[[ -f "$VLLM_REPO/pyproject.toml" ]] || die "invalid vLLM repo: $VLLM_REPO"
+[[ -x "$PYTHON_BIN" ]] || die "Python not found: $PYTHON_BIN; run ./setup_env.sh"
+[[ -c "$UGDS_DEVICE" ]] || die "$UGDS_DEVICE is not a character device"
+[[ -r "$UGDS_DEVICE" && -w "$UGDS_DEVICE" ]] || die \
+    "current user needs read/write permission on $UGDS_DEVICE"
+[[ -f "$UGDS_LIB_DIR/libugds.so" ]] || die \
+    "missing $UGDS_LIB_DIR/libugds.so; run ./setup_env.sh"
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v setsid >/dev/null 2>&1 || die "setsid is required"
+command -v timeout >/dev/null 2>&1 || die "timeout is required"
+
+for value in "$GPU_ID" "$MAX_MODEL_LEN" "$PROMPT_REPEATS" \
+    "$VLLM_PORT" "$LMCACHE_PORT" "$LMCACHE_HTTP_PORT" "$STARTUP_TIMEOUT"; do
+    [[ "$value" =~ ^[0-9]+$ ]] || die "expected a non-negative integer, got: $value"
+done
+[[ "$L1_SIZE_GB" =~ ^[0-9]+([.][0-9]+)?$ ]] || die \
+    "L1_SIZE_GB must be a positive number"
+[[ ! "$L1_SIZE_GB" =~ ^0+([.]0+)?$ ]] || die \
+    "L1_SIZE_GB must be greater than zero"
+((MAX_MODEL_LEN > 0)) || die "MAX_MODEL_LEN must be greater than zero"
+((PROMPT_REPEATS > 0)) || die "PROMPT_REPEATS must be greater than zero"
+((STARTUP_TIMEOUT > 0)) || die "STARTUP_TIMEOUT must be greater than zero"
+[[ "$VLLM_PORT" != "$LMCACHE_PORT" && \
+    "$VLLM_PORT" != "$LMCACHE_HTTP_PORT" && \
+    "$LMCACHE_PORT" != "$LMCACHE_HTTP_PORT" ]] || die \
+    "VLLM_PORT, LMCACHE_PORT, and LMCACHE_HTTP_PORT must be distinct"
+
+for port in "$VLLM_PORT" "$LMCACHE_PORT" "$LMCACHE_HTTP_PORT"; do
+    ((port >= 1 && port <= 65535)) || die "invalid TCP port: $port"
+    port_is_busy "$port" && die "TCP port $port is already in use"
+done
+
+mkdir -p "$ARTIFACT_DIR"
+if [[ "$USE_LOCAL_VLLM_SOURCE" == "1" ]]; then
+    export PYTHONPATH="$LMCACHE_REPO:$VLLM_REPO${PYTHONPATH:+:$PYTHONPATH}"
+elif [[ "$USE_LOCAL_VLLM_SOURCE" == "0" ]]; then
+    export PYTHONPATH="$LMCACHE_REPO${PYTHONPATH:+:$PYTHONPATH}"
+else
+    die "USE_LOCAL_VLLM_SOURCE must be 0 or 1"
+fi
+export LD_LIBRARY_PATH="$UGDS_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export CUDA_VISIBLE_DEVICES="$GPU_ID"
+export BENCH_LMCACHE_REPO="$LMCACHE_REPO"
+export BENCH_VLLM_REPO="$VLLM_REPO"
+export BENCH_USE_LOCAL_VLLM="$USE_LOCAL_VLLM_SOURCE"
+
+printf '==> Preflight checks\n'
+"$PYTHON_BIN" -c \
+    'import ctypes; lib = ctypes.CDLL("libugds.so"); assert hasattr(lib, "uGDSGetDeviceCapacity")'
+"$PYTHON_BIN" -c \
+    'import torch; assert torch.cuda.is_available(), "CUDA is unavailable"; print(torch.cuda.get_device_name(0))'
+{
+    printf 'LMCache revision: '
+    git -C "$LMCACHE_REPO" describe --always --dirty
+    printf 'vLLM revision: '
+    git -C "$VLLM_REPO" describe --always --dirty
+    printf 'uGDS revision: '
+    git -C "$UGDS_REPO" describe --always --dirty
+    "$PYTHON_BIN" - <<'PY'
+import os
+import pathlib
+
+import lmcache
+import vllm
+
+lmcache_repo = pathlib.Path(os.environ["BENCH_LMCACHE_REPO"])
+vllm_repo = pathlib.Path(os.environ["BENCH_VLLM_REPO"])
+lmcache_path = pathlib.Path(lmcache.__file__).resolve()
+vllm_path = pathlib.Path(vllm.__file__).resolve()
+assert lmcache_path.is_relative_to(lmcache_repo), lmcache_path
+if os.environ["BENCH_USE_LOCAL_VLLM"] == "1":
+    assert vllm_path.is_relative_to(vllm_repo), vllm_path
+print("lmcache:", lmcache_path)
+print("vllm:", vllm_path)
+PY
+} | tee "$ARTIFACT_DIR/versions.txt"
+
+if [[ -z "$LMCACHE_CONNECTOR_MODULE" ]]; then
+    VLLM_VERSION="$($PYTHON_BIN -c \
+        'import importlib.metadata as m; print(m.version("vllm"))')"
+    case "$VLLM_VERSION" in
+        0.20.1*)
+            LMCACHE_CONNECTOR_MODULE="lmcache.integration.vllm.lmcache_mp_connector_0201"
+            ;;
+        0.18.*)
+            LMCACHE_CONNECTOR_MODULE="lmcache.integration.vllm.lmcache_mp_connector_0180"
+            ;;
+        *)
+            LMCACHE_CONNECTOR_MODULE="lmcache.integration.vllm.lmcache_mp_connector"
+            ;;
+    esac
+fi
+printf 'LMCache connector: %s\n' "$LMCACHE_CONNECTOR_MODULE" | \
+    tee -a "$ARTIFACT_DIR/versions.txt"
+
+printf '==> Starting LMCache with uGDS L1 on %s\n' "$UGDS_DEVICE"
+setsid "$PYTHON_BIN" -m lmcache.cli.main server \
+    --host 127.0.0.1 \
+    --port "$LMCACHE_PORT" \
+    --http-host 127.0.0.1 \
+    --http-port "$LMCACHE_HTTP_PORT" \
+    --l1-size-gb "$L1_SIZE_GB" \
+    --eviction-policy LRU \
+    --chunk-size 256 \
+    --gds-l1-backend ugds \
+    --gds-l1-path "$UGDS_DEVICE" \
+    >"$ARTIFACT_DIR/lmcache.log" 2>&1 &
+LMCACHE_PID=$!
+wait_for_url \
+    "http://127.0.0.1:$LMCACHE_HTTP_PORT/healthcheck" \
+    "$LMCACHE_PID" "LMCache" 120
+grep -q 'GDSContext: uGDS raw-device slab opened' \
+    "$ARTIFACT_DIR/lmcache.log" || die \
+    "LMCache became healthy without logging uGDS raw-device initialization"
+curl --fail --silent --show-error \
+    "http://127.0.0.1:$LMCACHE_HTTP_PORT/status" \
+    >"$ARTIFACT_DIR/lmcache-status.json"
+
+KV_TRANSFER_CONFIG="$(printf \
+    '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"%s\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://127.0.0.1\",\"lmcache.mp.port\":%s}}' \
+    "$LMCACHE_CONNECTOR_MODULE" "$LMCACHE_PORT")"
+
+printf '==> Starting vLLM model %s\n' "$MODEL"
+setsid "$PYTHON_BIN" -m vllm.entrypoints.cli.main serve "$MODEL" \
+    --host 127.0.0.1 \
+    --port "$VLLM_PORT" \
+    --served-model-name "$MODEL" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --gpu-memory-utilization 0.80 \
+    --no-enable-prefix-caching \
+    --disable-hybrid-kv-cache-manager \
+    --kv-transfer-config "$KV_TRANSFER_CONFIG" \
+    >"$ARTIFACT_DIR/vllm.log" 2>&1 &
+VLLM_PID=$!
+wait_for_url \
+    "http://127.0.0.1:$VLLM_PORT/health" \
+    "$VLLM_PID" "vLLM" "$STARTUP_TIMEOUT"
+
+printf '==> Running cold/warm request benchmark\n'
+"$PYTHON_BIN" "$BENCH_DIR/bench_client.py" \
+    --base-url "http://127.0.0.1:$VLLM_PORT" \
+    --model "$MODEL" \
+    --prompt-repeats "$PROMPT_REPEATS" \
+    --output "$ARTIFACT_DIR/bench-result.json"
+
+printf '\nArtifacts: %s\n' "$ARTIFACT_DIR"
+printf 'LMCache uGDS evidence:\n'
+grep -Ei 'ugds|gds l1' "$ARTIFACT_DIR/lmcache.log" | tail -n 10 || true

--- a/examples/vllm_lmcache_bench/setup_env.sh
+++ b/examples/vllm_lmcache_bench/setup_env.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BENCH_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+UGDS_REPO="${UGDS_REPO:-$(cd -- "$BENCH_DIR/../.." && pwd)}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$(dirname -- "$UGDS_REPO")}"
+LMCACHE_REPO="${LMCACHE_REPO:-$WORKSPACE_DIR/LMCache}"
+VLLM_REPO="${VLLM_REPO:-$WORKSPACE_DIR/vllm}"
+VENV_DIR="${VENV_DIR:-$BENCH_DIR/.venv}"
+UV_BIN="${UV_BIN:-uv}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+EXISTING_PYTHON="${EXISTING_PYTHON:-}"
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -f "$UGDS_REPO/CMakeLists.txt" ]] || die "invalid uGDS repo: $UGDS_REPO"
+[[ -f "$LMCACHE_REPO/pyproject.toml" ]] || die \
+    "LMCache repo not found: $LMCACHE_REPO (set LMCACHE_REPO)"
+[[ -f "$VLLM_REPO/pyproject.toml" ]] || die \
+    "vLLM repo not found: $VLLM_REPO (set VLLM_REPO)"
+
+command -v "$UV_BIN" >/dev/null 2>&1 || die \
+    "uv is required; install it from https://docs.astral.sh/uv/"
+command -v cmake >/dev/null 2>&1 || die "cmake is required to build uGDS"
+
+if [[ -n "$EXISTING_PYTHON" ]]; then
+    [[ -x "$EXISTING_PYTHON" ]] || die \
+        "EXISTING_PYTHON is not executable: $EXISTING_PYTHON"
+    PYTHON_BIN="$EXISTING_PYTHON"
+    printf '==> Reusing existing Python environment: %s\n' "$PYTHON_BIN"
+    "$PYTHON_BIN" -c 'import torch, vllm; print(torch.__version__, vllm.__version__)'
+
+    printf '==> Rebuilding only local LMCache (dependencies unchanged)\n'
+    CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}" \
+    PATH="${CUDA_HOME:-/usr/local/cuda}/bin:$PATH" \
+    "$UV_BIN" pip install --python "$PYTHON_BIN" --no-deps \
+        -e "$LMCACHE_REPO" --no-build-isolation
+else
+    if [[ -x "$VENV_DIR/bin/python" ]]; then
+        printf '==> Reusing Python environment at %s\n' "$VENV_DIR"
+    else
+        printf '==> Creating Python %s environment at %s\n' \
+            "$PYTHON_VERSION" "$VENV_DIR"
+        "$UV_BIN" venv --python "$PYTHON_VERSION" "$VENV_DIR"
+    fi
+    PYTHON_BIN="$VENV_DIR/bin/python"
+
+    printf '==> Installing PyTorch\n'
+    "$UV_BIN" pip install --python "$PYTHON_BIN" torch --torch-backend=auto
+
+    printf '==> Installing native-extension build requirements\n'
+    "$UV_BIN" pip install --python "$PYTHON_BIN" \
+        ninja 'packaging>=24.2' 'setuptools>=77.0.3,<81.0.0' \
+        'setuptools-scm>=8' wheel
+
+    printf '==> Installing local vLLM source (precompiled extension)\n'
+    VLLM_USE_PRECOMPILED=1 "$UV_BIN" pip install \
+        --python "$PYTHON_BIN" -e "$VLLM_REPO" --torch-backend=auto
+
+    printf '==> Installing local LMCache source and CUDA extension\n'
+    "$UV_BIN" pip install --python "$PYTHON_BIN" \
+        -e "$LMCACHE_REPO" --no-build-isolation
+fi
+
+printf '==> Building libugds.so\n'
+cmake -S "$UGDS_REPO" -B "$UGDS_REPO/build" \
+    -DUGDS_BACKEND_CUDA=ON -DUGDS_BACKEND_HIP=OFF
+cmake --build "$UGDS_REPO/build" --target ugds -j "$(nproc)"
+
+if [[ "${BUILD_UGDS_DRIVER:-0}" == "1" ]]; then
+    printf '==> Building ugds_drv.ko\n'
+    make -C "$UGDS_REPO/drv" BUILD_CUDA=1 HAVE_CUDA_DMABUF=1
+fi
+
+if [[ -n "$EXISTING_PYTHON" ]]; then
+    VALIDATION_PYTHONPATH="$LMCACHE_REPO"
+else
+    VALIDATION_PYTHONPATH="$LMCACHE_REPO:$VLLM_REPO"
+fi
+PYTHONPATH="$VALIDATION_PYTHONPATH" "$PYTHON_BIN" -c \
+    'import lmcache, torch, vllm; print("torch", torch.__version__); print("vllm", vllm.__version__); print("lmcache", lmcache.__file__)'
+
+printf '%s\n' "$PYTHON_BIN" > "$BENCH_DIR/.python-bin"
+
+printf '\nEnvironment is ready. Next, bind a dedicated NVMe device and run:\n'
+printf '  UGDS_PCI_SLOT=<slot> I_UNDERSTAND_UGDS_ERASES_DEVICE=1 ./quickstart.sh\n'

--- a/examples/vllm_lmcache_bench/tests/test_bench_client.py
+++ b/examples/vllm_lmcache_bench/tests/test_bench_client.py
@@ -1,0 +1,91 @@
+"""Unit tests for the dependency-free end-to-end benchmark client."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+import bench_client
+
+
+class FakeResponse:
+    """Minimal streaming response returned by mocked urlopen calls."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self.lines = lines
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def __iter__(self):
+        return iter(self.lines)
+
+    def read(self) -> bytes:
+        return b"".join(self.lines)
+
+
+class BenchClientTest(unittest.TestCase):
+    def test_read_metrics_aggregates_engine_labels(self) -> None:
+        metrics = b"""\
+# HELP vllm:external_prefix_cache_hits External hits
+vllm:external_prefix_cache_hits_total{engine=\"0\"} 128
+vllm:external_prefix_cache_hits_total{engine=\"1\"} 256
+vllm:external_prefix_cache_queries_total{engine=\"0\"} 512
+vllm:prefix_cache_hits_total{engine=\"0\"} 0
+"""
+        with patch.object(bench_client, "http_get", return_value=metrics):
+            values = bench_client.read_metrics("http://unused")
+
+        self.assertEqual(
+            bench_client.metric_value(
+                values, "vllm:external_prefix_cache_hits"
+            ),
+            384,
+        )
+        self.assertEqual(
+            bench_client.metric_value(
+                values, "vllm:external_prefix_cache_queries"
+            ),
+            512,
+        )
+
+    def test_run_completion_parses_stream_usage(self) -> None:
+        events = [
+            {"choices": [{"text": "hello"}], "usage": None},
+            {
+                "choices": [],
+                "usage": {"prompt_tokens": 1024, "completion_tokens": 1},
+            },
+        ]
+        lines = [
+            f"data: {json.dumps(event)}\n\n".encode("utf-8") for event in events
+        ] + [b"data: [DONE]\n\n"]
+
+        with patch(
+            "bench_client.urllib.request.urlopen",
+            return_value=FakeResponse(lines),
+        ):
+            result = bench_client.run_completion(
+                "http://unused", "model", "prompt", 1, 1.0
+            )
+
+        self.assertEqual(result.prompt_tokens, 1024)
+        self.assertEqual(result.completion_tokens, 1)
+        self.assertGreaterEqual(result.latency_seconds, result.ttft_seconds)
+
+    def test_read_metrics_requires_external_counter(self) -> None:
+        with patch.object(
+            bench_client,
+            "http_get",
+            return_value=b"vllm:prefix_cache_hits_total 0\n",
+        ):
+            with self.assertRaisesRegex(RuntimeError, "external prefix cache"):
+                bench_client.read_metrics("http://unused")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a one-command end-to-end benchmark for the following inference path:

```text
vLLM -> LMCache MP Server -> uGDS -> NVMe SSD
```

The benchmark uses Qwen3-0.6B, sends one cold request followed by a warm request with the same prefix, and verifies through vLLM metrics that KV cache is stored and retrieved through LMCache's uGDS L1 backend.

## What Changed

- Added `examples/vllm_lmcache_bench/quickstart.sh` as the main entry point.
- Added automated environment setup for local vLLM and LMCache sources.
- Added uGDS userspace library and kernel module build steps.
- Added NVMe PCI validation, mount checks, driver binding, and device permission setup.
- Added automatic Qwen3-0.6B download.
- Added LMCache and vLLM service startup, health checks, log collection, and cleanup.
- Added a dependency-free benchmark client that records cold/warm TTFT and validates external KV-cache hits.
- Added unit tests for metrics aggregation and streaming response parsing.
- Added an English benchmark guide and a link from the main uGDS README.

## Usage

The uGDS, LMCache, and vLLM repositories should be siblings in the same workspace. After identifying a dedicated NVMe SSD, run:

```bash
cd uGDS/examples/vllm_lmcache_bench

UGDS_PCI_SLOT=0000:b8:00.0 \
I_UNDERSTAND_UGDS_ERASES_DEVICE=1 \
./quickstart.sh
```

The PCI address must be replaced with the address of the dedicated test SSD.

## Pass Criteria

The complete run succeeds only when:

- LMCache logs `GDSContext: uGDS raw-device slab opened`;
- vLLM reports external cache query tokens greater than zero; and
- vLLM reports external cache hit tokens greater than zero.

vLLM's local prefix cache is disabled during the benchmark, so the warm-request hit is attributable to LMCache and its uGDS L1 backend. TTFT improvement is reported as a performance observation but is not used as a pass condition.

Each run writes the following artifacts:

```text
artifacts/<run-id>/
├── bench-result.json
├── lmcache.log
├── lmcache-status.json
├── versions.txt
└── vllm.log
```

## Validation

The end-to-end path was validated with:

- NVIDIA A100 40 GB
- CUDA 12.4
- Samsung 990 PRO
- Qwen3-0.6B
- vLLM 0.20.1

Observed result:

```text
Cold TTFT: 0.1408 s
Warm TTFT: 0.1121 s
TTFT speedup: 1.26x
External query tokens: 4764
External hit tokens: 2304
Local prefix-cache hit tokens: 0
PASS: LMCache external cache hit increased by 2304 tokens
```

LMCache also logged the expected uGDS operations:

```text
GDSContext: uGDS raw-device slab opened at /dev/ugds_drv0 (1.0 GiB)
Stored 2048 tokens in 0.009 seconds
Stored 256 tokens in 0.001 seconds
Retrieved 2304 tokens in 0.006 seconds
```

Additional checks:

- All three benchmark client unit tests pass.
- All shell scripts pass `bash -n`.
- No new uGDS, UBSAN, NVIDIA Xid, OOM, or segmentation fault messages were observed in the kernel log during the end-to-end run.
- vLLM and LMCache processes and ports were cleaned up after the run.

## Safety

uGDS operates on raw NVMe blocks and can destroy existing partitions, filesystems, and data. The quick-start script therefore:

- requires an explicit `I_UNDERSTAND_UGDS_ERASES_DEVICE=1` acknowledgement;
- verifies that the selected PCI device is an NVMe controller;
- refuses to proceed when the target namespace or its partitions are mounted;
- refuses ambiguous automatic selection when multiple uGDS character devices already exist.

The benchmark documentation also states that the target must be a dedicated, disposable SSD.
